### PR TITLE
added saveguard to not print secrets to the console

### DIFF
--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -47,9 +47,17 @@ if (project.hasProperty('username') && project.hasProperty('password')) {
 inputPath = config.inputPath?config.inputPath:'.'
 referenceDocFile = config.referenceDocFile?config.referenceDocFile:''
 logger.info "docToolchain> referenceDocFile: ${referenceDocFile}"
-logger.info("\n==================\nParsed config file has ${config.size()} entries\n")
-config.each {key, value ->
-    logger.info("Found config -> '${key}': '${value}'")
+logger.info("\n==================\nParsed config file has ${config.flatten().size()} entries\n")
+
+List<String> confidentialIdentifiers = ["credential", "token", "secret"]
+config.flatten().each {key, value ->
+    String keyString = "${key}"
+
+    if(confidentialIdentifiers.any {id -> keyString.toLowerCase().contains(id)}){
+        logger.info("Found config -> '${keyString}': '********'")
+    }else{
+        logger.info("Found config -> '${keyString}': '${value}'")
+    }
 }
 
 ext {


### PR DESCRIPTION
### History
As discussed previously by mail a change introduced in PR #476 print **all** config keys **and their values** to the console when running with `--info`. This includes the Confluence and Jira Creds (Username + Password Base64-encoded). 
Through these changes secrets can appear in build logs unexpectedly.

### Remedy
Instead of reverting the change to the config printing (i think it's usefull for debugging), this PR introduces a blacklist of config key name fragments. If a key that is to be printed contains any of the defined fragments, '********' ist printed instead of the config's value. 

### Details's and Considerations
This solution providing a middleground between not printing the config and exposing secrets. Though should it be merged adds a blacklist, that needs to be kept up to date when new secrets are added to the config. Currently the following fragments in the config value name (`config.<NAME_1>.<NAME_2>`)result in redacted output: `credential, token, secret, passw, pwd`. It is possible to define fragments in the form of `some.name-suffix`.

Feedback and comments are greatly appreciated.

### All Submissions:
* [ ] Does your PR affect the documentation? -> No