### PR TITLE
Feature/export jira to excel

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -189,10 +189,36 @@ jira.with {
     // the label to restrict search to
     label = 
 
-    // Jira query
-    jql = "project='%jiraProject%' AND labels='%jiraLabel%' ORDER BY priority DESC, duedate ASC"
+    // Base filename in which Jira query results should be stored
+    resultsFilename = 'JiraTicketsContent'
+
+    saveAsciidoc = true // if true, asciidoc file will be created with *.adoc extension
+    saveExcel = true // if true, Excel file will be created with *.xlsx extension
+
+    /* 
+    List of requests to Jira API:
+    These are basically JQL expressions bundled with a filename in which results will be saved.
+    User can configure custom fields IDs and name those for column header,
+    i.e. customfield_10026:'Story Points' for Jira instance that has custom field with that name and will be saved in a coloumn named "Story Points"
+    */
+    requests = [
+        new JiraRequest(
+            filename:"File1_Done_issues",
+            jql:"project='%jiraProject%' AND status='Done' ORDER BY duedate ASC",
+            customfields: [customfield_10026:'Story Points']
+        ),
+        new JiraRequest(
+            filename:'CurrentSprint',
+            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC", 
+            customfields: [customfield_10026:'Story Points']
+        ),
+    ]    
+}
     
-    // Filename in which Jira query results should be stored
-    resultsFilename = 'JiraTicketsContent.adoc'
+@groovy.transform.Immutable
+class JiraRequest {
+    String filename  //filename (without extension) of the file in which JQL results will be saved. Extension will be determined automatically for Asciidoc or Excel file
+    String jql // Jira Query Language syntax 
+    Map<String,String> customfields // map of customFieldId:displayName values for Jira fields which don't have default names, i.e. customfield_10026:StoryPoints
 }
 //end::jiraConfig[]

