### PR TITLE
Add support for configuration of PDF styles

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -1,12 +1,14 @@
 
-// To use environment variables, you can use:
-// outputPath = "${System.getenv('HOME')}/docs"
-//
-// To specify paths relative to current directory, use PWD variable:
-// outputPath = "${System.getenv('PWD')}/docs"
+// Path where the docToolchain will produce the output files.
+// This path is appended to the docDir property specified in gradle.properties
+// or in the command line, and therefore must be relative to it.
 outputPath = 'build/docs'
 
+// Path where the docToolchain will search for the input files.
+// This path is appended to the docDir property specified in gradle.properties
+// or in the command line, and therefore must be relative to it.
 inputPath = 'src/docs'
+
 inputFiles = [[file: 'arc42-template-de.adoc', formats: ['html','pdf','docbook']],
               [file: 'arc42-template-en.adoc', formats: ['html','pdf','docbook']],
               [file: 'arc42-template-es.adoc', formats: ['html','pdf','docbook']],

--- a/build.gradle
+++ b/build.gradle
@@ -18,19 +18,20 @@ println "compiling with Java ${System.getProperty("java.version")} at ${new Date
 
 // configuration
 def config
+println "docDir: ${docDir}"
 println "mainConfigFile: ${mainConfigFile}"
-config = new ConfigSlurper().parse(new File(mainConfigFile).text)
+config = new ConfigSlurper().parse(new File(docDir, mainConfigFile).text)
 println "inputPath: ${config.inputPath}"
 println "inputFiles: ${config.inputFiles}"
 println "outputPath: ${config.outputPath}"
 
 ext {
-    srcDir  = config.inputPath
-    targetDir = config.outputPath
+    srcDir  = "${docDir}/${config.inputPath}"
+    targetDir = "${docDir}/${config.outputPath}"
     javaVersion = System.getProperty("java.version")
     currentDate = new Date().format("d. MMM yyyy")
     // where HTMLSanityCheck checking results ares stored
-    checkingResultsPath = "${config.outputPath}/report/htmlchecks"
+    checkingResultsPath = "${docDir}/${config.outputPath}/report/htmlchecks"
     sourceFiles = config.inputFiles
 }
 
@@ -82,17 +83,18 @@ apply from: 'scripts/htmlSanityCheck.gradle'
 tasks.withType(AsciidoctorTask) { docTask ->
   
     config.taskInputsDirs.each {
-        inputs.dir new File(it)
+        inputs.dir new File(docDir, it)
     }
     config.taskInputsFiles.each {
-        inputs.file new File(it)
+        inputs.file new File(docDir, it)
     }
 
+    // configure source and output files and folders
     outputDir = file(targetDir)
     sourceDir = file(srcDir)
 
     attributes \
-            'pdf-stylesdir': 'pdfTheme',
+            'pdf-stylesdir': "${docDir}/pdfTheme",
             'pdf-style': 'custom',
             'source-highlighter': 'coderay',
             'imagesdir': 'images',
@@ -115,10 +117,6 @@ tasks.withType(AsciidoctorTask) { docTask ->
                 createInline(parent, "anchor", target, attributes, options).render()
         }
     }
-
-    // configure source and output files and folders
-    sourceDir = file(config.inputPath)
-    outputDir = file(config.outputPath)
 
     // good to see what the build is doing...
     logDocuments = true
@@ -156,7 +154,7 @@ task generatePDF (
         description: 'use pdf as asciidoc backend') {
 
     attributes \
-        'plantUMLDir'         : file("${config.outputPath}/images/plantUML/").path
+        'plantUMLDir'         : file("${docDir}/${config.outputPath}/images/plantUML/").path
 
     sources {
         sourceFiles.findAll {
@@ -228,7 +226,7 @@ task generateDeck (
             include 'images/**'
         }
         into("ppt")
-        logger.error "${config.outputPath}/ppt/images"
+        logger.error "${docDir}/${config.outputPath}/ppt/images"
     }
 }
 //end::generateDeck[]

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,14 @@ jiraLabel = architecture-issue
 
 jiraJql  = project='%jiraProject%' AND resolution='Unresolved' AND labels='%jiraLabel%' ORDER BY priority DESC, duedate ASC
 
-confluenceConfigFile = scripts/ConfluenceConfig.groovy
+// Directory containing the documents to be processed by docToolchain.
+// If the documents are together with docToolchain, this can be relative path.
+// If the documents are outside of docToolchain, this must be absolute path, usually provided
+// on the command line with -P option given to gradle.
+docDir = .
+
+// Path to the main configuration file, relative to docDir.
 mainConfigFile = Config.groovy
+
+// Path to the confluence configuration file, relative to docDir.
+confluenceConfigFile = scripts/ConfluenceConfig.groovy

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -57,8 +57,9 @@ def baseUrl
 
 // configuration
 def config
+println "docDir: ${docDir}"
 println "confluenceConfigFile: ${confluenceConfigFile}"
-config = new ConfigSlurper().parse(new File(confluenceConfigFile).text)
+config = new ConfigSlurper().parse(new File(docDir, confluenceConfigFile).text)
 
 def confluenceSpaceKey
 def confluenceCreateSubpages
@@ -465,7 +466,8 @@ def promoteHeaders = { tree, start, offset ->
 
 config.input.each { input ->
 
-    println "${input.file}"
+    input.file = "${docDir}/${input.file}"
+
     if (input.file ==~ /.*[.](ad|adoc|asciidoc)$/) {
         println "convert ${input.file}"
         "groovy asciidoc2html.groovy ${input.file}".execute()

--- a/scripts/pandoc.gradle
+++ b/scripts/pandoc.gradle
@@ -3,13 +3,17 @@ task convertToDocx (
         group: 'docToolchain',
         type: Exec
 ) {
+    // For now it's only taking the first input file that has docbook format specified
+    def sourceFile = sourceFiles.find { 'docbook' in it.formats }.file.replace('.adoc', '.xml')
+    def targetFile = sourceFile.replace('.xml', '.docx')
+
     workingDir "$targetDir/docbook"
     executable = "pandoc"
     new File("$targetDir/docx/").mkdirs()
     args = ['-r','docbook',
             '-t','docx',
-            '-o','../docx/arc42-template-en.docx',
-            'arc42-template-en.xml']
+            '-o',"../docx/$targetFile",
+            sourceFile]
 }
 //end::convertToDocx[]
 
@@ -18,14 +22,17 @@ task convertToEpub (
         group: 'docToolchain',
         type: Exec
 ) {
+    // For now it's only taking the first input file that has docbook format specified
+    def sourceFile = sourceFiles.find { 'docbook' in it.formats }.file.replace('.adoc', '.xml')
+    def targetFile = sourceFile.replace('.xml', '.epub')
+
     workingDir "$targetDir/docbook"
-    //commandLine "pandoc -r arc42-template.xml -o arc42-template.docx "
     executable = "pandoc"
     new File("$targetDir/epub/").mkdirs()
     args = ['-r','docbook',
             '-t','epub',
-            '-o','../epub/arc42-template-en.epub',
-            'arc42-template-en.xml']
+            '-o',"../epub/$targetFile",
+            sourceFile]
 }
 //end::convertToEpub[]
 project.afterEvaluate {

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -17,6 +17,7 @@ task publishToConfluence(
         group: 'docToolchain'
 ) {
     doLast {
+        binding.setProperty('docDir', docDir)
         binding.setProperty('confluenceConfigFile', confluenceConfigFile)
         evaluate(new File('scripts/asciidoc2confluence.groovy'))
     }

--- a/src/test/config.groovy
+++ b/src/test/config.groovy
@@ -1,6 +1,4 @@
 
-// To use environment variables, you can use:
-// outputPath = "${System.getenv('HOME')}/docs"
 outputPath = 'build/test/docs'
 
 inputPath = 'src/test/docs'


### PR DESCRIPTION
Define new "docDir" property, which serves as a base for all other
configuration paths.
Support for PDF styles included with the contents, not with the tool.
Fix conversion to epub and docx.
Fix minor faults with paths.

This is meant to fix #88, I can now specify custom PDF style with my documents.