### PR TITLE
putting the grammar plugin gratie to the test

### DIFF
--- a/src/docs/manual/01_introduction_and_goals.adoc
+++ b/src/docs/manual/01_introduction_and_goals.adoc
@@ -18,14 +18,14 @@ How it all began...
 Before this project started, I wasn't aware of the term _docs-as-code_.
 I just got tired of keeping all my architecture diagrams up to date by copying them from my UML tool over to my word processor.
 
-As a lazy developer, I told myself 'there has to be a better way of doing this'.
+As a lazy developer, I told myself '`there has to be a better way of doing this`'.
 And I started to automate the diagram export and switched from a full fledged word processor over to a markup renderer.
 This enabled me to reference the diagrams from within my text and update them just before I render the document.
 
 === arc42
 
-Since my goal was to document software architectures, I was already using arc42 - a template for software architecture.
-At this time, it used the MS Word template.
+Since my goal was to document software architectures, I was already using arc42, a template for software architecture documentation.
+At that time, I used the MS Word template.
 
 But what is arc42?
 
@@ -34,27 +34,27 @@ They dumped all their experience about software architectures not only into a st
 These explanations are part of every chapter of the template and give you guidance on how to write each chapter of the document.
 
 arc42 is available in many formats like MS Word, textile, and Confluence.
-All these formats are automatically generated from one _golden master_ which is formatted in https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[_asciidoc_].
+All these formats are automatically generated from one _golden master_ formatted in https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[_AsciiDoc_].
 
 === docToolchain
 
-In order to follow the _docs-as-code_ approach, you need a build script which automates steps like exporting diagrams and rendering the used Markdown (_AsciiDoc_ in case of _docToolchain_) to the target format.
+In order to follow the _docs-as-code_ approach, you need a build script that automates steps like exporting diagrams and rendering the used Markdown (_AsciiDoc_ in case of _docToolchain_) to the target format.
 
-Unfortunately, such a build script is not easy to create in the first place ('how do I create .docx?', 'why does lib x not work with lib y?') and it is also not too easy to maintain.
+Unfortunately, such a build script is not easy to create in the first place ('`how do I create .docx?`', '`why does lib x not work with lib y?`') and it is also not too easy to maintain.
 
 _docToolchain_ is the result of my journey through the _docs-as-code_ land.
-The goal is to have an easy to use build script which only has to be configured and not modified and which is maintained by a community as open source software.
+The goal is to have an easy to use build script that only has to be configured and not modified and that is maintained by a community as open source software.
 
 The technical steps of my journey are written down in my blog: https://rdmueller.github.io.
 
----
+'''
 
 Let's start with what you'll get when you use _docToolchain_...
 
 == Benefits of the docs-as-code Approach
 
 You want to write technical docs for your software project.
-So it is very likely that you already have the tools and processes to work with source code in place.
+So it is likely you already have the tools and processes to work with source code in place.
 Why not also use it for your docs?
 
 === Document Management System
@@ -73,7 +73,7 @@ And when you store your docs in the same repository as your code, you always hav
 Git as a distributed version control system even enables collaboration on your docs.
 People can fork the docs and send you pull requests for the changes they made.
 By reviewing the pull request, you have a perfect review process out of the box - by accepting the pull request, you show that you've reviewed and accepted the changes.
-Most git frontends like https://www.bitbucket.org[Bitbucket], https://gitlab.com[GitLab] and of course https://github.com[GitHub] also allow you to reject pull requests with comments.
+Most Git frontends like https://www.bitbucket.org[Bitbucket], https://gitlab.com[GitLab] and of course https://github.com[GitHub] also allow you to reject pull requests with comments.
 
 === Image References and Code Snippets
 
@@ -85,8 +85,8 @@ This way, these snippets are also always up to date!
 
 === Compound and Stakeholder-Tailored Docs
 
-Since you can not only reference images and code snippets but also sub-documents, you can split your docs into several sub-documents and a master which brings all those docs together.
-But you are not restricted to one master - you can create master docs for several different stakeholders which only contain the chapters needed for them.
+Since you can not only reference images and code snippets but also sub-documents, you can split your docs into several sub-documents and a master, which brings all those docs together.
+But you are not restricted to one master -- you can create master docs for different stakeholders that only contain the chapters needed for them.
 
 === Many more Features...
 


### PR DESCRIPTION
I've given the [Grazie grammar checking plugin](https://plugins.jetbrains.com/plugin/12175-grazie/) a test run on the first chapter. I also read up on "which" vs. "that" and changed some of them according to this website: https://www.grammarly.com/blog/which-vs-that/. Please double check.

### All Submissions:

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/manual`. 
To "publish" it, execute `./gradlew && ./copyDocs.sh`.
This will convert the `.adoc` file to HTML and copy them to the right folder so that github pages will pick them up.

If you didn't find the time to update docs, please create an issue as reminder to do so.

### Change to Documentation:

* [x] Did you build the docs and copy them to the `/docs` folder?
