### PR TITLE
Add the export of notes found on an EA diagram itself.

### DIFF
--- a/scripts/exportEAP.vbs
+++ b/scripts/exportEAP.vbs
@@ -183,6 +183,9 @@
         End If
         Repository.CloseDiagram(currentDiagram.DiagramID)
 
+        ' Write the note of the diagram 
+        WriteNote currentModel, currentDiagram, currentDiagram.Notes, diagramName&"_notes"
+        
         For Each diagramElement In currentDiagram.DiagramObjects
             Set currentElement = Repository.GetElementByID(diagramElement.ElementID)
             WriteNote currentModel, currentElement, currentElement.Notes, diagramName&"_notes"


### PR DESCRIPTION
This pull request fixes the issue #450. It adds the export of notes that are found for the diagram itself.
Without it, all notes found on elements used by the diagram are exported only.
As it requires to start the notes on elements with {adoc: to be exported, it is the same for diagram notes.
If the tag is not found at the beginning of a note, the note is not going to be exported.

There was no need to update the documentation of exportEA.

I created this pull request as a representative of AndreaMcls. 