--- a/Config.groovy
+++ b/Config.groovy
@@ -187,7 +187,10 @@ jira.with {
     dateTimeFormatOutput = "dd.MM.yyyy HH:mm:ss z" // i.e. 24.07.2020 09:02:40 CEST
 
     // the label to restrict search to
-    label = 
+    label = 'label1'
+
+    // Legacy settings for Jira query. This setting is deprecated & support for it will soon be completely removed. Please use JiraRequests settings
+    jql = "project='%jiraProject%' AND labels='%jiraLabel%' ORDER BY priority DESC, duedate ASC"
 
     // Base filename in which Jira query results should be stored
     resultsFilename = 'JiraTicketsContent'

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -8,6 +8,11 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 == Unreleased
 
 === Added
+2020-07-08::
+* Jira configuration for multiple request to Jira API
+* Saving Jira results to Excel files
+* Basic support for custom fields in Jira results
+
 2020-05-08::
 * Jira configuration refactoring to Config.groovy
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,10 +11,9 @@ jiraDateTimeFormatParse = 'yyyy-MM-dd'T'H:m:s.Sz' // the format to parse the rec
 jiraDateTimeOutput = 'dd.MM.yy' // the format in which the date time is output
 jiraLabel = '' // the label to restrict search to
 
-jiraJql  = project='%jiraProject%' AND resolution='Unresolved' AND labels='%jiraLabel%' ORDER BY priority DESC, duedate ASC
-
 // Filename to save results from Jira
-jiraResultsFilename = 'openissues.adoc'
+jiraResultsFilename = 'openissues'
+
 
 // Directory containing the documents to be processed by docToolchain.
 // If the documents are together with docToolchain, this can be relative path.

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -47,12 +47,12 @@ task exportJiraIssues(
 
         // map configuration from Config.groovy to existing variables for compatibility with naming of Jira settings in gradle.properties
         jiraRoot = config.jira.api
-        jiraJql = config.jira.jql
         jiraProject = config.jira.project
         jiraLabel = config.jira.label
         jiraResultsFilename = config.jira.resultsFilename
         jiraDateTimeFormatParse = config.jira.dateTimeFormatParse
         jiraDateTimeOutput = config.jira.dateTimeFormatOutput
+        def defaultFields = 'priority,created,resolutiondate,summary,assignee,timeoriginalestimate,status'
 
         def jira = new groovyx.net.http.RESTClient(jiraRoot + '/rest/api/2/')
         jira.encoderRegistry = new groovyx.net.http.EncoderRegistry(charset: 'utf-8')
@@ -60,23 +60,60 @@ task exportJiraIssues(
                 'Authorization': "Basic " + config.jira.credentials,
                 'Content-Type' : 'application/json; charset=utf-8'
         ]
-        def openIssues = new File(targetDir, jiraResultsFilename)
+        def jiraRequests = config.jira.requests
+        
+        jiraRequests.each {rq -> 
+            logger.quiet("Request to Jira API for '${rq.filename}' with query: '${rq.jql}'")
+
+            def allHeaders = "${defaultFields},${rq.customfields.values().join(",")}"
+            def allFieldIds = "${defaultFields},${rq.customfields.keySet().join(",")}"
+            logger.quiet("Preparing headers for default & custom fields: ${allHeaders}")
+            logger.quiet("Preparing field IDs for default & custom fields: ${allFieldIds}")
+
+            // Save AsciiDoc file
+            if (config.jira.saveAsciidoc) {
+                def extension = 'adoc'
+                jiraResultsFilename = "${rq.filename}.${extension}"
+                logger.quiet(">> Results will be saved in '${rq.filename}.${extension}' file")
+                
+                def openIssues = new File(targetDir, "${rq.filename}.${extension}")
         openIssues.write(".Table {Title}\n", 'utf-8')
         openIssues.append("|=== \n")
-        openIssues.append("|Key |Priority |Created | Assignee | Summary\n", 'utf-8')
-        println jiraJql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel)
+
+                // AsciiDoc table headers (custom fields map needs values here)
+                openIssues.append("|Key ", 'utf-8')
+                allHeaders.split(",").each {field -> 
+                    openIssues.append("|${field} ", 'utf-8')
+                }
+                openIssues.append("\n", 'utf-8')
+                
         jira.get(path: 'search',
-                query: ['jql'       : jiraJql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel),
+                    query: ['jql'       : rq.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel),
                         'maxResults': 1000,
-                        'fields'    : 'created,resolutiondate,priority,summary,timeoriginalestimate, assignee'
+                            fields: "${allFieldIds}"
                 ],
                 headers: headers
         ).data.issues.each { issue ->
-            openIssues.append("| <<${issue.key}>> ", 'utf-8')
+                    //logger.quiet(">> Whole issue ${issue.key}:\n   ${issue.fields}")
+                    openIssues.append("| ${jiraRoot}/browse/${issue.key}[${issue.key}] ", 'utf-8')
             openIssues.append("| ${issue.fields.priority.name} ", 'utf-8')
             openIssues.append("| ${Date.parse(jiraDateTimeFormatParse, issue.fields.created).format(jiraDateTimeOutput)} ", 'utf-8')
-            openIssues.append("| ${issue.fields.assignee ? issue.fields.assignee.displayName : 'not assigned'} ", 'utf-8')
-            openIssues.append("| ${jiraRoot}/browse/${issue.key}[${issue.fields.summary}]\n", 'utf-8')
+                    openIssues.append("| ${issue.fields.resolutiondate ? Date.parse(jiraDateTimeFormatParse, issue.fields.resolutiondate).format(jiraDateTimeOutput) : ''} ", 'utf-8')
+                    openIssues.append("| ${issue.fields.summary} ", 'utf-8')
+                    openIssues.append("| ${issue.fields.assignee ? issue.fields.assignee.displayName : 'not assigned'}", 'utf-8')
+                    openIssues.append("| ${issue.fields.timeoriginalestimate} ", 'utf-8')
+                    openIssues.append("| ${issue.fields.status.name} ", 'utf-8')
+                    
+                    rq.customfields.each { field -> 
+                        def foundCustom = issue.fields.find {it.key == field.key}
+                        //logger.quiet("Examining issue '${issue.key}' for custom field '${field.key}' has found: '${foundCustom}'")
+                        openIssues.append("| ${foundCustom ? foundCustom.value : '-'}\n", 'utf-8')
+                    }
+                }
+                openIssues.append("|=== \n")
+            } else {
+                logger.quiet("Set saveAsciidoc=true in '${configFile.name}' to save results in AsciiDoc file")
+            }
         }
     }
 }

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -60,6 +60,7 @@ task exportJiraIssues(
                 'Authorization': "Basic " + config.jira.credentials,
                 'Content-Type' : 'application/json; charset=utf-8'
         ]
