### PR TITLE
Update 02_install.adoc

### DIFF
--- a/src/docs/manual/02_install.adoc
+++ b/src/docs/manual/02_install.adoc
@@ -80,6 +80,9 @@ cd <docToolchain home>
 You need to open Config.groovy file and configure names of your files properly.
 You may also change the PDF schema file to your taste.
 
+IMPORTANT: docToolchain use by default `src/docs` as the directory of your documentation. If you use a different directory you need to go to <docToolchain home> and set the `inputPath` property in `gradle.properties` to `your/path`.
+
+
 === arc42 from scratch
 
 If you don't have existing documents yet, or if you need a fresh start, you can get the https://arc42.org[arc42] template in AsciiDoc


### PR DESCRIPTION
missing advice about where docToolchain expect the documentation. If you follow the instructions with a fresh instalation and put your `adoc` files in other place than `src/docs` the `docToolchain` can't find it

### All Submissions:

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

### Change to Documentation:

* [ ] Did you build the docs and copy them to the `/docs` folder?
* [x] If not, did you create an issue for doing so?

inspiration: https://github.com/stevemao/github-issue-templates
