### PR TITLE
added hint for windows-only

### DIFF
--- a/src/docs/manual/03_task_exportEA.adoc
+++ b/src/docs/manual/03_task_exportEA.adoc
@@ -2,6 +2,7 @@
 ifndef::imagesdir[:imagesdir: ../images]
 
 = exportEA
+IMPORTANT: Currently this feature is WINDOWS-only. https://github.com/docToolchain/docToolchain/issues/231[See related issue]
 
 include::feedback.adoc[]
 


### PR DESCRIPTION
Added 'windows-only' hint to exportEA



### All Submissions:

* [X ] Does your PR affect the documentation?
* [X] If yes, did you update the documentation or create an issue for updating it?

### Change to Documentation:

* [ ] Did you build the docs and copy them to the `/docs` folder?
* [ ] If not, did you create an issue for doing so?
