### PR TITLE
Added attachment support

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -109,6 +109,13 @@ confluence.with {
     // extraPageContent = '<ac:structured-macro ac:name="warning"><ac:parameter ac:name="title" /><ac:rich-text-body>This is a generated page, do not edit!</ac:rich-text-body></ac:structured-macro>
     extraPageContent = ''
 
+    // enable or disable attachment uploads for local file references
+    enableAttachments = false
+
+    // default attachmentPrefix = attachment - All files to attach will require to be linked inside the document.
+    // attachmentPrefix = "attachment"
+
+
     // Optional proxy configuration, only used to access Confluence
     // schema supports http and https
     // proxy = [host: 'my.proxy.com', port: 1234, schema: 'http']
@@ -135,4 +142,3 @@ exportEA.with {
 //                  ]
 }
 //end::exportEAConfig[]
- 

--- a/src/docs/manual/03_task_publishToConfluence.adoc
+++ b/src/docs/manual/03_task_publishToConfluence.adoc
@@ -58,6 +58,21 @@ For all ways to set these variables, have a look at the https://docs.gradle.org/
 extraPageContent::
 If you need to prefix your pages with a warning that this is generated content - this is the right place.
 
+enableAttachments::
+
+If value is set to *true*, your links to local file references will be uploaded as attachments. The current implementation only supports a single folder. This foldername will be used as a prefix to validate if your file should be uploaded or not.
+In case you enable this feature, and use a folder which starts with "attachment*", an adaption of this prefix is required.
+
+Example:
+
+All files to attach will require to be linked inside the document.
+
+``link:attachement/myfolder/myfile.json[My API definition]``
+
+attachmentPrefix::
+
+The expected foldername of your output dir. *Default*: `attachment`
+
 proxy::
 If you need to provide a proxy to access Confluence, you may set a map with keys `host` (e.g. `'my.proxy.com'`), `port` (e.g. `'1234'`) and `schema` (e.g. `'http'`) of your proxy.
 


### PR DESCRIPTION
What i actually added are 2 configuration options.
1st to enable attachments for confluence
2nd to tell the folder name of the attachments.


### All Submissions:

* [ x] Does your PR affect the documentation?
* [x ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/manual`. 
To "publish" it, execute `./gradlew && ./copyDocs.sh`.
This will convert the `.adoc` file to HTML and copy them to the right folder so that github pages will pick them up.

If you didn't find the time to update docs, please create an issue as reminder to do so.

-------

**Please be so kind to do a manual verification, that the step works after integration into the official repository. I had limitations on this side. On a copy of the adapted asciidoc2confluence.gradle it worked well.**

No tests written, due to simplicity of the  added feature and complexity of the required confluence backend.

### Change to Documentation:

* [] Did you build the docs and copy them to the `/docs` folder?
No, i somehow had issues rendering. A link to the documentation ticket will follow. Documentation is updated, but not rendered as html.

