### PR TITLE
wrong path to doctoolchain

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -936,15 +936,15 @@ Blog-Post: <a href="https://rdmueller.github.io/arc42/">Let&#8217;s add Content!
 <div class="listingblock">
 <div class="title">Linux</div>
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">doctoolchain &lt;docDir&gt; generateHTML
-doctoolchain &lt;docDir&gt; generatePDF</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">bin/doctoolchain &lt;docDir&gt; generateHTML
+bin/doctoolchain &lt;docDir&gt; generatePDF</code></pre>
 </div>
 </div>
 <div class="listingblock">
 <div class="title">Windows</div>
 <div class="content">
-<pre class="CodeRay highlight"><code>doctoolchain.bat &lt;docDir&gt; generateHTML
-doctoolchain.bat &lt;docDir&gt; generatePDF</code></pre>
+<pre class="CodeRay highlight"><code>bin\doctoolchain.bat &lt;docDir&gt; generateHTML
+bin\doctoolchain.bat &lt;docDir&gt; generatePDF</code></pre>
 </div>
 </div>
 <div class="paragraph">


### PR DESCRIPTION
missing `bin` to the path to doctoolchain

### All Submissions:

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it? Update

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

inspiration: https://github.com/stevemao/github-issue-templates
