### PR TITLE
Improving doctoolchain.bat. Introduced call gradlew and switch back t…

### DIFF
--- a/bin/doctoolchain.bat
+++ b/bin/doctoolchain.bat
@@ -24,13 +24,13 @@ cd /d %BASEDIR%
 
 IF "%PATHTODOCS:~0,1%"=="." goto :relativePath
 
-./gradlew --project-cache-dir %BASEDIR%/.gradle "-PdocDir=%PATHTODOCS%" %2 %3 %4 %5 %6
+call %GRADLECMD% --project-cache-dir %BASEDIR%/.gradle "-PdocDir=%PATHTODOCS%" %2 %3 %4 %5 %6
 
 goto :end
 
 :relativePath
 
-./gradlew --project-cache-dir %BASEDIR%/.gradle "-PdocDir=%WORKINGDIR%%PATHTODOCS%" %2 %3 %4 %5 %6
+call %GRADLECMD% --project-cache-dir %BASEDIR%/.gradle "-PdocDir=%WORKINGDIR%%PATHTODOCS%" %2 %3 %4 %5 %6
 
 goto :end
 
@@ -61,3 +61,5 @@ echo     doctoolchain . publishToConfluence
 goto :end
 
 :end
+rem back to WORKINGDIR
+cd /d %WORKINGDIR%


### PR DESCRIPTION
On Windows: Using doctoolchain.bat like "doctoolchain . generateHTML" from a document source path other than the default (e.g. c:\mysources\myproject\docs)  does not swith back to the document source path.

Reason: 

In doctoolchain.bat the control goes to gradlew-script. When it ends the working path switched to the installation of doctoolchain and not back where I started.

I added a 'call' for gradlew and at the end of doctoolchain.bat reassure that the document working dir is activated so you stay where you came from.