### PR TITLE
enable TravisCI to publish the docs to the website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,13 @@ jdk:
   - openjdk12
   - openjdk13
 
+git:
+  depth: false
+
 addons:
   apt:
     packages:
       - shellcheck
-
-git:
-  depth: 3000
-
-addons:
-  apt:
-    packages:
       - graphviz
 
 before_cache:
@@ -27,6 +23,13 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
+install: skip
+
 script:
   - ./.ci.sh
   - find . -type f -exec grep -l '^#!/bin/bash' {} + | xargs shellcheck
+
+env:
+  global:
+    # use `travis env set GH_TOKEN XXX` to set token to publish contents to GitHub pages
+    secure: XsGE9f9tLzIdqzKVCf6HyULznWPgw2k3Ghve+TAACsmSu1N1CpuNUdjfMS/9IdDncoP+AWV2aYZUAKImE/WyBvvXrgy8n3VpcCe13efU3fEXRkPQNBIZZOL1+/P7jeVTjX4cTe2ptemtJ2d4oFBcslJAX/c4D5HSu2/GMAfhe74=

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,10 @@
 
 == docToolchain
 
+:url-ci-travis: https://travis-ci.org/doctoolchain/doctoolchain
+
+image:https://api.travis-ci.org/doctoolchain/doctoolchain.svg?branch=master[link={url-ci-travis}]
+
 image::https://hacktoberfest.digitalocean.com/assets/HF-full-logo-b05d5eb32b3f3ecc9b2240526104cf4da3187b8b61963dd9042fdc2536e4a76c.svg[float=left,width=200]
 
 *This project joined https://hacktoberfest.digitalocean.com/[Hacktoberfest]!
@@ -86,7 +90,7 @@ image::https://opencollective.com/doctoolchain/sponsor/0/avatar.svg["Sponsor", l
 === History of this project
 
 I just found an older https://twitter.com/RalfDMueller/status/668540860649349120[tweet] which reminded me of the roots and beginning of this project.
-It all began with two important parts. 
+It all began with two important parts.
 A script called asciidoc2confluence and some scripts to export diagrams from enterprise architect.
 
 The first one is linked in the tweet above and the first commit dates back to mid of 2015.

--- a/build.gradle
+++ b/build.gradle
@@ -75,4 +75,4 @@ apply from: 'scripts/exportOpenApi.gradle'
 
 // let's set a defaultTask for convenience
 //defaultTasks 'exportChangeLog','exportJiraIssues','asciidoctor'
