### PR TITLE
fix #105

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ jdk:
 git:
   depth: 3000
 
+addons:
+  apt:
+    packages:
+      - graphviz
+      
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,8 @@
 
 import org.asciidoctor.gradle.AsciidoctorTask
 
-buildscript {
-    dependencies {
-        //needed as workaround for https://github.com/asciidoctor/asciidoctorj/issues/471 :
-        classpath 'org.jruby:jruby:1.7.24'
-    }
-}
 plugins {
-    id "org.asciidoctor.convert" version "1.5.6"
+    id "org.asciidoctor.convert" version "1.5.3"
     id "org.aim42.htmlSanityCheck" version "0.9.7"
     id "com.github.ben-manes.versions" version "0.15.0"
 }
@@ -45,7 +39,7 @@ ext {
 apply plugin:'groovy'
 
 dependencies {
-    asciidoctor 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
+    asciidoctor 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.15'
     // carefull!
     // asciidoctor 1.5.6 needs diagram 1.5.4.1
     // but then reveal.js is broken...

--- a/src/test/docs/test.adoc
+++ b/src/test/docs/test.adoc
@@ -1,8 +1,29 @@
 include::config-de.adoc[]
 
+.sequence diagram (without graphviz)
 [plantuml,"{plantUMLDir}testPlant",png]
 ----
 a --> b
+----
+
+.component diagram (needs graphviz)
+[plantuml,"{plantUMLDir}testPlant2",png]
+----
+[c]->[d]
+----
+
+.component diagram with jdot
+[plantuml, "{plantUMLDir}demoPlantUML", png]
+----
+'!pragma graphviz_dot jdot
+class BlockProcessor
+class DiagramBlock
+class DitaaBlock
+class PlantUmlBlock
+
+BlockProcessor <|-- DiagramBlock
+DiagramBlock <|-- DitaaBlock
+DiagramBlock <|-- PlantUmlBlock
 ----
 
 image::ea/Use_Cases.png[width=25%]

--- a/src/test/groovy/docToolchain/GenerateHTMLSpec.groovy
+++ b/src/test/groovy/docToolchain/GenerateHTMLSpec.groovy
@@ -26,6 +26,8 @@ class GenerateHTMLSpec extends Specification {
         and: 'the output does not contain the warning "image to embed not found or not readable"'
             println result.output
             result.output.contains('image to embed not found or not readable') == false
+        and: 'the output does not contain the warning "invalid style for listing block: plantuml'
+            result.output.contains('invalid style for listing block: plantuml') == false
     }
 
 }


### PR DESCRIPTION
tried to create a test that fails, but somehow, the test (if run as test) does not fail. As run outside the test, the planUML creation fails as expected.
This change adds a refined test and reverts to the older dependency versions (which where know to work well)