### PR TITLE
Feature/confluence page id from page name

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -56,6 +56,9 @@ confluence = [:]
 // Attributes
 // - 'file': absolute or relative path to the asciidoc generated html file to be exported
 // - 'url': absolute URL to an asciidoc generated html file to be exported
+// - 'ancestorName' (optional): the name of the parent page in Confluence as string;
+//                             this attribute has priority over ancestorId, but if page with given name doesn't exist,
+//                             ancestorId will be used as a fallback 
 // - 'ancestorId' (optional): the id of the parent page in Confluence as string; leave this empty
 //                            if a new parent shall be created in the space
 // - 'preambleTitle' (optional): the title of the page containing the preamble (everything

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -742,6 +742,27 @@ def promoteHeaders = { tree, start, offset ->
     }
 }
 
+def retrievePageIdByName = { String name ->
+        def api = new RESTClient(config.confluence.api)
+        def headers = [
+            'Authorization': 'Basic ' + config.confluence.credentials,
+            'Content-Type':'application/json; charset=utf-8'
+        ]
+        trythis {
+            def request = [
+                'title'    : name,
+                'spaceKey' : confluenceSpaceKey
+            ]
+            api.get(
+                [
+                        'headers': headers,
+                        'path'   : "${baseApiPath}content",
+                        'query'  : request,
+                ]
+            ).data.results?.getAt(0)?.id
+        } ?: null
+}
+
 config.confluence.input.each { input ->
 
     input.file = "${docDir}/${input.file}"

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -804,6 +804,8 @@ config.confluence.input.each { input ->
 
     // if parentId is still not set, create a new parent page (parentId = null)
     parentId = parentId ?: null
+    //println("ancestorName: '${input.ancestorName}', ancestorId: ${input.ancestorId} ---> final parentId: ${parentId}")
+
     def anchors = [:]
     def pageAnchors = [:]
     def sections = pages = []

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -791,8 +791,17 @@ config.confluence.input.each { input ->
     dom.outputSettings().escapeMode(org.jsoup.nodes.Entities.EscapeMode.xhtml); //This will ensure xhtml validity regarding entities
     dom.outputSettings().charset("UTF-8"); //does no harm :-)
 
-    //if input does not contain an ancestorId, check if there is a global one
-    def parentId = input.ancestorId ?: config.confluence.ancestorId
+    // if ancestorName is defined try to find machingAncestorId in confluence
+    def retrievedAncestorId
+    if (input.ancestorName) {
+        // Retrieve a page id by name
+        retrievedAncestorId = retrievePageIdByName(input.ancestorName)
+        println("Retrieved pageId for given ancestorName '${input.ancestorName}' is ${retrievedAncestorId}")
+    }
+
+    // if input does not contain an ancestorName, check if there is ancestorId, otherwise check if there is a global one
+    def parentId = retrievedAncestorId ?: input.ancestorId ?: config.confluence.ancestorId
+
     // if parentId is still not set, create a new parent page (parentId = null)
     parentId = parentId ?: null
     def anchors = [:]

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -65,6 +65,9 @@ confluence = [:]
 // Attributes
 // - 'file': absolute or relative path to the asciidoc generated html file to be exported
 // - 'url': absolute URL to an asciidoc generated html file to be exported
+// - 'ancestorName' (optional): the name of the parent page in Confluence as string;
+//                             this attribute has priority over ancestorId, but if page with given name doesn't exist,
+//                             ancestorId will be used as a fallback 
 // - 'ancestorId' (optional): the id of the parent page in Confluence as string; leave this empty
 //                            if a new parent shall be created in the space
 // - 'preambleTitle' (optional): the title of the page containing the preamble (everything


### PR DESCRIPTION
This PR resolves [ticket 460](https://github.com/docToolchain/docToolchain/issues/460) and adds `ancestorName` attribute to the confluence section of `Config.groovy` configuration file as well as respective implementation that takes advantage of new attribute 

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?
