### PR TITLE
Add maven repository to sub builds so that tests can be executed

### DIFF
--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -4,8 +4,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
     }
-
     dependencies {
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.3'
     }

--- a/scripts/exportExcel.gradle
+++ b/scripts/exportExcel.gradle
@@ -1,10 +1,13 @@
 buildscript {
+    repositories {
+        jcenter()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
     dependencies {
         //for export Excel Task
         classpath 'org.apache.poi:poi-ooxml:3.9'
-    }
-    repositories {
-        jcenter()
     }
 }
 

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -1,10 +1,13 @@
 buildscript {
+    repositories {
+        jcenter()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
     dependencies {
         //for the exportJiraIssues Task
         classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.6'
-    }
-    repositories {
-        jcenter()
     }
 }
 

--- a/scripts/exportMarkdown.gradle
+++ b/scripts/exportMarkdown.gradle
@@ -1,10 +1,13 @@
 buildscript {
+    repositories {
+        jcenter()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
     dependencies {
         //for the markdown conversion
         classpath 'nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc:1.0'
-    }
-    repositories {
-        jcenter()
     }
 }
 

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -1,13 +1,16 @@
 buildscript {
+    repositories {
+        jcenter()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
+    }
     dependencies {
         //for the exportJiraIssues Task
         classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.6'
         //for the renderToConfluence Task
         classpath 'org.apache.httpcomponents:httpmime:4.5.1'
         classpath 'org.jsoup:jsoup:1.9.1'
-    }
-    repositories {
-        jcenter()
     }
 }
 


### PR DESCRIPTION
Partially solves #267, now at least all files can be downloaded. Didn't use mavencenter() but maven with URL because it failed for some of the sub builds otherwise.

Now the tests execute, but some of them have errors. At least the gradle config seems to be more stable this way:

```shell
Condition not satisfied:

result.task(":generatePDF").outcome == SUCCESS
|      |                    |       |
|      |                    |       false
|      |                    UP_TO_DATE
|      :generatePDF=UP_TO_DATE
org.gradle.testkit.runner.internal.FeatureCheckBuildResult@245e3d61

	at docToolchain.GeneratePdfSpec.test correct handling of plantUML(GeneratePdfSpec.groovy:25)
```

And the problem that the sub builds don't take the proxy configuration from GRADLE_USER_HOME which the main build does also persists.