### PR TITLE
Lower loglevel from error to info in case openAPI spec is not set

### DIFF
--- a/scripts/exportOpenApi.gradle
+++ b/scripts/exportOpenApi.gradle
@@ -20,7 +20,7 @@ task exportOpenApi (
         description: 'exports OpenAPI specification to the asciidoc file') {
         
     if (!specFile) {
-        logger.error("\n---> OpenAPI specification file not found in Config.groovy (https://doctoolchain.github.io/docToolchain/#_exportopenapi)")
+        logger.info("\n---> OpenAPI specification file not found in Config.groovy (https://doctoolchain.github.io/docToolchain/#_exportopenapi)")
         return
     } else { 
         logger.info("Found OpenAPI specification in Config.groovy")


### PR DESCRIPTION
### This request fixes the minor issue #493.
It avoid unnecessary error logs in case an export specific configuration is not set.
Instead an info log level is set to at least show the log in case calling exportOpenAPI with --info.


### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?

### New Feature Submissions:

1. [ ] Did you create new tests for your submission?
2. [ ] Does your submission pass all tests? (see travis check)

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
