### PR TITLE
Add parameter exportPath and searchPath to exportEA module

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -143,5 +143,10 @@ exportEA.with {
 //                    "{A237ECDE-5419-4d47-AECC-B836999E7AE0}",
 //                    "{B73FA2FB-267D-4bcd-3D37-5014AD8806D6}"
 //                  ]
+// OPTIONAL: relative path to base 'docDir' to which the diagrams and notes are to be exported
+// exportPath = "src/docs/"
+// OPTIONAL: relative path to base 'docDir', in which Enterprise Architect project files are searched
+// searchPath = "src/docs/"
+ 
 }
 //end::exportEAConfig[]

--- a/scripts/exportEA.gradle
+++ b/scripts/exportEA.gradle
@@ -44,15 +44,17 @@ task exportEA(
         group: 'docToolchain'
 ) {
     doFirst {
-        logger.info ("docToolchain> docDir: "+docDir)
-        //make sure path for notes exists
-        //and remove old notes
-        new File(docDir, 'src/docs/ea').deleteDir()
-        //also remove old diagrams
-        new File(docDir, 'src/docs/images/ea').deleteDir()
-        //create a readme to clarify things
+    }
+    doLast {
+        logger.info("docToolchain > exportEA: "+docDir)
+        logger.info("docToolchain > exportEA: "+mainConfigFile)
+        def configFile = new File(docDir, mainConfigFile)
+        def config = new ConfigSlurper().parse(configFile.text)
+        def scriptParameterString = ""
+        def exportPath = ""
+        def searchPath = ""
         def readme = """This folder contains exported diagrams or notes from Enterprise Architect.
-		
+
 Please note that these are generated files but reside in the `src`-folder in order to be versioned.
 
 This is to make sure that they can be used from environments other than windows.
@@ -63,20 +65,10 @@ This is to make sure that they can be used from environments other than windows.
 
 use `gradle exportEA` to re-export files
 """
-        new File(docDir, 'src/docs/images/ea/.').mkdirs()
-        new File(docDir, 'src/docs/images/ea/readme.ad').write(readme)
-        new File(docDir, 'src/docs/ea/.').mkdirs()
-        new File(docDir, 'src/docs/ea/readme.ad').write(readme)
-    }
-    doLast {
-        logger.info("docToolchain > exportEA: "+docDir)
-        logger.info("docToolchain > exportEA: "+mainConfigFile)
-        def configFile = new File(docDir, mainConfigFile)
-        def config = new ConfigSlurper().parse(configFile.text)
-		def scriptParameterString = ""
+
         if(!config.exportEA.connection.isEmpty()){
             logger.info("docToolchain > exportEA: found "+config.exportEA.connection)
-			scriptParameterString = scriptParameterString + "-c \"${config.exportEA.connection}\""
+            scriptParameterString = scriptParameterString + "-c \"${config.exportEA.connection}\""
         }
         if (!config.exportEA.packageFilter.isEmpty()){
             def packageFilterToCreate = config.exportEA.packageFilter as List
@@ -85,11 +77,39 @@ use `gradle exportEA` to re-export files
                scriptParameterString = scriptParameterString + " -p \"${packageFilter}\""
             }
         }
+        if (!config.exportEA.exportPath.isEmpty()){
+            exportPath = new File(docDir, config.exportEA.exportPath).getAbsolutePath()
+        }
+        else {
+            exportPath = new File(docDir, 'src/docs').getAbsolutePath()
+        }
+        if (!config.exportEA.searchPath.isEmpty()){
+            searchPath = new File(docDir, config.exportEA.searchPath).getAbsolutePath()
+        }
+        else {
+            searchPath = new File(docDir, 'src').getAbsolutePath()
+        }
+        scriptParameterString = scriptParameterString + " -d \"$exportPath\""
+        scriptParameterString = scriptParameterString + " -s \"$searchPath\""
+        logger.info("docToolchain > exportEA: exportPath: "+exportPath)
+
+        //make sure path for notes exists
+        //and remove old notes
+        new File(exportPath , 'ea').deleteDir()
+        //also remove old diagrams
+        new File(exportPath , 'images/ea').deleteDir()
+
+        //create a readme to clarify things
+        new File(exportPath , 'images/ea/.').mkdirs()
+        new File(exportPath , 'images/ea/readme.ad').write(readme)
+        new File(exportPath , 'ea/.').mkdirs()
+        new File(exportPath , 'ea/readme.ad').write(readme)
+
         //execute through cscript in order to make sure that we get WScript.echo right
         "%SystemRoot%\\System32\\cscript.exe //nologo ${projectDir}/scripts/exportEAP.vbs ${scriptParameterString}".executeCmd()
         //the VB Script is only capable of writing iso-8859-1-Files.
         //we now have to convert them to UTF-8
-        new File(docDir, 'src/docs/ea/.').eachFileRecurse { file ->
+        new File(exportPath, 'ea/.').eachFileRecurse { file ->
             if (file.isFile()) {
                 println "exported notes " + file.canonicalPath
                 file.write(file.getText('iso-8859-1'), 'utf-8')

--- a/src/docs/manual/03_task_exportEA.adoc
+++ b/src/docs/manual/03_task_exportEA.adoc
@@ -14,7 +14,7 @@ TIP: Blog-Posts: https://rdmueller.github.io/jria2eac/[JIRA to Sparx EA], https:
 == Configuration
 By default no special configuration is necessary.
 But, to be more specific on the project and its packages to be used for export,
-two optional parameter configurations are available.
+four optional parameter configurations are available.
 The parameters can be used independently from each other.
 A sample how to edit your projects Config.groovy is given in the 'Config.groovy'
 of the docToolchain project itself.
@@ -24,6 +24,20 @@ Set the connection to a certain project or comment it out to use all project fil
 
 packageFilter::
 Add one or multiple packageGUIDs to be used for export. All packages are analysed, if no packageFilter is set.
+
+exportPath::
+Relative path to base 'docDir' to which the diagrams and notes are to be exported.
+Default: "src/docs".
+Example: docDir = 'D:\work\mydoc\' ; exportPath = 'src/pdocs' ;
+Images will be exported to 'D:\work\mydoc\src\pdocs\images\ea',
+Notes  will be exported to 'D:\work\mydoc\src\pdocs\ea',
+
+searchPath::
+Relative path to base 'docDir', in which Enterprise Architect project files are searched
+Default: "src/docs".
+Example: docDir = 'D:\work\mydoc\' ; exportPath = 'src/projects' ;
+Lookup for eap and eapx files starts in 'D:\work\mydoc\src\projects' and goes down the folder structure.
+*Note*: In case connection is already defined, the searchPath value is ignored.
 
 == Source
 


### PR DESCRIPTION
As described in issue #439, the export does not work as expected in case the docToolchain repository is not used as a submodule, but used as a standalone tool. In this case the configured docDir wasn't used as base directory.
This is fixed by this pull request. 
In addition the path to export the diagrams can be set as an optional parameter. Same for the path where to look for eap or eapx project files. Both paths are relative to the docDir path.
The sample Config.groovy and documentation is updated accordingly.
A method is added tp clean the filenames in case it contains invalid characters.

