### PR TITLE
calculate localHash after prefixing extraPageContent

### DIFF
--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -516,12 +516,12 @@ def pushToConfluence = { pageTitle, pageBody, String parentId, anchors, pageAnch
     //try to get an existing page
     localPage = parseBody(pageBody, anchors, pageAnchors)
 
-    def localHash = MD5(localPage)
     def default_toc = '<p><ac:structured-macro ac:name="toc"/></p>'
     def prefix = (config.confluence.tableOfContents?:default_toc)+(config.confluence.extraPageContent?:'')
     localPage  = prefix+localPage
     def default_children = '<p><ac:structured-macro ac:name="children"><ac:parameter ac:name="sort">creation</ac:parameter></ac:structured-macro></p>'
     localPage += (config.confluence.tableOfChildren?:default_children)
+    def localHash = MD5(localPage)
     localPage += '<p style="display:none">hash: #'+localHash+'#</p>'
 
     def request = [


### PR DESCRIPTION
The MD5 for the localPage was calculated before the extraPageContent was prefixed to the localPage. Therefore the hashes didn't differ, if there weren't any other page changes in the local HTML.

With this change it is now possible to just change the extraPageContent banner and push it to Confluence.