### PR TITLE
added hint to pandoc dep and formats in Config.groovy

### DIFF
--- a/src/docs/manual/03_task_convertToDocx.adoc
+++ b/src/docs/manual/03_task_convertToDocx.adoc
@@ -3,6 +3,9 @@ ifndef::imagesdir[:imagesdir: ../images]
 
 = convertToDocx
 
+* Needs pandoc installed
+* Please make sure that 'docbook' and 'docx' are added to the inputFiles formats in Config.groovy
+
 include::feedback.adoc[]
 
 image::ea/Manual/convertToDocx.png[]


### PR DESCRIPTION
### All Submissions:

* [X] Does your PR affect the documentation?
* [X] If yes, did you update the documentation or create an issue for updating it?

Once again, the current docs is technically correct: the necessary info (pandoc, docx format) is there, but very easy to overlook.


### Change to Documentation:

* [ ] Did you build the docs and copy them to the `/docs` folder?
* [ ] If not, did you create an issue for doing so?