-defaultTasks 'exportChangeLog', 'exportContributors', 'exportMarkdown', 'generateHTML', 'htmlSanityCheck'
+defaultTasks 'exportMarkdown', 'exportChangeLog', 'exportContributors', 'generateHTML', 'htmlSanityCheck'

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -32,23 +32,23 @@ logger.info("\nGradle project Properties [${props.size()}]:\n${props}\n=========
 
 if (project.hasProperty('jiraUser') && project.hasProperty('jiraPass')) {
     logger.info("Found passed Jira credentials")
-    config.jira.credentials = "${project.getProperty('jiraUser')}:${project.getProperty('jiraPass')}".bytes.encodeBase64().toString() 
+    config.jira.credentials = "${project.getProperty('jiraUser')}:${project.getProperty('jiraPass')}".bytes.encodeBase64().toString()
 }
 if (project.hasProperty('confluenceUser') && project.hasProperty('confluencePass')) {
     logger.info("Found passed Confluence credentials")
-    config.confluence.credentials = "${project.getProperty('confluenceUser')}:${project.getProperty('confluencePass')}".bytes.encodeBase64().toString() 
+    config.confluence.credentials = "${project.getProperty('confluenceUser')}:${project.getProperty('confluencePass')}".bytes.encodeBase64().toString()
 }
 if (project.hasProperty('username') && project.hasProperty('password')) {
     logger.info("Found passed common Jira & Confluence credentials")
-    config.jira.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString() 
-    config.confluence.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString() 
+    config.jira.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString()
+    config.confluence.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString()
 }
 
 inputPath = config.inputPath?config.inputPath:'.'
 referenceDocFile = config.referenceDocFile?config.referenceDocFile:''
 logger.info "docToolchain> referenceDocFile: ${referenceDocFile}"
 logger.info("\n==================\nParsed config file has ${config.size()} entries\n")
-config.each {key, value -> 
+config.each {key, value ->
     logger.info("Found config -> '${key}': '${value}'")
 }
 
@@ -143,6 +143,10 @@ task generateHTML (
             'html' in it.formats
         }.empty
     }
+
+    // specify output folder explicitly to avoid cleaning targetDir from other generated content
+    outputDir = file(targetDir + '/html5/')
+    separateOutputDirs(false)
 
     sources {
         sourceFiles.findAll {

--- a/scripts/exportContributors.gradle
+++ b/scripts/exportContributors.gradle
@@ -6,10 +6,6 @@ task exportContributors(
         description: 'exports all contributors for all asciidoc files',
         group: 'docToolchain'
 ) {
-    doFirst {
-        new File(targetDir, 'contributors').mkdirs()
-        new File(targetDir, 'fileattribs').mkdirs()
-    }
     doLast {
         def wordsPerMinute = 189
         def md5 = { input ->
@@ -38,22 +34,22 @@ task exportContributors(
                                 }
                 }.unique { a, b -> a[1] <=> b[1] }
                 def avatars = contributors.collect {
-                    "image:http://www.gravatar.com/avatar/" +
+                    "image:https://www.gravatar.com/avatar/" +
                             md5(it[1].toLowerCase().trim()) +
                             "?d=identicon" +
-                            "[32,32,role='gravatar',alt='${it[0]}',title='${it[0]}']"
+                            "[height=32,width=32,role='gravatar',alt='${it[0]}',title='${it[0]}']"
                 }.join(" ")
                 def tag = (file.canonicalPath - sourceFolder.canonicalPath).replace("\\", "/").replaceAll("^/", "")
-                def targetFile = new File(targetDir, "/contributors/" + tag)
-                new File(targetDir, ("/contributors/" + tag).split("/")[0..-2].join("/")).mkdirs()
+                File targetFile = new File(targetDir.toString(), "/contributors/" + tag)
+                safeMkDirs(targetFile)
                 targetFile.write(avatars + "\n")
 //              println("\u023F1 $readingtime minutes to read")
                 def minutesTerm = readingtime == 1 ? "minute" : "minutes"
                 targetFile.append("\n $readingtime $minutesTerm to read \n")
 
                 //file attributes
-                new File(targetDir, ("/fileattribs/" + tag).split("/")[0..-2].join("/")).mkdirs()
-                targetFile = new File(targetDir, "/fileattribs/" + tag)
+                targetFile = new File(targetDir.toString(), "/fileattribs/" + tag)
+                safeMkDirs(targetFile)
 
                 def attributes = ["git", "log", "-1", "--no-merges", "--pretty=format:%x7c%x20%at%n%x7c%x20%ad%x20%n%x7c%x20%aE%n%x7c%x20%an%x20%n%x7c%x20%s%x20%n", "--date=short", "HEAD", currentFileName].execute()
                 attributes.waitForOrKill(1000)
@@ -90,6 +86,15 @@ def getReadingtime(def filename, def wpm) {
                     .split("\\s+");
 
     return (words.length / wpm).toInteger() +1
+}
+
+void safeMkDirs(File file) {
+    File fileDir = file.getParentFile();
+    if (!fileDir.exists()) {
+        if (!fileDir.mkdirs()) {
+            throw new RuntimeException("unable to create folder '" + fileDir + '')
+        }
+    }
 }
 
 //end::exportContributors[]


### PR DESCRIPTION
This PR leaves all existing documentation in place. It adds to the build process the feature to publish the master content automatically to the GitHub pages. This will avoid errors like this currently present on the public site: 

![image](https://user-images.githubusercontent.com/3957921/95651081-e293eb00-0ae7-11eb-900e-9ae73b0b73dd.png)

fixes #260 (although not moving to Netlify, but keeping Travis and GitHub pages)

This worked fine on my test repository; some with access to the the docToolchain repo would need to update the .travisci.yml to make this work and add a GitHub token. As this is an organization, it would probably be best to have a CI-User in the organization who's access is limited to the organization.

maybe fixes #465 as well (the part "problem that the result of exportContributors gets deleted afterwards"):

This fixes the problem that on travis CI the contributors where never included in the final site; it complained by logging "manual/feedback.adoc: line 6: include file not found: /home/travis/build/docToolchain/docToolchain/build/docs/contributors/manual/01_introduction_and_goals.adoc"
I suppose the `separateOutputDirs(false)` finally did the trick - the contributors were only deleted on TraviCI, never on my local (Windows) setup. Strange... 