+        
         def jiraRequests = config.jira.requests
         
         jiraRequests.each {rq -> 
@@ -77,8 +78,8 @@ task exportJiraIssues(
                 logger.quiet(">> Results will be saved in '${rq.filename}.${extension}' file")
                 
                 def openIssues = new File(targetDir, "${rq.filename}.${extension}")
-        openIssues.write(".Table {Title}\n", 'utf-8')
-        openIssues.append("|=== \n")
+                openIssues.write(".Table {Title}\n", 'utf-8')
+                openIssues.append("|=== \n")
 
                 // AsciiDoc table headers (custom fields map needs values here)
                 openIssues.append("|Key ", 'utf-8')
@@ -87,17 +88,17 @@ task exportJiraIssues(
                 }
                 openIssues.append("\n", 'utf-8')
                 
-        jira.get(path: 'search',
+                jira.get(path: 'search',
                     query: ['jql'       : rq.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel),
-                        'maxResults': 1000,
+                            'maxResults': 1000,
                             fields: "${allFieldIds}"
-                ],
-                headers: headers
-        ).data.issues.each { issue ->
+                    ],
+                    headers: headers
+                ).data.issues.each { issue ->
                     //logger.quiet(">> Whole issue ${issue.key}:\n   ${issue.fields}")
                     openIssues.append("| ${jiraRoot}/browse/${issue.key}[${issue.key}] ", 'utf-8')
-            openIssues.append("| ${issue.fields.priority.name} ", 'utf-8')
-            openIssues.append("| ${Date.parse(jiraDateTimeFormatParse, issue.fields.created).format(jiraDateTimeOutput)} ", 'utf-8')
+                    openIssues.append("| ${issue.fields.priority.name} ", 'utf-8')
+                    openIssues.append("| ${Date.parse(jiraDateTimeFormatParse, issue.fields.created).format(jiraDateTimeOutput)} ", 'utf-8')
                     openIssues.append("| ${issue.fields.resolutiondate ? Date.parse(jiraDateTimeFormatParse, issue.fields.resolutiondate).format(jiraDateTimeOutput) : ''} ", 'utf-8')
                     openIssues.append("| ${issue.fields.summary} ", 'utf-8')
                     openIssues.append("| ${issue.fields.assignee ? issue.fields.assignee.displayName : 'not assigned'}", 'utf-8')
@@ -113,6 +114,65 @@ task exportJiraIssues(
                 openIssues.append("|=== \n")
             } else {
                 logger.quiet("Set saveAsciidoc=true in '${configFile.name}' to save results in AsciiDoc file")
+            }
+
+            // Save Excel file
+            if (config.jira.saveExcel) {
+                def extension = 'xlsx'
+                jiraResultsFilename = "${rq.filename}.${extension}"
+                logger.quiet(">> Results will be saved in '${rq.filename}.${extension}' file")
+                
+                def openIssues = new File(targetDir, "${rq.filename}.${extension}")
+
+                def jiraDataXls = new File(targetDir, jiraResultsFilename)
+                def jiraFos = new FileOutputStream(jiraDataXls)
+
+                Workbook wb = new XSSFWorkbook();
+                CreationHelper hyperlinkHelper = wb.getCreationHelper();
+                def sheetName = "${rq.filename}"
+                def ws = wb.createSheet(sheetName)
+
+                def titleRow = ws.createRow(0);
+                int cellNumber = 0;
+                titleRow.createCell(cellNumber).setCellValue("Key")
+                allHeaders.split(",").each {field -> 
+                    titleRow.createCell(++cellNumber).setCellValue("${field}")
+                }
+                def lastRow = titleRow.getRowNum()
+
+                jira.get(path: 'search',
+                    query: ['jql'       : rq.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel),
+                            'maxResults': 1000,
+                            fields: "${allFieldIds}"
+                    ],
+                    headers: headers
+                ).data.issues.each { issue ->
+                    int cellPosition = 0
+                    def row = ws.createRow(++lastRow)
+                    Hyperlink link = hyperlinkHelper.createHyperlink(HyperlinkType.URL)
+                    link.setAddress("${jiraRoot}/browse/${issue.key}")
+                    Cell cellWithUrl = row.createCell(cellPosition)
+                    cellWithUrl.setCellValue("${issue.key}")
+                    cellWithUrl.setHyperlink(link)
+
+                    row.createCell(++cellPosition).setCellValue("${issue.fields.priority.name}")
+                    row.createCell(++cellPosition).setCellValue("${Date.parse(jiraDateTimeFormatParse, issue.fields.created).format(jiraDateTimeOutput)}")
+                    row.createCell(++cellPosition).setCellValue("${issue.fields.resolutiondate ? Date.parse(jiraDateTimeFormatParse, issue.fields.resolutiondate).format(jiraDateTimeOutput) : ''}")
+                    row.createCell(++cellPosition).setCellValue("${issue.fields.summary}")
+                    row.createCell(++cellPosition).setCellValue("${issue.fields.assignee ? issue.fields.assignee.displayName : ''}")
+                    row.createCell(++cellPosition).setCellValue("${issue.fields.timeoriginalestimate} ")
+                    row.createCell(++cellPosition).setCellValue("${issue.fields.status.name}")
+
+                    // Custom fields
+                    rq.customfields.each { field -> 
+                        def position = ++cellPosition
+                        def foundCustom = issue.fields.find {it.key == field.key}
+                        row.createCell(position).setCellValue("${foundCustom ? foundCustom.value : '-'}")
+                    }
+                }
+                wb.write(jiraFos)
+            } else {
+                logger.quiet("Set saveExcel=true in '${configFile.name}' to save results in Excel file")
             }
         }
     }

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -80,7 +80,7 @@ task exportJiraIssues(
             if (config.jira.saveAsciidoc) {
                 def extension = 'adoc'
                 jiraResultsFilename = "${rq.filename}.${extension}"
-                logger.quiet(">> Results will be saved in '${rq.filename}.${extension}' file")
+                logger.info("Results will be saved in '${rq.filename}.${extension}' file")
                 
                 def openIssues = new File(targetDir, "${rq.filename}.${extension}")
                 openIssues.write(".Table {Title}\n", 'utf-8')

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -8,8 +8,14 @@ buildscript {
     dependencies {
         //for the exportJiraIssues Task
         classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
+        classpath 'org.apache.poi:poi-ooxml:4.1.1'
     }
 }
+
+import org.apache.poi.ss.usermodel.*
+import org.apache.poi.xssf.usermodel.*
+import org.apache.poi.ss.util.*
+import org.apache.poi.common.usermodel.*
 
 //tag::exportJiraIssues[]
 task exportJiraIssues(

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -63,6 +63,11 @@ task exportJiraIssues(
         
         def jiraRequests = config.jira.requests
         
+        if (config.jira.jql) {
+            logger.warn(">>>Found legacy Jira requests. Please migrate to the new Jira configuration ASAP. Old config with jql will be removed soon")
+            writeAsciiDocFileForLegacyConfiguration(jira, headers, config.jira)
+        }
+        
         jiraRequests.each {rq -> 
             logger.quiet("Request to Jira API for '${rq.filename}' with query: '${rq.jql}'")
 
@@ -176,5 +181,32 @@ task exportJiraIssues(
             }
         }
     }
+}
+
+// This method can be removed when support for legacy Jira configuration is gone
+def writeAsciiDocFileForLegacyConfiguration(def restClient, def headers, def jiraConfig) {
+    def resultsFilename = "${jiraConfig.resultsFilename}_legacy.adoc"
+    
+    def openIssues = new File(targetDir, "${resultsFilename}")
+    openIssues.write(".Table {Title}\n", 'utf-8')
+    openIssues.append("|=== \n")
+    openIssues.append("|Key |Priority |Created | Assignee | Summary\n", 'utf-8')
+        def legacyJql = jiraConfig.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel)
+        println ("Results will for legacy query ${legacyJql} will be saved in '${resultsFilename}' file")
+        
+        restClient.get(path: 'search',
+                query: ['jql'       : jiraConfig.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel),
+                        'maxResults': 1000,
+                        'fields'    : 'created,resolutiondate,priority,summary,timeoriginalestimate, assignee'
+                ],
+                headers: headers
+      ).data.issues.each { issue ->
+        openIssues.append("| ${jiraRoot}/browse/${issue.key}[${issue.key}] ", 'utf-8')
+        openIssues.append("| ${issue.fields.priority.name} ", 'utf-8')
+        openIssues.append("| ${Date.parse(jiraConfig.dateTimeFormatParse, issue.fields.created).format(jiraConfig.dateTimeFormatOutput)} ", 'utf-8')
+        openIssues.append("| ${issue.fields.assignee ? issue.fields.assignee.displayName : 'not assigned'}", 'utf-8')
+        openIssues.append("| ${issue.fields.summary} ", 'utf-8')
+    }
+    openIssues.append("|=== \n")
 }
 //end::exportJiraIssues[]

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -165,6 +165,7 @@ htmlSanityCheck.with {
     //sourceDir = "build/html5/site"
     //checkingResultsDir =
 }
