### PR TITLE
Feature/folder per jira task

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -201,6 +201,9 @@ jira.with {
     saveAsciidoc = true // if true, asciidoc file will be created with *.adoc extension
     saveExcel = true // if true, Excel file will be created with *.xlsx extension
 
+    // Output folder for this task inside main outputPath
+    resultsFolder = 'JiraRequests'
+    
     /* 
     List of requests to Jira API:
     These are basically JQL expressions bundled with a filename in which results will be saved.
@@ -256,6 +259,9 @@ sprintChangelog.with {
     showTicketStatus = false
     showTicketType = true
     sprintBoardId = 12345  // Jira instance probably have multiple boards; here it can be defined which board should be used
+
+    // Output folder for this task inside main outputPath
+    resultsFolder = 'Sprints'
 
     // if sprintName is not defined or sprint with that name isn't found, release notes will be created on for all sprints that match sprint state configuration
     sprintName = 'PRJ Sprint 1' // if sprint with a given sprintName is found, release notes will be created just for that sprint

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -9,6 +9,9 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === Added
 
+2020-09-07::
+* Ability to export Jira Sprint(s) data changelog (key, summary) (https://github.com/docToolchain/docToolchain/pull/473[#473])
+
 2020-08-24::
 * Ability to export OpenAPI specification to asciidoc (https://github.com/docToolchain/docToolchain/issues/464[#464])
 

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -27,9 +27,10 @@ task exportJiraIssues(
         def configFile = new File(docDir, mainConfigFile)
         def config = new ConfigSlurper().parse(configFile.text)
 
-        final String taskSubfolderName = "JiraRequests"
+        final String taskSubfolderName = config.jira.resultsFolder
         final File targetFolder = new File(targetDir + File.separator + taskSubfolderName)
         if (!targetFolder.exists()) targetFolder.mkdirs()
+        logger.debug("Output folder for 'exportJiraIssues' task is: '${targetFolder}'")
 
         if(config.jira.credentials.isEmpty()){
             logger.quiet("No JIRA credentials are set in '${configFile.name}'")

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -27,7 +27,8 @@ task exportJiraIssues(
         def configFile = new File(docDir, mainConfigFile)
         def config = new ConfigSlurper().parse(configFile.text)
 
-        final File targetFolder = new File(targetDir)
+        final String taskSubfolderName = "JiraRequests"
+        final File targetFolder = new File(targetDir + File.separator + taskSubfolderName)
         if (!targetFolder.exists()) targetFolder.mkdirs()
 
         if(config.jira.credentials.isEmpty()){
@@ -69,7 +70,7 @@ task exportJiraIssues(
         
         if (config.jira.jql) {
             logger.warn(">>>Found legacy Jira requests. Please migrate to the new Jira configuration ASAP. Old config with jql will be removed soon")
-            writeAsciiDocFileForLegacyConfiguration(jira, headers, config.jira)
+            writeAsciiDocFileForLegacyConfiguration(targetFolder, jira, headers, config.jira)
         }
         
         jiraRequests.each {rq -> 
@@ -86,16 +87,16 @@ task exportJiraIssues(
                 jiraResultsFilename = "${rq.filename}.${extension}"
                 logger.info("Results will be saved in '${rq.filename}.${extension}' file")
                 
-                def openIssues = new File(targetDir, "${rq.filename}.${extension}")
-                openIssues.write(".${rq.filename}\n", 'utf-8')
-                openIssues.append("|=== \n")
+                def jiraDataAsciidoc = new File(targetFolder, "${rq.filename}.${extension}")
+                jiraDataAsciidoc.write(".${rq.filename}\n", 'utf-8')
+                jiraDataAsciidoc.append("|=== \n")
 
                 // AsciiDoc table headers (custom fields map needs values here)
-                openIssues.append("|Key ", 'utf-8')
+                jiraDataAsciidoc.append("|Key ", 'utf-8')
                 allHeaders.split(",").each {field -> 
-                    openIssues.append("|${field.capitalize()} ", 'utf-8')
+                    jiraDataAsciidoc.append("|${field.capitalize()} ", 'utf-8')
                 }
-                openIssues.append("\n", 'utf-8')
+                jiraDataAsciidoc.append("\n", 'utf-8')
                 
                 jira.get(path: 'search',
                     query: ['jql'       : rq.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel),
@@ -105,21 +106,21 @@ task exportJiraIssues(
                     headers: headers
                 ).data.issues.each { issue ->
                     //logger.quiet(">> Whole issue ${issue.key}:\n   ${issue.fields}")
-                    openIssues.append("| ${jiraRoot}/browse/${issue.key}[${issue.key}] ", 'utf-8')
-                    openIssues.append("| ${issue.fields.priority.name} ", 'utf-8')
-                    openIssues.append("| ${Date.parse(jiraDateTimeFormatParse, issue.fields.created).format(jiraDateTimeOutput)} ", 'utf-8')
-                    openIssues.append("| ${issue.fields.resolutiondate ? Date.parse(jiraDateTimeFormatParse, issue.fields.resolutiondate).format(jiraDateTimeOutput) : ''} ", 'utf-8')
-                    openIssues.append("| ${issue.fields.summary} ", 'utf-8')
-                    openIssues.append("| ${issue.fields.assignee ? issue.fields.assignee.displayName : 'not assigned'}", 'utf-8')
-                    openIssues.append("| ${issue.fields.status.name} ", 'utf-8')
+                    jiraDataAsciidoc.append("| ${jiraRoot}/browse/${issue.key}[${issue.key}] ", 'utf-8')
+                    jiraDataAsciidoc.append("| ${issue.fields.priority.name} ", 'utf-8')
+                    jiraDataAsciidoc.append("| ${Date.parse(jiraDateTimeFormatParse, issue.fields.created).format(jiraDateTimeOutput)} ", 'utf-8')
+                    jiraDataAsciidoc.append("| ${issue.fields.resolutiondate ? Date.parse(jiraDateTimeFormatParse, issue.fields.resolutiondate).format(jiraDateTimeOutput) : ''} ", 'utf-8')
+                    jiraDataAsciidoc.append("| ${issue.fields.summary} ", 'utf-8')
+                    jiraDataAsciidoc.append("| ${issue.fields.assignee ? issue.fields.assignee.displayName : 'not assigned'}", 'utf-8')
+                    jiraDataAsciidoc.append("| ${issue.fields.status.name} ", 'utf-8')
                     
                     rq.customfields.each { field -> 
                         def foundCustom = issue.fields.find {it.key == field.key}
                         //logger.quiet("Examining issue '${issue.key}' for custom field '${field.key}' has found: '${foundCustom}'")
-                        openIssues.append("| ${foundCustom ? foundCustom.value : '-'}\n", 'utf-8')
+                        jiraDataAsciidoc.append("| ${foundCustom ? foundCustom.value : '-'}\n", 'utf-8')
                     }
                 }
-                openIssues.append("|=== \n")
+                jiraDataAsciidoc.append("|=== \n")
             } else {
                 logger.quiet("Set saveAsciidoc=true in '${configFile.name}' to save results in AsciiDoc file")
             }
@@ -130,9 +131,9 @@ task exportJiraIssues(
                 jiraResultsFilename = "${rq.filename}.${extension}"
                 logger.quiet(">> Results will be saved in '${rq.filename}.${extension}' file")
                 
-                def openIssues = new File(targetDir, "${rq.filename}.${extension}")
+                //def jiraDataAsciidoc = new File(targetFolder, "${rq.filename}.${extension}")
 
-                def jiraDataXls = new File(targetDir, jiraResultsFilename)
+                def jiraDataXls = new File(targetFolder, jiraResultsFilename)
                 def jiraFos = new FileOutputStream(jiraDataXls)
 
                 Workbook wb = new XSSFWorkbook();
@@ -204,10 +205,10 @@ task exportJiraIssues(
 }
 
 // This method can be removed when support for legacy Jira configuration is gone
-def writeAsciiDocFileForLegacyConfiguration(def restClient, def headers, def jiraConfig) {
+def writeAsciiDocFileForLegacyConfiguration(def targetFolder, def restClient, def headers, def jiraConfig) {
     def resultsFilename = "${jiraConfig.resultsFilename}_legacy.adoc"
     
-    def openIssues = new File(targetDir, "${resultsFilename}")
+    def openIssues = new File(targetFolder, "${resultsFilename}")
     openIssues.write(".Table {Title}\n", 'utf-8')
     openIssues.append("|=== \n")
     openIssues.append("|Key |Priority |Created | Assignee | Summary\n", 'utf-8')

--- a/scripts/exportJiraSprintChangelog.gradle
+++ b/scripts/exportJiraSprintChangelog.gradle
@@ -50,9 +50,10 @@ task exportJiraSprintChangelog(
         }
 
         // preparing target folder for generated files
-        final String taskSubfolderName = "Sprints"
+        final String taskSubfolderName = config.sprintChangelog.resultsFolder
         final File targetFolder = new File(targetDir + File.separator + taskSubfolderName)
         if (!targetFolder.exists()) targetFolder.mkdirs()
+        logger.debug("Output folder for 'exportJiraSprintChangelog' task is: '${targetFolder}'")
 
         // Checking Jira credentials
         if(config.jira.credentials.isEmpty()){

--- a/scripts/exportJiraSprintChangelog.gradle
+++ b/scripts/exportJiraSprintChangelog.gradle
@@ -26,6 +26,8 @@ task exportJiraSprintChangelog(
     doLast {
         def configFile = new File(docDir, mainConfigFile)
         def config = new ConfigSlurper().parse(configFile.text)
+
+        // Pre defined ticket fields for Changelog based on Jira Sprints
         def defaultTicketFields = 'summary,status,assignee,issuetype'
 
         // retrieving sprints for a given board
@@ -48,7 +50,8 @@ task exportJiraSprintChangelog(
         }
 
         // preparing target folder for generated files
-        final File targetFolder = new File(targetDir)
+        final String taskSubfolderName = "Sprints"
+        final File targetFolder = new File(targetDir + File.separator + taskSubfolderName)
         if (!targetFolder.exists()) targetFolder.mkdirs()
 
         // Checking Jira credentials
@@ -102,7 +105,7 @@ task exportJiraSprintChangelog(
         def allChangelogsFilename = "${allSprintsFilename}.xlsx"
         logger.quiet("Changelogs of all sprints will be saved in '${allChangelogsFilename}' file")
         
-        def changelogsXls = new File(targetDir, allChangelogsFilename)
+        def changelogsXls = new File(targetFolder, allChangelogsFilename)
         def changelogsXlsFos = new FileOutputStream(changelogsXls)
         Workbook wb = new XSSFWorkbook();
         CreationHelper hyperlinkHelper = wb.getCreationHelper();
@@ -155,7 +158,7 @@ task exportJiraSprintChangelog(
             def asciidocFilename = "${sprint.name.replaceAll(" ", "_")}.adoc"
             logger.info("Results will be saved in '${asciidocFilename}' file")
             
-            def changeLogAdoc = new File(targetDir, "${asciidocFilename}")
+            def changeLogAdoc = new File(targetFolder, "${asciidocFilename}")
             changeLogAdoc.write(".Table ${sprint.name} Changelog\n", 'utf-8')
             changeLogAdoc.append("|=== \n")
 

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -1,5 +1,3 @@
-
-
 outputPath = 'build'
 
 // Path where the docToolchain will search for the input files.
@@ -210,6 +208,9 @@ jira.with {
     saveAsciidoc = true // if true, asciidoc file will be created with *.adoc extension
     saveExcel = true // if true, Excel file will be created with *.xlsx extension
 
+    // Output folder for this task inside main outputPath
+    resultsFolder = 'JiraRequests'
+
     /* 
     List of requests to Jira API:
     These are basically JQL expressions bundled with a filename in which results will be saved.
@@ -265,6 +266,9 @@ sprintChangelog.with {
     showTicketStatus = false
     showTicketType = true
     sprintBoardId = 12345  // Jira instance probably have multiple boards; here it can be defined which board should be used
+
+    // Output folder for this task inside main outputPath
+    resultsFolder = 'Sprints'
 
     // if sprintName is not defined or sprint with that name isn't found, release notes will be created on for all sprints that match sprint state configuration
     sprintName = 'PRJ Sprint 1' // if sprint with a given sprintName is found, release notes will be created just for that sprint


### PR DESCRIPTION
This PR adds convenience configuration to separate results of `exportJiraSprintChangelog` & `exportJiraIssues` tasks, which can be useful in cases there are several result files

In addition PR updates project changelog