### PR TITLE
Update remaining dependency versions except the asciidoctor related ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: groovy
 jdk:
   - openjdk8
   - openjdk11
+  - openjdk12
 
 addons:
   apt:

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testCompile(
             ('junit:junit:4.12'),
             ('org.spockframework:spock-core:1.3-groovy-2.5'),
-            ('com.athaydes:spock-reports:1.3.2'),
+            ('com.athaydes:spock-reports:1.6.2'),
             //('org.slf4j:slf4j-api:1.7.13'),
             //('org.slf4j:slf4j-simple:1.7.13'),
             gradleTestKit()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,

--- a/scripts/exportExcel.gradle
+++ b/scripts/exportExcel.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         //for export Excel Task
-        classpath 'org.apache.poi:poi-ooxml:3.9'
+        classpath 'org.apache.poi:poi-ooxml:3.10.1'
     }
 }
 

--- a/scripts/exportExcel.gradle
+++ b/scripts/exportExcel.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         //for export Excel Task
-        classpath 'org.apache.poi:poi-ooxml:3.10.1'
+        classpath 'org.apache.poi:poi-ooxml:4.1.1'
     }
 }
 
@@ -126,7 +126,7 @@ use `gradle exportExcel` to re-export files
                                         cellStyle += '.^'
                                         break
                                 }
-                                color = cell.cellStyle.fillForegroundXSSFColor?.rgb?.encodeHex()
+                                color = cell.cellStyle.fillForegroundXSSFColor?.RGB?.encodeHex()
                                 color = color != null ? nl + "{set:cellbgcolor:#${color}}" : ''
                                 data << cellValue
                                 if (color == '' && resetColor) {

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         //for the exportJiraIssues Task
-        classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.6'
+        classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
     }
 }
 

--- a/scripts/exportMarkdown.gradle
+++ b/scripts/exportMarkdown.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         //for the markdown conversion
-        classpath 'nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc:1.0'
+        classpath 'nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc:1.1'
     }
 }
 

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -7,10 +7,10 @@ buildscript {
     }
     dependencies {
         //for the exportJiraIssues Task
-        classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.6'
+        classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
         //for the renderToConfluence Task
-        classpath 'org.apache.httpcomponents:httpmime:4.5.1'
-        classpath 'org.jsoup:jsoup:1.11.3'
+        classpath 'org.apache.httpcomponents:httpmime:4.5.10'
+        classpath 'org.jsoup:jsoup:1.12.1'
     }
 }
 

--- a/src/test/testData/excel/Sample.xlsx/ColAndRowSpan.adoc
+++ b/src/test/testData/excel/Sample.xlsx/ColAndRowSpan.adoc
@@ -1,7 +1,7 @@
 [options="header",cols="25,25,25,25"]
 |===
 2+.>| ColSpan
-{set:cellbgcolor:#595959}
+{set:cellbgcolor:#002864}
 
 .>| a
 {set:cellbgcolor!}


### PR DESCRIPTION
Doing this while getting more familiar with the toolchain.

Updating asciidoctor dependencies to versions that play well together while not breaking anything seems to be not trivial or even requires some task code changes due to API updates in:
* asciidoctor-gradle-plugin
* asciidoctor.convert
* asiidoctorj-pdf
* asciidoctorj-diagram

Seems to be an interesting task to explore to see how everything plays together. But that would anyway go via different PR.