### PR TITLE
Add new feature to export attributes of a EA diagram as a separate file

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -148,6 +148,7 @@ confluence.with {
 // -  glossaryAsciiDocFormat: if set, the EA glossary is exported into exportPath as 'glossary.ad'
 // -  glossaryTypes: if set and glossary is exported, used to filter for certain types.
 //    Not set or empty list will cause no filtered glossary.
+// -  diagramAttributes: if set, the diagram attributes are exported and formatted as specified
 
 exportEA.with {
 // OPTIONAL: Set the connection to a certain project or comment it out to use all project files inside the src folder or its child folder.
@@ -165,6 +166,8 @@ exportEA.with {
 // glossaryAsciiDocFormat = "TERM:: MEANING"
 // OPTIONAL: only terms of type Business and Technical will be exported.
 // glossaryTypes = ["Business", "Technical"]
+// OPTIONAL: Additional files will be exported containing diagram attributes in the given asciidoc format
+// diagramAttributes = "Modified: %DIAGRAM_AUTHOR%, %DIAGRAM_MODIFIED%, %DIAGRAM_NAME%, %DIAGRAM_GUID%, %DIAGRAM_CREATED%"
 }
 //end::exportEAConfig[]
 

--- a/scripts/exportEA.gradle
+++ b/scripts/exportEA.gradle
@@ -188,6 +188,10 @@ use `gradle exportEA` to re-export files
             glossaryPath = new File(exportPath , 'glossary').getAbsolutePath()
             scriptParameterString = scriptParameterString + " -g \"$glossaryPath\""
         }
+        //configure additional diagram attributes to be exported
+        if (!config.exportEA.diagramAttributes.isEmpty()) {
+            scriptParameterString = scriptParameterString + " -da \"$config.exportEA.diagramAttributes\""
+        }
         //make sure path for notes exists
         //and remove old notes
         new File(exportPath , 'ea').deleteDir()

--- a/src/docs/manual/03_task_exportEA.adoc
+++ b/src/docs/manual/03_task_exportEA.adoc
@@ -61,6 +61,18 @@ is not evaluated. It is used to filter for certain types. If the glossaryTypes
 list is empty, all entries will be used.
 Example: glossaryTypes = ["Business", "Technical"]
 
+diagramAttributes::
+Beside the diagram image, an EA diagram offers several useful attributes which 
+could be required in the resulting document. If set, the string is used to create
+and store the diagram attributes to be included in the document.
+These placeholders are defined and filled with the diagram attributes if used in the 
+diagramAttributes string: %DIAGRAM_AUTHOR%, %DIAGRAM_CREATED%, %DIAGRAM_GUID%, %DIAGRAM_MODIFIED%, %DIAGRAM_NAME%.
+Example: diagramAttributes = "Last modification: %DIAGRAM_MODIFIED%"
+The resulting text is stored beside the diagram image using same path and file named,
+but different file extension (.ad). This can included in the document if required.
+If diagramAttributes is not set or string is empty, no file is written.
+
+
 == Glossary export
 By setting the glossaryAsciiDocFormat the glossary terms stored in the EA project
 is exported into a folder named 'glossary' below the configured exportPath.


### PR DESCRIPTION
This PR fulfills the new feature request #497 
It enables the export of some diagram attributes as part of the script exportEA. 
If the new configuration parameter is not set, the previous behaviour is left unchanged.
Following attribute placeholders are supported with this PR:
%DIAGRAM_AUTHOR%, %DIAGRAM_CREATED%, %DIAGRAM_GUID%, %DIAGRAM_MODIFIED%, %DIAGRAM_NAME%.
and filled with information read from EA project.
The diagramAttributes string can make use of none, one, many or all of this placeholders to format a resulting text block being included in the documentation.

### All Submissions:

* [X] Does your PR affect the documentation? 
** yes, as a new configuration update
* [X] If yes, did you update the documentation or create an issue for updating it?
** exportEA manual updated



