### PR TITLE
Update build.gradle testCompile soon to be depreca

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 apply plugin:'groovy'
 
 dependencies {
-    testCompile(
+    testImplementation(
             ('junit:junit:4.12'),
             ('org.spockframework:spock-core:1.3-groovy-2.5'),
             ('com.athaydes:spock-reports:1.6.2'),


### PR DESCRIPTION
Changed testCompile to testImplementation to make the build.gradle compatible with upcoming gradle version. I was not able to find out, which the minimum gradle version is, which works with testImplemenation, however, gradle 4.6 seems to include it. https://docs.gradle.org/4.6/release-notes.html

"Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.1/userguide/command_line_interface.html#sec:command_line_warnings"
