### PR TITLE
Fix for #428 publishToConfluence authentication failure

### DIFF
--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -175,6 +175,11 @@ def uploadAttachment = { def pageId, String url, String fileName, String note ->
             'Authorization': 'Basic ' + config.confluence.credentials,
             'X-Atlassian-Token':'no-check'
     ]
+    //Add api key and value to REST API request header if configured - required for authentification.
+    if (config.confluence.apikey)
+    {
+       headers.keyid = config.confluence.apikey
+    }
     //check if attachment already exists
     def result = "nothing"
     def attachment = api.get(path: 'content/' + pageId + '/child/attachment',
@@ -513,6 +518,11 @@ def pushToConfluence = { pageTitle, pageBody, String parentId, anchors, pageAnch
             'Authorization': 'Basic ' + config.confluence.credentials,
             'Content-Type':'application/json; charset=utf-8'
     ]
+    //Add api key and value to REST API request header if configured - required for authentification.
+    if (config.confluence.apikey)
+    {
+       headers.keyid = config.confluence.apikey
+    }
     String realTitleLC = realTitle(pageTitle).toLowerCase()
 
     //this fixes the encoding


### PR DESCRIPTION
As reported in issue  #428, the configuration of publishToConfluence is not used for the APIkey representation in the HTTP header. So, requests were rejected in case it is required with reason: missing authentication credentials.
This pull request fixes the issue by adding the apikey key/value pair if the config parameter: 'config.confluence.apikey' is set, otherwise no additional header field is added and previous behaviour is retained.

### All Submissions:

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

Documentation not affected.
