### PR TITLE
Clarified usage and type of ancestorId #375

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -56,7 +56,7 @@ confluence = [:]
 // Attributes
 // - 'file': absolute or relative path to the asciidoc generated html file to be exported
 // - 'url': absolute URL to an asciidoc generated html file to be exported
-// - 'ancestorId' (optional): the id of the parent page in Confluence; leave this empty
+// - 'ancestorId' (optional): the id of the parent page in Confluence as string; leave this empty
 //                            if a new parent shall be created in the space
 // - 'preambleTitle' (optional): the title of the page containing the preamble (everything
 //                            before the first second level heading). Default is 'arc42'

--- a/src/docs/manual/03_task_publishToConfluence.adoc
+++ b/src/docs/manual/03_task_publishToConfluence.adoc
@@ -22,7 +22,8 @@ We tried to make the configuration self-explaining, but there are always some no
 
 ancestorId::
 this is the page ID of the parent page to which you want your docs to be published.
-Go to this page, click on edit and the needed ID will show up in the URL
+Go to this page, click on edit and the needed ID will show up in the URL.
+Specify the ID as string within the config file.
 
 api::
 for cloud instances, `[context]` is `wiki`

--- a/template_config/scripts/ConfluenceConfig.groovy
+++ b/template_config/scripts/ConfluenceConfig.groovy
@@ -20,8 +20,8 @@ input = [
         [ file: "build/docs/html5/arc42-template-de.html" ],
 //      [ url:  "http://aim42.github.io/htmlSanityCheck/hsc_arc42.html" ],
 //    	[ file: "asciidocOutput1.html", ancestorId: '' ],
-//    	[ file: "asciidocOutput2.html", ancestorId: 123456 ],
-//      [ file: "asciidocOutput3.html", ancestorId: 123456, preambleTitle: 'Third Output', createSubpages: true, pagePrefix: 'docs-as-code - ']
+//    	[ file: "asciidocOutput2.html", ancestorId: '123456' ],
+//      [ file: "asciidocOutput3.html", ancestorId: '123456', preambleTitle: 'Third Output', createSubpages: true, pagePrefix: 'docs-as-code - ']
 ]
 
 // endpoint of the confluenceAPI (REST) to be used


### PR DESCRIPTION
Source #375 
This fixed the documentation to clarify that the `ancestorId` shall be a of type `String`. 

* [x] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?
* [ ] Did you build the docs and copy them to the `/docs` folder?
* [ ] If not, did you create an issue for doing so?

I did not build the docs for several reasons:
* the `feedback.adoc` cannot be included (on every page), didn't find out why (it was already an issue when I generated docs based on master, also in the published version) - and that would leave all generated HTML with my local path I don't want in the repo
* the doc generation changed a lot of HTML properties - not sure why (I'm on Windows btw.), e.g. 
```
-<img src="images/demoPlantUML.png" alt="demoPlantUML" width="246" height="236">
+<img src="images/demoPlantUML.png" alt="demoPlantUML" width="231" height="236">
```