### PR TITLE
Improve exception message

### DIFF
--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -438,7 +438,8 @@ def pushToConfluence = { pageTitle, pageBody, parentId, anchors, pageAnchors ->
             if (foreignPage) {
                 throw new IllegalArgumentException("Cannot create page, page with the same "
                     + "title=${foreignPage.title} "
-                    + "and id=${foreignPage.id} already exists in the space")
+                    + "with id=${foreignPage.id} already exists in the space. "
+                    + "A Confluence page title must be unique within a space, consider specifying a 'confluencePagePrefix' in ConfluenceConfig.groovy")
             }
         }
 


### PR DESCRIPTION
Most important update is changing the 'and' to 'with'.
'And' suggests a page with the same id en title already exists, but the limitation is only the confluence page title, the id the exception message is merely for assisting the user to find the duplicate page (title).
Also added some extra context about the Confluence limitation and  possibilities of docToolChain. This will save everyone time (who is less familiar with confluence or the tool)

### All Submissions:

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [x] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?

### New Feature Submissions:

1. [ ] Did you create new tests for your submission?
2. [ ] Does your submission pass all tests? (see travis check)

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Change to Documentation:

* [ ] Did you build the docs and copy them to the `/docs` folder?
* [ ] If not, did you create an issue for doing so?

inspiration: https://github.com/stevemao/github-issue-templates
