### PR TITLE
Add new exportEA feature to export project glossary filtered & sorted

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -135,11 +135,19 @@ confluence.with {
 //Configuration for the export script 'exportEA.vbs'.
 // The following parameters can be used to change the default behaviour of 'exportEA'.
 // All parameter are optionally.
-// Parameter 'connection' allows to select a certain database connection by using the ConnectionString as used for
-// directly connecting to the project database instead of looking for EAP/EAPX files inside and below the 'src' folder.
-// Parameter 'packageFilter' is an array of package GUID's to be used for export. All images inside and in all packages below the package represented by its GUID are exported.
-// A packageGUID, that is not found in the currently opened project, is silently skipped.
-// PackageGUID of multiple project files can be mixed in case multiple projects have to be opened.
+// -  connection: Parameter allows to select a certain database connection by 
+//    using the ConnectionString as used for directly connecting to the project
+//    database instead of looking for EAP/EAPX files inside and below the 'src' folder.
+// - 'packageFilter' is an array of package GUID's to be used for export. All 
+//    images inside and in all packages below the package represented by its GUID 
+//    are exported. A packageGUID, that is not found in the currently opened
+//    project, is silently skipped. PackageGUID of multiple project files can
+//    be mixed in case multiple projects have to be opened.
+// -  exportPath: relative path to base 'docDir' to which the diagrams and notes are to be exported
+// -  searchPath: relative path to base 'docDir', in which Enterprise Architect project files are searched
+// -  glossaryAsciiDocFormat: if set, the EA glossary is exported into exportPath as 'glossary.ad'
+// -  glossaryTypes: if set and glossary is exported, used to filter for certain types.
+//    Not set or empty list will cause no filtered glossary.
 
 exportEA.with {
 // OPTIONAL: Set the connection to a certain project or comment it out to use all project files inside the src folder or its child folder.
@@ -149,11 +157,14 @@ exportEA.with {
 //                    "{A237ECDE-5419-4d47-AECC-B836999E7AE0}",
 //                    "{B73FA2FB-267D-4bcd-3D37-5014AD8806D6}"
 //                  ]
-// OPTIONAL: relative path to base 'docDir' to which the diagrams and notes are to be exported
+// OPTIONAL: export diagrams, notes, etc. below folder src/docs
 // exportPath = "src/docs/"
-// OPTIONAL: relative path to base 'docDir', in which Enterprise Architect project files are searched
-// searchPath = "src/docs/"
-
+// OPTIONAL: EA project files are expected to be located in folder src/projects  
+// searchPath = "src/projects/"
+// OPTIONAL: terms will be exported as asciidoc 'Description, single-line'
+// glossaryAsciiDocFormat = "TERM:: MEANING"
+// OPTIONAL: only terms of type Business and Technical will be exported.
+// glossaryTypes = ["Business", "Technical"]
 }
 //end::exportEAConfig[]
 

--- a/scripts/exportEA.gradle
+++ b/scripts/exportEA.gradle
@@ -1,3 +1,88 @@
+import org.json.*;
+import groovy.json.JsonSlurper
+
+
+//The GlossaryHandler reads all files from a given folder path url.
+//It expects the files are JSON formatted glossary exports from EA. 
+//There is one single glossary file per EA project expected.
+//All entries not being part of the glossaryTypes list will be removed from the glossaries.
+//If the glossaryTypes list is empty, all entries will be used.
+//Each glossary is sorted by terms in alphabetical order.
+//Using the outputFormat the json formatted file is overwritten with 
+//the sorted and filtered list to be included in asciidoc files.
+//An additional file is written to the folder containing the entries of all
+//single glossaries in an alphabetical sorted order. 
+//This global glossary is stored as glossary.ad.
+class GlossaryHandler 
+{
+    private List<List<Object>> globalGlossaryList = []
+    
+    //Collect all files inside the glossary folder (jsonFilePath)
+    //Each file is processed individually,
+    //finally a merged glossary of all single glossaries is written
+    void execute(jsonFilePath, outputFormat, glossaryTypes) {
+        def count = 0
+        def glossaryFile
+        new File(jsonFilePath).eachFileRecurse { file ->
+            if (file.isFile()) {
+                glossaryFile = file.canonicalPath
+                reformatJsonFile(glossaryFile, outputFormat, glossaryTypes)
+                count = count+1
+            }
+        }  
+        if (!globalGlossaryList.isEmpty()) {
+            if (count == 1) { 
+                //use the already sorted and stored file, but rename it
+                new File(glossaryFile).renameTo(new File(jsonFilePath+"/glossary.ad"))
+            }
+            else {
+                //sort and store the global glossary (summary of all single glossaries)
+                sortAndWriteToFile(jsonFilePath+"/glossary.ad", globalGlossaryList, outputFormat)
+            }
+        }        
+    }
+    
+    //Reads the json file if available, other terminates silently.
+    //the glossary list read is filtered by the glossaryTypes list and 
+    //sorted by term in alphabetical order.
+    //The resulting glossary list is handed over to a 
+    //file handler to be sorted and written to file system
+    void reformatJsonFile(jsonFilePath, outputFormat, glossaryTypes) {
+        if (new File(jsonFilePath).isFile()) {
+            def jsonSlurper = new JsonSlurper()
+            def glossaryList = jsonSlurper.parse(new File(jsonFilePath))
+            if (glossaryTypes && !glossaryTypes.isEmpty()) {
+                glossaryList.retainAll { glossaryTypes.contains(it['type']) }
+            }
+            globalGlossaryList.addAll(glossaryList)
+            sortAndWriteToFile(jsonFilePath, glossaryList, outputFormat)
+        }
+    }
+    
+    //Sorts the given glossaryList in alphabetical order and calls the output formatter
+    //to create the new output format and write the file.
+    void sortAndWriteToFile(jsonFilePath, glossaryList, outputFormat) {
+        glossaryList.sort{a, b -> a['term'].compareTo(b['term'])}
+        writeFormattedGlossaryToFile(jsonFilePath, glossaryList, outputFormat)
+    }
+    
+    //Filehandler to write a glossary list to a new file.
+    //An output format is used to format each glossary entry in a certain output format.
+    //Following placeholder are defined: ID, TERM, MEANING, TYPE. One or many of these placeholder can 
+    //be used by the output format. A valid output format: "TERM:: MEANING" to include the glossary
+    //as a flat list. Other formats can be used to include it as a table row.
+    void writeFormattedGlossaryToFile(jsonFilePath, glossaryList, outputFormat) {
+        new File(jsonFilePath).withWriter('utf-8') { writer ->
+            glossaryList.each { key ->
+                def out = outputFormat.replace("ID" , key['termID'])
+                out = out.replace("TERM" , key['term'])
+                out = out.replace("MEANING" , key['meaning'])
+                out = out.replace("TYPE" , key['type'])
+                writer.writeLine(out)
+            }
+        }
+    }
+}
 
 //tag::streamingExecute[]
 task streamingExecute(
@@ -53,6 +138,7 @@ task exportEA(
         def scriptParameterString = ""
         def exportPath = ""
         def searchPath = ""
+        def glossaryPath = ""
         def readme = """This folder contains exported diagrams or notes from Enterprise Architect.
 
 Please note that these are generated files but reside in the `src`-folder in order to be versioned.
@@ -92,7 +178,16 @@ use `gradle exportEA` to re-export files
         scriptParameterString = scriptParameterString + " -d \"$exportPath\""
         scriptParameterString = scriptParameterString + " -s \"$searchPath\""
         logger.info("docToolchain > exportEA: exportPath: "+exportPath)
-
+        
+        //remove old glossary files/folder if exist
+        new File(exportPath , 'glossary').deleteDir()
+        //set the glossary file path in case an output format is configured, other no glossary is written
+        if (!config.exportEA.glossaryAsciiDocFormat.isEmpty()) {
+            //create folder to store glossaries
+            new File(exportPath , 'glossary/.').mkdirs()
+            glossaryPath = new File(exportPath , 'glossary').getAbsolutePath()
+            scriptParameterString = scriptParameterString + " -g \"$glossaryPath\""
+        }
         //make sure path for notes exists
         //and remove old notes
         new File(exportPath , 'ea').deleteDir()
@@ -114,6 +209,16 @@ use `gradle exportEA` to re-export files
                 println "exported notes " + file.canonicalPath
                 file.write(file.getText('iso-8859-1'), 'utf-8')
             }
+        }
+        
+        //sort, filter and reformat a glossary if an output format is configured
+        if (!config.exportEA.glossaryAsciiDocFormat.isEmpty()) {
+            def glossaryTypes
+
+            if (!config.exportEA.glossaryTypes.isEmpty()){
+                glossaryTypes = config.exportEA.glossaryTypes as List
+            }
+            new GlossaryHandler().execute(glossaryPath, config.exportEA.glossaryAsciiDocFormat, glossaryTypes);
         }
     }
 }

--- a/src/docs/manual/03_task_exportEA.adoc
+++ b/src/docs/manual/03_task_exportEA.adoc
@@ -14,7 +14,7 @@ TIP: Blog-Posts: https://rdmueller.github.io/jria2eac/[JIRA to Sparx EA], https:
 == Configuration
 By default no special configuration is necessary.
 But, to be more specific on the project and its packages to be used for export,
-four optional parameter configurations are available.
+six optional parameter configurations are available.
 The parameters can be used independently from each other.
 A sample how to edit your projects Config.groovy is given in the 'Config.groovy'
 of the docToolchain project itself.
@@ -38,6 +38,39 @@ Default: "src/docs".
 Example: docDir = 'D:\work\mydoc\' ; exportPath = 'src/projects' ;
 Lookup for eap and eapx files starts in 'D:\work\mydoc\src\projects' and goes down the folder structure.
 *Note*: In case connection is already defined, the searchPath value is ignored.
+
+glossaryAsciiDocFormat::
+Depending on this configuration option, the EA project glossary is exported.
+If it is not set or an empty string, no glossary is exported.
+The glossaryAsciiDocFormat string is used to format each glossary entry in a
+certain asciidoc format.
+Following placeholder for the format string are defined: ID, TERM, MEANING, TYPE.
+One or many of these placeholder can be used by the output format.
+
+Example: A valid output format to include the glossary as a flat list.
+The file can be included where needed in the documentation.
+....
+glossaryAsciiDocFormat = "TERM:: MEANING"
+....
+Other format strings can be used to include it as a table row.
+The glossary is sorted by terms in alphabetical order.
+
+glossaryTypes::
+This parameter is used in case a glossaryAsciiDocFormat is defined, otherwise it
+is not evaluated. It is used to filter for certain types. If the glossaryTypes
+list is empty, all entries will be used.
+Example: glossaryTypes = ["Business", "Technical"]
+
+== Glossary export
+By setting the glossaryAsciiDocFormat the glossary terms stored in the EA project
+is exported into a folder named 'glossary' below the configured exportPath.
+In case multiple EA projects were found for export, one glossary per project is
+exported. Each named with the projects GUID plus extension '.ad'.
+Each single file will be filtered (see glossaryTypes) and sorted in alphabetical order.
+In addition, a global glossary is created by using all single glossary files.
+This global file is named 'glossary.ad' and is also placed in the glossary folder.
+The global glossary is also filtered and sorted.
+In case there is one EA project only, the global glossary is written only.
 
 == Source
 


### PR DESCRIPTION
This pull request refers to issue #490

It is a new feature of the exportEA script.
It enables the exportEA script to run an export of the EnterpriseArchitect project glossary.
The output format can be configured to be according to asciidoc notation.
The types of elements used to generate the exported asciidoc formatted is configurable.
A new glossary subfolder will be added to the exportPath.
Multiple glossary files will be generated in case of multiple project files are found.
One global glossary file is generated by merging all single glossary files.
The generated  files can be used as part of the resulting documentation depending in individual format of the user.

Documentation is added and reformatted manual of exportEA.
