### PR TITLE
Feature/credentials params

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -98,13 +98,16 @@ confluence.with {
 
     pageSuffix = ''
 
-    // username:password of an account which has the right permissions to create and edit
-    // confluence pages in the given space.
-    // if you want to store it securely, fetch it from some external storage or leave it empty to fallback to gradle variables
-    // set through gradle properties files or environment variables. The fallback uses the 'confluenceUser' and 'confluencePassword' keys.
-    // you might even want to prompt the user for the password like in this example
+    /*
+    WARNING: It is strongly recommended to store credentials securely instead of commiting plain text values to your git repository!!!
 
-    credentials = "user:pass_or_token".bytes.encodeBase64().toString()
+    Tool expects credentials that belong to an account which has the right permissions to to create and edit confluence pages in the given space.
+    Credentials can be used in a form of:
+     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or  
+     - gradle variables set through gradle properties (uses the 'confluenceUser' and 'confluencePass' keys)
+    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as 
+    -Pusername=myUser -Ppassword=myPassword
+    */
 
     //optional API-token to be added in case the credentials are needed for user and password exchange.
     //apikey = "[API-token]"
@@ -171,15 +174,16 @@ jira.with {
     api = 'https://your-jira-instance'
     
     /*
-    username:password (username:token) of an account which has the right permissions to read the JIRA issues for a given project.
-    It is recommended to store these securely instead of commiting them to your git repository.
-    In that case, either fetch it from some external storage or leave it empty (credentials = '') to fallback to gradle variables set through gradle properties files or environment variables.
-    The fallback in gradle.properties uses the 'jiraUser' and 'jiraPassword' keys.
-    You might even want to prompt the user for the password (by not providing it anywhere)
+    WARNING: It is strongly recommended to store credentials securely instead of commiting plain text values to your git repository!!!
+
+    Tool expects credentials that belong to an account which has the right permissions to read the JIRA issues for a given project.
+    Credentials can be used in a form of:
+     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or  
+     - gradle variables set through gradle properties (uses the 'jiraUser' and 'jiraPass' keys)
+    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as 
+    -Pusername=myUser -Ppassword=myPassword
     */
 
-    credentials = "username@domain.com:accesstoken".bytes.encodeBase64().toString() // colon ":" is used as a separation of username from password/token before base64 encoding 
-    
     // the key of the Jira project
     project = 'PROJECTKEY'
     

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx2048m
 // Aim for keeping Jira configuration in Config.groovy file. 
 // That way whole configuration is kept at one location and it is possible to pass complete configuration from outside docToolchain container
 jiraRoot = 'https://jira-instance'
-jiraUser = 'username'
+jiraUser = ''
 jiraPass = '' // leave empty to get a prompt
 jiraProject = '' // the key of the project
 jiraDateTimeFormatParse = 'yyyy-MM-dd'T'H:m:s.Sz' // the format to parse the received date time values

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,8 @@ includeRoot = .
 
 // Path to the main configuration file, relative to docDir.
 mainConfigFile = Config.groovy
+// Placeholder for global configuration variable which will be set during runtime with the content of Config.groovy  
+config = ''
 
 // Path to the configuration file of exportChangelog task, relative to docDir.
 changelogConfigFile = scripts/ChangelogConfig.groovy

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -43,12 +43,14 @@ if (project.hasProperty('username') && project.hasProperty('password')) {
     config.jira.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString() 
     config.confluence.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString() 
 }
+
 inputPath = config.inputPath?config.inputPath:'.'
-logger.info "docToolchain> inputPath: ${inputPath}"
-logger.info "docToolchain> inputFiles: ${config.inputFiles}"
-logger.info "docToolchain> outputPath: ${config.outputPath}"
 referenceDocFile = config.referenceDocFile?config.referenceDocFile:''
 logger.info "docToolchain> referenceDocFile: ${referenceDocFile}"
+logger.info("\n==================\nParsed config file has ${config.size()} entries\n")
+config.each {key, value -> 
+    logger.info("Found config -> '${key}': '${value}'")
+}
 
 ext {
     srcDir  = "${docDir}/${inputPath}"

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -26,6 +26,23 @@ logger.info "docToolchain> mainConfigFile: ${mainConfigFile}"
 logger.info "docToolchain> pdfThemeDir: ${pdfThemeDir}"
 def configSlurper = new ConfigSlurper()
 config = configSlurper.parse(new File(docDir, mainConfigFile).text)
+
+def props = project.gradle.startParameter.projectProperties
+logger.info("\nGradle project Properties [${props.size()}]:\n==============================")
+
+if (project.hasProperty('jiraUser') && project.hasProperty('jiraPass')) {
+    logger.info("Found passed Jira credentials")
+    config.jira.credentials = "${project.getProperty('jiraUser')}:${project.getProperty('jiraPass')}".bytes.encodeBase64().toString() 
+}
+if (project.hasProperty('confluenceUser') && project.hasProperty('confluencePass')) {
+    logger.info("Found passed Confluence credentials")
+    config.confluence.credentials = "${project.getProperty('confluenceUser')}:${project.getProperty('confluencePass')}".bytes.encodeBase64().toString() 
+}
+if (project.hasProperty('username') && project.hasProperty('password')) {
+    logger.info("Found passed common Jira & Confluence credentials")
+    config.jira.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString() 
+    config.confluence.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString() 
+}
 inputPath = config.inputPath?config.inputPath:'.'
 logger.info "docToolchain> inputPath: ${inputPath}"
 logger.info "docToolchain> inputFiles: ${config.inputFiles}"

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -15,7 +15,6 @@ buildscript {
 import org.asciidoctor.gradle.AsciidoctorTask
 
 // configuration
-def config
 if (docDir.startsWith('.')) {
     docDir = new File(projectDir, docDir).canonicalPath
 }

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -28,7 +28,7 @@ def configSlurper = new ConfigSlurper()
 config = configSlurper.parse(new File(docDir, mainConfigFile).text)
 
 def props = project.gradle.startParameter.projectProperties
-logger.info("\nGradle project Properties [${props.size()}]:\n==============================")
+logger.info("\nGradle project Properties [${props.size()}]:\n${props}\n==============================")
 
 if (project.hasProperty('jiraUser') && project.hasProperty('jiraPass')) {
     logger.info("Found passed Jira credentials")

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -83,7 +83,7 @@ def trythis(Closure action) {
         switch (error.response.status) {
             case '401':
                 println (error.response.data.toString().replaceAll("^.*Reason","Reason"))
-                println "please check your confluence credentials in "+configFile.canonicalPath
+                println "please check your confluence credentials in config file or passed parameters"
                 throw new Exception("missing authentication credentials")
                 break
             default:
@@ -380,7 +380,7 @@ def rewriteJiraLinks = { body ->
     // find links to jira tickets and replace them with jira macros
     body.select('a[href]').each { a ->
         def href = a.attr('href')
-        if (href.startsWith(jiraRoot + "/browse/")) { 
+        if (href.startsWith(config.jira.api + "/browse/")) { 
                 def ticketId = a.text()
                 a.before("""<ac:structured-macro ac:name=\"jira\" ac:schema-version=\"1\">
                      <ac:parameter ac:name=\"key\">${ticketId}</ac:parameter>

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -24,40 +24,18 @@ task exportJiraIssues(
         group: 'docToolchain'
 ) {
     doLast {
-        def configFile = new File(docDir, mainConfigFile)
-        def config = new ConfigSlurper().parse(configFile.text)
-
         final String taskSubfolderName = config.jira.resultsFolder
         final File targetFolder = new File(targetDir + File.separator + taskSubfolderName)
         if (!targetFolder.exists()) targetFolder.mkdirs()
         logger.debug("Output folder for 'exportJiraIssues' task is: '${targetFolder}'")
 
-        if(config.jira.credentials.isEmpty()){
-            logger.quiet("No JIRA credentials are set in '${configFile.name}'")
-            logger.quiet("Trying 'jiraUser' and 'jiraPassword' from gradle properties")
-
-            if(project.hasProperty("jiraUser") && project.hasProperty("jiraPass")){
-                if (!jiraPass) {
-                    // FIXME Currently doesn't work with Gradle daemon. See: https://github.com/gradle/gradle/issues/1251
-                     jiraPass = System.console().readPassword("Jira password for user '$jiraUser': ")
-                }
-                config.jira.credentials = "${jiraUser}:${jiraPass}".bytes.encodeBase64().toString()
-            }else{
-                logger.quiet("Variables 'jiraUser' and/or 'jiraPassword' are not set!")
-                logger.quiet("Please specify them with other Jira properties through Config.groovy, or even better via the CLI or environment variables")
-            }
-
-        } else {
-            logger.quiet("Found JIRA credentials in '${configFile.name}'. Consider passing these via environment variables")
-        }
-
         // map configuration from Config.groovy to existing variables for compatibility with naming of Jira settings in gradle.properties
-        jiraRoot = config.jira.api
-        jiraProject = config.jira.project
-        jiraLabel = config.jira.label
-        jiraResultsFilename = config.jira.resultsFilename
-        jiraDateTimeFormatParse = config.jira.dateTimeFormatParse
-        jiraDateTimeOutput = config.jira.dateTimeFormatOutput
+        def jiraRoot = config.jira.api
+        def jiraProject = config.jira.project
+        def jiraLabel = config.jira.label
+        def jiraResultsFilename = config.jira.resultsFilename
+        def jiraDateTimeFormatParse = config.jira.dateTimeFormatParse
+        def jiraDateTimeOutput = config.jira.dateTimeFormatOutput
         def defaultFields = 'priority,created,resolutiondate,summary,assignee,status'
 
         def jira = new groovyx.net.http.RESTClient(jiraRoot + '/rest/api/2/')
@@ -213,10 +191,11 @@ def writeAsciiDocFileForLegacyConfiguration(def targetFolder, def restClient, de
     openIssues.write(".Table {Title}\n", 'utf-8')
     openIssues.append("|=== \n")
     openIssues.append("|Key |Priority |Created | Assignee | Summary\n", 'utf-8')
+        def legacyJql = jiraConfig.jql.replaceAll('%jiraProject%', config.jira.project).replaceAll('%jiraLabel%', config.jira.label)
         println ("Results for legacy query '${legacyJql}' will be saved in '${resultsFilename}' file")
         
         restClient.get(path: 'search',
-                query: ['jql'       : jiraConfig.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel),
+                query: ['jql'       : legacyJql,
                         'maxResults': 1000,
                         'fields'    : 'created,resolutiondate,priority,summary,timeoriginalestimate, assignee'
                 ],

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -213,8 +213,7 @@ def writeAsciiDocFileForLegacyConfiguration(def targetFolder, def restClient, de
     openIssues.write(".Table {Title}\n", 'utf-8')
     openIssues.append("|=== \n")
     openIssues.append("|Key |Priority |Created | Assignee | Summary\n", 'utf-8')
-        def legacyJql = jiraConfig.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel)
-        println ("Results will for legacy query ${legacyJql} will be saved in '${resultsFilename}' file")
+        println ("Results for legacy query '${legacyJql}' will be saved in '${resultsFilename}' file")
         
         restClient.get(path: 'search',
                 query: ['jql'       : jiraConfig.jql.replaceAll('%jiraProject%', jiraProject).replaceAll('%jiraLabel%', jiraLabel),

--- a/scripts/exportJiraSprintChangelog.gradle
+++ b/scripts/exportJiraSprintChangelog.gradle
@@ -24,9 +24,6 @@ task exportJiraSprintChangelog(
         group: 'docToolchain'
 ) {
     doLast {
-        def configFile = new File(docDir, mainConfigFile)
-        def config = new ConfigSlurper().parse(configFile.text)
-
         // Pre defined ticket fields for Changelog based on Jira Sprints
         def defaultTicketFields = 'summary,status,assignee,issuetype'
 
@@ -55,29 +52,9 @@ task exportJiraSprintChangelog(
         if (!targetFolder.exists()) targetFolder.mkdirs()
         logger.debug("Output folder for 'exportJiraSprintChangelog' task is: '${targetFolder}'")
 
-        // Checking Jira credentials
-        if(config.jira.credentials.isEmpty()){
-            logger.debug("No JIRA credentials are set in '${configFile.name}'")
-            logger.debug("Trying 'jiraUser' and 'jiraPassword' from gradle properties")
-
-            if(project.hasProperty("jiraUser") && project.hasProperty("jiraPass")){
-                if (!jiraPass) {
-                    // FIXME Currently doesn't work with Gradle daemon. See: https://github.com/gradle/gradle/issues/1251
-                     jiraPass = System.console().readPassword("Jira password for user '$jiraUser': ")
-                }
-                config.jira.credentials = "${jiraUser}:${jiraPass}".bytes.encodeBase64().toString()
-            }else{
-                logger.debug("Variables 'jiraUser' and/or 'jiraPassword' are not set!")
-                logger.debug("Please specify them with other Jira properties through Config.groovy, or even better via the CLI or environment variables")
-            }
-
-        } else {
-            logger.quiet("Found JIRA credentials in '${configFile.name}'. Consider passing these via environment variables")
-        }
-
         // Getting configuration
-        jiraRoot = config.jira.api
-        jiraProject = config.jira.project
+        def jiraRoot = config.jira.api
+        def jiraProject = config.jira.project
         
         def sprintState = config.sprintChangelog.sprintState
         def ticketStatusForReleaseNotes = config.sprintChangelog.ticketStatus

--- a/scripts/exportOpenApi.gradle
+++ b/scripts/exportOpenApi.gradle
@@ -11,7 +11,6 @@ buildscript {
 }
 apply plugin: 'org.openapi.generator'
 
-def config = new ConfigSlurper().parse(new File(docDir, mainConfigFile).text)
 def specFile = config.openApi.specFile
 
 //tag::exportOpenApi[]

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -22,20 +22,6 @@ task publishToConfluence(
     doLast {
         logger.info("docToolchain> docDir: "+docDir)
         def configFile = new File(docDir, mainConfigFile)
-        def config = new ConfigSlurper().parse(configFile.text)
-
-        if(config.confluence.credentials.isEmpty()){
-            logger.quiet("no credentials set in '${configFile.name}'")
-            logger.quiet("trying 'confluenceUser' and 'confluencePassword' from gradle properties")
-
-            if(project.hasProperty("confluenceUser") && project.hasProperty("confluencePassword")){
-                config.confluence.credentials = "${confluenceUser}:${confluencePassword}".bytes.encodeBase64().toString()
-            }else{
-                logger.quiet("variables 'confluenceUser' and/or 'confluencePassword' are not set!")
-                logger.quiet("please specify them through gradle.properties, the commandline or environment variables")
-            }
-
-        }
 
         binding.setProperty('config',config)
         binding.setProperty('docDir',docDir)

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -21,12 +21,9 @@ task publishToConfluence(
 ) {
     doLast {
         logger.info("docToolchain> docDir: "+docDir)
-        def configFile = new File(docDir, mainConfigFile)
 
         binding.setProperty('config',config)
         binding.setProperty('docDir',docDir)
-        binding.setProperty('configFile', configFile)
-        binding.setProperty('jiraRoot', jiraRoot)
         evaluate(new File(projectDir, 'scripts/asciidoc2confluence.groovy'))
     }
 }

--- a/src/docs/manual/03_task_publishToConfluence.adoc
+++ b/src/docs/manual/03_task_publishToConfluence.adoc
@@ -174,5 +174,5 @@ include::../../../scripts/publishToConfluence.gradle[tags=publishToConfluence]
 .scripts/asciidoc2confluence.groovy
 [source,groovy]
 ----
-include::../../../scripts/asciidoc2confluence.groovy[]
+include::../../../scripts/asciidoc2confluence.groovy[tags=publishToConfluence]
 ----

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -105,13 +105,16 @@ confluence.with {
 
     pageSuffix = ''
 
-    // username:password of an account which has the right permissions to create and edit
-    // confluence pages in the given space.
-    // if you want to store it securely, fetch it from some external storage or leave it empty to fallback to gradle variables
-    // set through gradle properties files or environment variables. The fallback uses the 'confluenceUser' and 'confluencePassword' keys.
-    // you might even want to prompt the user for the password like in this example
+    /*
+    WARNING: It is strongly recommended to store credentials securely instead of commiting plain text values to your git repository!!!
 
-    credentials = "user:pass_or_token".bytes.encodeBase64().toString()
+    Tool expects credentials that belong to an account which has the right permissions to to create and edit confluence pages in the given space.
+    Credentials can be used in a form of:
+     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or  
+     - gradle variables set through gradle properties (uses the 'confluenceUser' and 'confluencePass' keys)
+    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as 
+    -Pusername=myUser -Ppassword=myPassword
+    */
 
     //optional API-token to be added in case the credentials are needed for user and password exchange.
     //apikey = "[API-token]"
@@ -178,15 +181,16 @@ jira.with {
     api = 'https://your-jira-instance'
     
     /*
-    username:password (username:token) of an account which has the right permissions to read the JIRA issues for a given project.
-    It is recommended to store these securely instead of commiting them to your git repository.
-    In that case, either fetch it from some external storage or leave it empty (credentials = '') to fallback to gradle variables set through gradle properties files or environment variables.
-    The fallback in gradle.properties uses the 'jiraUser' and 'jiraPassword' keys.
-    You might even want to prompt the user for the password (by not providing it anywhere)
+    WARNING: It is strongly recommended to store credentials securely instead of commiting plain text values to your git repository!!!
+
+    Tool expects credentials that belong to an account which has the right permissions to read the JIRA issues for a given project.
+    Credentials can be used in a form of:
+     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or  
+     - gradle variables set through gradle properties (uses the 'jiraUser' and 'jiraPass' keys)
+    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as 
+    -Pusername=myUser -Ppassword=myPassword
     */
 
-    credentials = "username@domain.com:accesstoken".bytes.encodeBase64().toString() // colon ":" is used as a separation of username from password/token before base64 encoding 
-    
     // the key of the Jira project
     project = 'PROJECTKEY'
     


### PR DESCRIPTION
This PR takes care of **secrets in configuration files** and offers users clean possibility to pass credentials as parameters to specific docToolchain commands.

For example, to pass Confluence credentials use:
`./doctoolchain ../ publishToConfluence -PconfluenceUser=admin -PconfluencePass=secretPassword42` 

or, to pass Jira credentials:
`./doctoolchain ../ exportJiraIssues -PjiraUser=admin -PjiraPass=jiraPassword`

As often in production environment credentials for Jira & Confluence are the same, users could take advantage of the highest priority `username` & `password` parameters, which can be used for both endpoints.

After this PR, docToolchain can be safely used in CI/CD with for example Jenkins secrets without risk that credentials will be exposed in project/documentation/cofinguration repository

Parsing Config.groovy now indeed happens just once, so we could safely remove copy pasted code which parsed configuration in few different files. 

 
p.s. Documentation needs to be updated ASAP with separate ticket #477 