### PR TITLE
Replace Contains GQL operator with simple EQUALS operator to mathc pa…

### DIFF
--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -23,7 +23,7 @@
  */
 
 /*
-    Additions for issue #342 marked as #342-dierk42 
+    Additions for issue #342 marked as #342-dierk42
     ;-)
 */
 
@@ -105,7 +105,7 @@ def parseAdmonitionBlock(block, String type) {
 }
 
 /*  #342-dierk42
-    
+
     add labels to a Confluence page. Labels are taken from :keywords: which
     are converted as meta tags in HTML. Building the array: see below
 
@@ -365,7 +365,7 @@ def parseBody =  { body, anchors, pageAnchors ->
         if(!src.startsWith("http")) {
           def newUrl = baseUrl.toString().replaceAll('\\\\','/').replaceAll('/[^/]*$','/')+src
           def fileName = java.net.URLDecoder.decode((src.tokenize('/')[-1]),"UTF-8")
-          newUrl = java.net.URLDecoder.decode(newUrl,"UTF-8")      
+          newUrl = java.net.URLDecoder.decode(newUrl,"UTF-8")
 
           trythis {
               deferredUpload <<  [0,newUrl,fileName,"automatically uploaded"]
@@ -441,7 +441,7 @@ def pushToConfluence = { pageTitle, pageBody, parentId, anchors, pageAnchors, ke
         // #342-dierk42: Colons in title irritate Confluence's lucene search engine
         // (not really part of #342 but useful)
         def sPageTitle = pageTitle.replace(':', '')
-        def cql = "space='${confluenceSpaceKey}' AND type=page AND title~'" + realTitle(sPageTitle) + "'"
+        def cql = "space='${confluenceSpaceKey}' AND type=page AND title = '" + realTitle(sPageTitle) + "'"
         if (parentId) {
             cql += " AND parent=${parentId}"
         }
@@ -505,7 +505,7 @@ def pushToConfluence = { pageTitle, pageBody, parentId, anchors, pageAnchors, ke
         if (parentId) {
             def foreignPages
             trythis {
-                def foreignCql = "space='${confluenceSpaceKey}' AND type=page AND title~'" + realTitle(pageTitle) + "'"
+                def foreignCql = "space='${confluenceSpaceKey}' AND type=page AND title = '" + realTitle(pageTitle) + "'"
                 foreignPages = api.get(path: 'content/search',
                                       query: ['cql' : foreignCql],
                                     headers: headers).data.results

--- a/src/docs/manual/05_contributors.adoc
+++ b/src/docs/manual/05_contributors.adoc
@@ -38,6 +38,7 @@ Here is an incomplete and unordered list of contributors:
 - https://github.com/chrira[Christoph Raaflaub]
 - https://twitter.com/jagedn[Jorge Aguilera]
 - https://github.com/bohni[Stefan Bohn]
+- https://github.com/LuisMuniz[Luis Muniz]
 
 (please update your entry to match your preferences! :-)
 


### PR DESCRIPTION
Allow publishing to a standalone confluence server, by changing the operator used to find an existing page matching the realTitle from contains (`~`) to EQUALS (`=`)

I did not create new tests for my submission (publishing to confluence is a hard thing to test).

however, my change is backwards compatible as I tested it both on cloud and standalone confluence.