+//end::htmlSanityCheckConfig[]
 
 //tag::jiraConfig[]
 // Configuration for Jira related tasks
@@ -197,10 +198,36 @@ jira.with {
     // the label to restrict search to
     label = 
 
-    // Jira query
-    jql = "project='%jiraProject%' AND labels='%jiraLabel%' ORDER BY priority DESC, duedate ASC"
+    // Base filename in which Jira query results should be stored
+    resultsFilename = 'JiraTicketsContent'
+
+    saveAsciidoc = true // if true, asciidoc file will be created with *.adoc extension
+    saveExcel = true // if true, Excel file will be created with *.xlsx extension
+
+    /* 
+    List of requests to Jira API:
+    These are basically JQL expressions bundled with a filename in which results will be saved.
+    User can configure custom fields IDs and name those for column header,
+    i.e. customfield_10026:'Story Points' for Jira instance that has custom field with that name and will be saved in a coloumn named "Story Points"
+    */
+    requests = [
+        new JiraRequest(
+            filename:"File1_Done_issues",
+            jql:"project='%jiraProject%' AND status='Done' ORDER BY duedate ASC",
+            customfields: [customfield_10026:'Story Points']
+        ),
+        new JiraRequest(
+            filename:'CurrentSprint',
+            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC", 
+            customfields: [customfield_10026:'Story Points']
+        ),
+    ]    
+}
     
