### PR TITLE
Added Credentials Fallback based on gradle properties to publishToConfluence

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -97,7 +97,8 @@ confluence.with {
 
     // username:password of an account which has the right permissions to create and edit
     // confluence pages in the given space.
-    // if you want to store it securely, fetch it from some external storage.
+    // if you want to store it securely, fetch it from some external storage or leave it empty to fallback to gradle variables
+    // set through gradle properties files or environment variables. The fallback uses the 'confluenceUser' and 'confluencePassword' keys.
     // you might even want to prompt the user for the password like in this example
 
     credentials = "user:pass_or_token".bytes.encodeBase64().toString()

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -23,6 +23,20 @@ task publishToConfluence(
         logger.info("docToolchain> docDir: "+docDir)
         def configFile = new File(docDir, mainConfigFile)
         def config = new ConfigSlurper().parse(configFile.text)
+
+        if(config.confluence.credentials.isEmpty()){
+            logger.quiet("no credentials set in '${configFile.name}'")
+            logger.quiet("trying 'confluenceUser' and 'confluencePassword' from gradle properties")
+
+            if(project.hasProperty("confluenceUser") && project.hasProperty("confluencePassword")){
+                config.confluence.credentials = "${confluenceUser}:${confluencePassword}".bytes.encodeBase64().toString()
+            }else{
+                logger.quiet("variables 'confluenceUser' and/or 'confluencePassword' are not set!")
+                logger.quiet("please specify them through gradle.properties, the commandline or environment variables")
+            }
+
+        }
+
         binding.setProperty('config',config)
         binding.setProperty('docDir',docDir)
         binding.setProperty('configFile', configFile)

--- a/src/docs/manual/03_task_publishToConfluence.adoc
+++ b/src/docs/manual/03_task_publishToConfluence.adoc
@@ -17,7 +17,7 @@ Special features:
 * only pages and images which have changed between task runs are really published and hence only for those changes notifications are sent to watchers. This is quite important - otherwise watchers are easily annoyed by too many notifications.
 * `:keywords:` Keywords are attached as labels to every generated Confluence page. The rules for page labels should be kept in mind. See https://confluence.atlassian.com/doc/add-remove-and-search-for-labels-136419.html. Several keywords are allowed. They must be separated by comma, e.g. `:keywords: label_1, label-2, label3, ...`. Labels (keywords) must not contain a space character! Use '_' or '-'.
 
-NOTE: code-macro-blocks in confluence render an error if the language attribute contains an unknown language. 
+NOTE: code-macro-blocks in confluence render an error if the language attribute contains an unknown language.
 See https://confluence.atlassian.com/doc/code-block-macro-139390.html for a list of valid language and how to add further languages.
 
 == Configuration
@@ -49,6 +49,11 @@ Use username and password or even better username and api-token.
 You can create new API-tokens in https://confluence.atlassian.com/cloud/api-tokens-938839638.html[your profile].
 To avoid having your password or api-token versioned through git, you can store it outside of this configuration as environment variable or in another file - the key here is that the config file is a groovy script.
 e.g. you can do things like `credentials = "user:${new File("/home/me/apitoken").text}".bytes.encodeBase64().toString()`
+
+To simplify the injection of credentials from external sources there is a fallback. Should you leave the credentials field empty,
+the variables `confluenceUser` and `confluencePassword` from the build environment will be used for authentication. You can set these through any means
+allowed by gradle like the `gradle.properties` file in the project or your home directory, environment variables or command-line flags.
+For all ways to set these variables, have a look at the https://docs.gradle.org/current/userguide/build_environment.html[gradle manual].
 
 extraPageContent::
 If you need to prefix your pages with a warning that this is generated content - this is the right place.

--- a/src/docs/manual/05_contributors.adoc
+++ b/src/docs/manual/05_contributors.adoc
@@ -46,6 +46,7 @@ Here is an incomplete and unordered list of contributors:
 - https://github.com/mindyou[Maarten Gribnau]
 - https://github.com/mpriess[Michael Prieß]
 - https://github.com/stehlih[Heiko Stehli]
+- https://github.com/nilsmahlstaedt[Nils Mahlstädt] @ https://github.com/hmmh[hmmh]
 
 (please update your entry to match your preferences! :-)
 


### PR DESCRIPTION
Pullrequest for suggestion from [Issue 405](https://github.com/docToolchain/docToolchain/issues/405)

Adds a block, that modifies the config if `confluence.credentials` is empty.
Takes the variables `confluenceUser` and `confluencePassword` from the build environment (see [gradle manual](https://docs.gradle.org/current/userguide/build_environment.html)) to generate a new credentials string and insert it into the confluence object befor binding it.

### All Submissions:

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation ~or create an issue for updating it~?

The source of the documentation can be found in `/src/docs/manual`. 
To "publish" it, execute `./gradlew && ./copyDocs.sh`.
This will convert the `.adoc` file to HTML and copy them to the right folder so that github pages will pick them up.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [x] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Change to Documentation:

* [ ] Did you build the docs and copy them to the `/docs` folder?
* [ ] If not, did you create an issue for doing so?

inspiration: https://github.com/stevemao/github-issue-templates
