### PR TITLE
Fix writing of diagram attributes using exportEA

### DIFF
--- a/scripts/exportEAP.vbs
+++ b/scripts/exportEAP.vbs
@@ -10,6 +10,7 @@
     Dim projectInterface 'As EA.Project
     
     Const   ForAppending = 8
+    Const   ForWriting = 2
     
     ' Helper
     ' http://windowsitpro.com/windows/jsi-tip-10441-how-can-vbscript-create-multiple-folders-path-mkdir-command
@@ -143,15 +144,16 @@
     ' easily be included in an asciidoc file.
     Sub SaveDiagramAttribute(currentDiagram, path, diagramName)
         If Len(diagramAttributes) > 0 Then
+            filledDiagAttr = diagramAttributes
             set objFSO = CreateObject("Scripting.FileSystemObject")
             filename = objFSO.BuildPath(path, diagramName & ".ad")
-            set objFile = objFSO.OpenTextFile(filename, ForAppending, True)
-            diagramAttributes = Replace(diagramAttributes, "%DIAGRAM_AUTHOR%", currentDiagram.Author)
-            diagramAttributes = Replace(diagramAttributes, "%DIAGRAM_CREATED%", currentDiagram.CreatedDate)
-            diagramAttributes = Replace(diagramAttributes, "%DIAGRAM_GUID%", currentDiagram.DiagramGUID)                        
-            diagramAttributes = Replace(diagramAttributes, "%DIAGRAM_MODIFIED%", currentDiagram.ModifiedDate)
-            diagramAttributes = Replace(diagramAttributes, "%DIAGRAM_NAME%", currentDiagram.Name)                        
-            objFile.WriteLine(diagramAttributes)
+            set objFile = objFSO.OpenTextFile(filename, ForWriting, True)
+            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_AUTHOR%", currentDiagram.Author)
+            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_CREATED%", currentDiagram.CreatedDate)
+            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_GUID%", currentDiagram.DiagramGUID)                        
+            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_MODIFIED%", currentDiagram.ModifiedDate)
+            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_NAME%", currentDiagram.Name)                        
+            objFile.WriteLine(filledDiagAttr)
             objFile.Close
         End If
     End Sub


### PR DESCRIPTION
This pull request fixes bug #529.

The script exportEA supports export of diagram attributes like author, name and modified date.
Because of a bug in the script, all diagrams gets the same attributes - the attributes of the first read diagram.
Sorry for this. I have to be more careful with merges in future.

Additionally, I introduced the const 'ForWriting'. By this, the files written are newly created and existing content will be removed. Previously used 'ForAppending' is not causing direct errors, but is not the intended functionality. Furthermore, in case same name is used for multiple diagrams, the last exported diagram is available only, but because of appending the attributes to file, the attributes of all diagrams with the same name were added.