-    // Filename in which Jira query results should be stored
-    resultsFilename = 'JiraTicketsContent.adoc'
+@groovy.transform.Immutable
+class JiraRequest {
+    String filename  //filename (without extension) of the file in which JQL results will be saved. Extension will be determined automatically for Asciidoc or Excel file
+    String jql // Jira Query Language syntax 
+    Map<String,String> customfields // map of customFieldId:displayName values for Jira fields which don't have default names, i.e. customfield_10026:StoryPoints
 }
 //end::jiraConfig[]

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -198,6 +198,9 @@ jira.with {
     // the label to restrict search to
     label = 
 
+    // Legacy settings for Jira query. This setting is deprecated & support for it will soon be completely removed. Please use JiraRequests settings
+    jql = "project='%jiraProject%' AND labels='%jiraLabel%' ORDER BY priority DESC, duedate ASC"
+
     // Base filename in which Jira query results should be stored
     resultsFilename = 'JiraTicketsContent'
 


### PR DESCRIPTION
PR regarding https://github.com/docToolchain/docToolchain/issues/454

- Support for multiple Jira queries
- Basic support for custom fields in Jira results
- Saving to Excel files

### All Submissions:

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/manual`.
To "publish" it, execute `./gradlew exportContributors && ./gradlew && ./copyDocs.sh`.
This will convert the `.adoc` file to HTML and copy them to the right folder so that github pages will pick them up.

If you didn't find the time to update docs, please create an issue as reminder to do so.

### Change to Documentation:

* [x] Did you build the docs and copy them to the `/docs` folder?
* [x] If not, did you create an issue for doing so?

inspiration: https://github.com/stevemao/github-issue-templates
