### PR TITLE
Add support for another OpenAPI Confluence macro

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -58,7 +58,7 @@ confluence = [:]
 // - 'url': absolute URL to an asciidoc generated html file to be exported
 // - 'ancestorName' (optional): the name of the parent page in Confluence as string;
 //                             this attribute has priority over ancestorId, but if page with given name doesn't exist,
-//                             ancestorId will be used as a fallback
+//                             ancestorId will be used as a fallback 
 // - 'ancestorId' (optional): the id of the parent page in Confluence as string; leave this empty
 //                            if a new parent shall be created in the space
 // - 'preambleTitle' (optional): the title of the page containing the preamble (everything
@@ -103,9 +103,9 @@ confluence.with {
 
     Tool expects credentials that belong to an account which has the right permissions to to create and edit confluence pages in the given space.
     Credentials can be used in a form of:
-     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or
+     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or  
      - gradle variables set through gradle properties (uses the 'confluenceUser' and 'confluencePass' keys)
-    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as
+    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as 
     -Pusername=myUser -Ppassword=myPassword
     */
 
@@ -129,9 +129,9 @@ confluence.with {
     // schema supports http and https
     // proxy = [host: 'my.proxy.com', port: 1234, schema: 'http']
 
-   // Optional: specify which Confluence OpenAPI Macro should be used to render OpenAPI definitions
-   // possible values: ["confluence-open-api", "open-api", true]. true is the same as "confluence-open-api" for backward compatibility
-   // useOpenapiMacro = "confluence-open-api"
+    // Optional: specify which Confluence OpenAPI Macro should be used to render OpenAPI definitions
+    // possible values: ["confluence-open-api", "open-api", true]. true is the same as "confluence-open-api" for backward compatibility
+    // useOpenapiMacro = "confluence-open-api"
 }
 //end::confluenceConfig[]
 //*****************************************************************************************
@@ -139,11 +139,11 @@ confluence.with {
 //Configuration for the export script 'exportEA.vbs'.
 // The following parameters can be used to change the default behaviour of 'exportEA'.
 // All parameter are optionally.
-// -  connection: Parameter allows to select a certain database connection by
+// -  connection: Parameter allows to select a certain database connection by 
 //    using the ConnectionString as used for directly connecting to the project
 //    database instead of looking for EAP/EAPX files inside and below the 'src' folder.
-// - 'packageFilter' is an array of package GUID's to be used for export. All
-//    images inside and in all packages below the package represented by its GUID
+// - 'packageFilter' is an array of package GUID's to be used for export. All 
+//    images inside and in all packages below the package represented by its GUID 
 //    are exported. A packageGUID, that is not found in the currently opened
 //    project, is silently skipped. PackageGUID of multiple project files can
 //    be mixed in case multiple projects have to be opened.
@@ -164,7 +164,7 @@ exportEA.with {
 //                  ]
 // OPTIONAL: export diagrams, notes, etc. below folder src/docs
 // exportPath = "src/docs/"
-// OPTIONAL: EA project files are expected to be located in folder src/projects
+// OPTIONAL: EA project files are expected to be located in folder src/projects  
 // searchPath = "src/projects/"
 // OPTIONAL: terms will be exported as asciidoc 'Description, single-line'
 // glossaryAsciiDocFormat = "TERM:: MEANING"
@@ -204,24 +204,24 @@ jira.with {
 
     // endpoint of the JiraAPI (REST) to be used
     api = 'https://your-jira-instance'
-
+    
     /*
     WARNING: It is strongly recommended to store credentials securely instead of commiting plain text values to your git repository!!!
 
     Tool expects credentials that belong to an account which has the right permissions to read the JIRA issues for a given project.
     Credentials can be used in a form of:
-     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or
+     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or  
      - gradle variables set through gradle properties (uses the 'jiraUser' and 'jiraPass' keys)
-    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as
+    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as 
     -Pusername=myUser -Ppassword=myPassword
     */
 
     // the key of the Jira project
     project = 'PROJECTKEY'
-
+    
     // the format of the received date time values to parse
     dateTimeFormatParse = "yyyy-MM-dd'T'H:m:s.SSSz" // i.e. 2020-07-24'T'9:12:40.999 CEST
-
+    
     // the format in which the date time should be saved to output
     dateTimeFormatOutput = "dd.MM.yyyy HH:mm:ss z" // i.e. 24.07.2020 09:02:40 CEST
 
@@ -239,8 +239,8 @@ jira.with {
 
     // Output folder for this task inside main outputPath
     resultsFolder = 'JiraRequests'
-
-    /*
+    
+    /* 
     List of requests to Jira API:
     These are basically JQL expressions bundled with a filename in which results will be saved.
     User can configure custom fields IDs and name those for column header,
@@ -254,16 +254,16 @@ jira.with {
         ),
         new JiraRequest(
             filename:'CurrentSprint',
-            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC",
+            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC", 
             customfields: [customfield_10026:'Story Points']
         ),
-    ]
+    ]    
 }
-
+    
 @groovy.transform.Immutable
 class JiraRequest {
     String filename  //filename (without extension) of the file in which JQL results will be saved. Extension will be determined automatically for Asciidoc or Excel file
-    String jql // Jira Query Language syntax
+    String jql // Jira Query Language syntax 
     Map<String,String> customfields // map of customFieldId:displayName values for Jira fields which don't have default names, i.e. customfield_10026:StoryPoints
 }
 //end::jiraConfig[]

--- a/Config.groovy
+++ b/Config.groovy
@@ -58,7 +58,7 @@ confluence = [:]
 // - 'url': absolute URL to an asciidoc generated html file to be exported
 // - 'ancestorName' (optional): the name of the parent page in Confluence as string;
 //                             this attribute has priority over ancestorId, but if page with given name doesn't exist,
-//                             ancestorId will be used as a fallback 
+//                             ancestorId will be used as a fallback
 // - 'ancestorId' (optional): the id of the parent page in Confluence as string; leave this empty
 //                            if a new parent shall be created in the space
 // - 'preambleTitle' (optional): the title of the page containing the preamble (everything
@@ -103,9 +103,9 @@ confluence.with {
 
     Tool expects credentials that belong to an account which has the right permissions to to create and edit confluence pages in the given space.
     Credentials can be used in a form of:
-     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or  
+     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or
      - gradle variables set through gradle properties (uses the 'confluenceUser' and 'confluencePass' keys)
-    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as 
+    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as
     -Pusername=myUser -Ppassword=myPassword
     */
 
@@ -128,6 +128,10 @@ confluence.with {
     // Optional proxy configuration, only used to access Confluence
     // schema supports http and https
     // proxy = [host: 'my.proxy.com', port: 1234, schema: 'http']
+
+   // Optional: specify which Confluence OpenAPI Macro should be used to render OpenAPI definitions
+   // possible values: ["confluence-open-api", "open-api", true]. true is the same as "confluence-open-api" for backward compatibility
+   // useOpenapiMacro = "confluence-open-api"
 }
 //end::confluenceConfig[]
 //*****************************************************************************************
@@ -135,11 +139,11 @@ confluence.with {
 //Configuration for the export script 'exportEA.vbs'.
 // The following parameters can be used to change the default behaviour of 'exportEA'.
 // All parameter are optionally.
-// -  connection: Parameter allows to select a certain database connection by 
+// -  connection: Parameter allows to select a certain database connection by
 //    using the ConnectionString as used for directly connecting to the project
 //    database instead of looking for EAP/EAPX files inside and below the 'src' folder.
-// - 'packageFilter' is an array of package GUID's to be used for export. All 
-//    images inside and in all packages below the package represented by its GUID 
+// - 'packageFilter' is an array of package GUID's to be used for export. All
+//    images inside and in all packages below the package represented by its GUID
 //    are exported. A packageGUID, that is not found in the currently opened
 //    project, is silently skipped. PackageGUID of multiple project files can
 //    be mixed in case multiple projects have to be opened.
@@ -160,7 +164,7 @@ exportEA.with {
 //                  ]
 // OPTIONAL: export diagrams, notes, etc. below folder src/docs
 // exportPath = "src/docs/"
-// OPTIONAL: EA project files are expected to be located in folder src/projects  
+// OPTIONAL: EA project files are expected to be located in folder src/projects
 // searchPath = "src/projects/"
 // OPTIONAL: terms will be exported as asciidoc 'Description, single-line'
 // glossaryAsciiDocFormat = "TERM:: MEANING"
@@ -200,24 +204,24 @@ jira.with {
 
     // endpoint of the JiraAPI (REST) to be used
     api = 'https://your-jira-instance'
-    
+
     /*
     WARNING: It is strongly recommended to store credentials securely instead of commiting plain text values to your git repository!!!
 
     Tool expects credentials that belong to an account which has the right permissions to read the JIRA issues for a given project.
     Credentials can be used in a form of:
-     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or  
+     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or
      - gradle variables set through gradle properties (uses the 'jiraUser' and 'jiraPass' keys)
-    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as 
+    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as
     -Pusername=myUser -Ppassword=myPassword
     */
 
     // the key of the Jira project
     project = 'PROJECTKEY'
-    
+
     // the format of the received date time values to parse
     dateTimeFormatParse = "yyyy-MM-dd'T'H:m:s.SSSz" // i.e. 2020-07-24'T'9:12:40.999 CEST
-    
+
     // the format in which the date time should be saved to output
     dateTimeFormatOutput = "dd.MM.yyyy HH:mm:ss z" // i.e. 24.07.2020 09:02:40 CEST
 
@@ -235,8 +239,8 @@ jira.with {
 
     // Output folder for this task inside main outputPath
     resultsFolder = 'JiraRequests'
-    
-    /* 
+
+    /*
     List of requests to Jira API:
     These are basically JQL expressions bundled with a filename in which results will be saved.
     User can configure custom fields IDs and name those for column header,
@@ -250,16 +254,16 @@ jira.with {
         ),
         new JiraRequest(
             filename:'CurrentSprint',
-            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC", 
+            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC",
             customfields: [customfield_10026:'Story Points']
         ),
-    ]    
+    ]
 }
-    
+
 @groovy.transform.Immutable
 class JiraRequest {
     String filename  //filename (without extension) of the file in which JQL results will be saved. Extension will be determined automatically for Asciidoc or Excel file
-    String jql // Jira Query Language syntax 
+    String jql // Jira Query Language syntax
     Map<String,String> customfields // map of customFieldId:displayName values for Jira fields which don't have default names, i.e. customfield_10026:StoryPoints
 }
 //end::jiraConfig[]

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -197,13 +197,13 @@ def uploadAttachment = { def pageId, String url, String fileName, String note ->
         }
     } else {
         http = new HTTPBuilder(config.confluence.api + 'content/' + pageId + '/child/attachment')
-
+        
     }
-    if (http) {
+    if (http) {																												
 		if (config.confluence.proxy) {
             http.setProxy(config.confluence.proxy.host, config.confluence.proxy.port, config.confluence.proxy.schema ?: 'http')
-        }
-
+        } 
+		
         http.request(Method.POST) { req ->
             requestContentType: "multipart/form-data"
             MultipartEntity multiPartContent = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE)
@@ -382,7 +382,7 @@ def rewriteJiraLinks = { body ->
     // find links to jira tickets and replace them with jira macros
     body.select('a[href]').each { a ->
         def href = a.attr('href')
-        if (href.startsWith(config.jira.api + "/browse/")) {
+        if (href.startsWith(config.jira.api + "/browse/")) { 
                 def ticketId = a.text()
                 a.before("""<ac:structured-macro ac:name=\"jira\" ac:schema-version=\"1\">
                      <ac:parameter ac:name=\"key\">${ticketId}</ac:parameter>
@@ -416,7 +416,6 @@ def rewriteCodeblocks = { body ->
             .unwrap()
     }
 }
-
 
 def rewriteOpenAPI = { org.jsoup.nodes.Element body ->
          if (config.confluence.useOpenapiMacro == true || config.confluence.useOpenapiMacro == 'confluence-open-api') {

--- a/src/docs/manual/03_task_publishToConfluence.adoc
+++ b/src/docs/manual/03_task_publishToConfluence.adoc
@@ -59,7 +59,7 @@ apikey::
 In cases where you have to use full user authorization because of internal confluence permission handling, you need to add the API-token in addition to the credentials.
 The API-token cannot be added to the credentials as it is used for user and password exchange.
 Therefore the API-token can be added as parameter apikey, which makes the addition of the token as a separate header field with key: `keyId` and value of `apikey`.
-Example including storing of the real value outside this configuration: `apikey = "${new File("/home/me/apitoken").text}"`.
+Example including storing of the real value outside this configuration: `apikey = "${new File("/home/me/apitoken").text}"`. 
 
 extraPageContent::
 If you need to prefix your pages with a warning that this is generated content - this is the right place.
@@ -70,7 +70,7 @@ If value is set to *true*, your links to local file references will be uploaded 
 In case you enable this feature, and use a folder which starts with "attachment*", an adaption of this prefix is required.
 
 jiraServerId::
-the jira server id your confluence instance is connected to. If value is set, all anchors pointing to a jira ticket will be replaced by the confluence jira macro.
+the jira server id your confluence instance is connected to. If value is set, all anchors pointing to a jira ticket will be replaced by the confluence jira macro. 
 To function properly jiraRoot has to be configured (see <<exportJiraIssues>>).
 
 Example:

--- a/src/docs/manual/03_task_publishToConfluence.adoc
+++ b/src/docs/manual/03_task_publishToConfluence.adoc
@@ -59,7 +59,7 @@ apikey::
 In cases where you have to use full user authorization because of internal confluence permission handling, you need to add the API-token in addition to the credentials.
 The API-token cannot be added to the credentials as it is used for user and password exchange.
 Therefore the API-token can be added as parameter apikey, which makes the addition of the token as a separate header field with key: `keyId` and value of `apikey`.
-Example including storing of the real value outside this configuration: `apikey = "${new File("/home/me/apitoken").text}"`. 
+Example including storing of the real value outside this configuration: `apikey = "${new File("/home/me/apitoken").text}"`.
 
 extraPageContent::
 If you need to prefix your pages with a warning that this is generated content - this is the right place.
@@ -70,7 +70,7 @@ If value is set to *true*, your links to local file references will be uploaded 
 In case you enable this feature, and use a folder which starts with "attachment*", an adaption of this prefix is required.
 
 jiraServerId::
-the jira server id your confluence instance is connected to. If value is set, all anchors pointing to a jira ticket will be replaced by the confluence jira macro. 
+the jira server id your confluence instance is connected to. If value is set, all anchors pointing to a jira ticket will be replaced by the confluence jira macro.
 To function properly jiraRoot has to be configured (see <<exportJiraIssues>>).
 
 Example:
@@ -87,8 +87,9 @@ proxy::
 If you need to provide a proxy to access Confluence, you may set a map with keys `host` (e.g. `'my.proxy.com'`), `port` (e.g. `'1234'`) and `schema` (e.g. `'http'`) of your proxy.
 
 useOpenapiMacro::
-If this option is present and equal to `true`, then any source block marked with class openapi will be wrapped in a swagger-editor macro.
-(see https://marketplace.atlassian.com/apps/1218914/open-api-swagger-editor-for-confluence[Elitesoft Swagger Editor], based on swagger-ui) +
+If this option is present and equal to "confluence-open-api" then any source block marked with class openapi will be wrapped in Elitesoft Swagger Editor macro:  (see https://marketplace.atlassian.com/apps/1218914/open-api-swagger-editor-for-confluence[Elitesoft Swagger Editor]) +
+For backward compatibility: If this option is present and equal to `true`, then again the Elitesoft Swagger Editor macro will be used. +
+If this option is present and equal to "open-api" then any source block marked with class openapi will be wrapped in Open API Documentation for Confluence macro:  (see https://marketplace.atlassian.com/apps/1215176/open-api-documentation-for-confluence[Open API Documentation for Confluence]). A download source (yaml) button is shown by default. +
 This is how you'd include your openapi YAML file: +
 +
 [source,asciidoc]

--- a/src/docs/manual/05_contributors.adoc
+++ b/src/docs/manual/05_contributors.adoc
@@ -54,6 +54,7 @@ Here is an incomplete and unordered list of contributors:
 - https://github.com/dkessel[Daniel Kessel]
 - https://github.com/bjsee[Björn Seebeck]
 - https://twitter.com/Txemanu[Txemanu]
+- https://github.com/silverdonkey[Nikolay Orozov]
 
 (please update your entry to match your preferences! :-)
 

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -65,7 +65,7 @@ confluence = [:]
 // - 'url': absolute URL to an asciidoc generated html file to be exported
 // - 'ancestorName' (optional): the name of the parent page in Confluence as string;
 //                             this attribute has priority over ancestorId, but if page with given name doesn't exist,
-//                             ancestorId will be used as a fallback
+//                             ancestorId will be used as a fallback 
 // - 'ancestorId' (optional): the id of the parent page in Confluence as string; leave this empty
 //                            if a new parent shall be created in the space
 // - 'preambleTitle' (optional): the title of the page containing the preamble (everything
@@ -110,9 +110,9 @@ confluence.with {
 
     Tool expects credentials that belong to an account which has the right permissions to to create and edit confluence pages in the given space.
     Credentials can be used in a form of:
-     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or
+     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or  
      - gradle variables set through gradle properties (uses the 'confluenceUser' and 'confluencePass' keys)
-    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as
+    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as 
     -Pusername=myUser -Ppassword=myPassword
     */
 
@@ -136,10 +136,9 @@ confluence.with {
     // schema supports http and https
     // proxy = [host: 'my.proxy.com', port: 1234, schema: 'http']
 
-   // Optional: specify which Confluence OpenAPI Macro should be used to render OpenAPI definitions
-   // possible values: ["confluence-open-api", "open-api", true]. true is the same as "confluence-open-api" for backward compatibility
-   // useOpenapiMacro = "confluence-open-api"
-
+    // Optional: specify which Confluence OpenAPI Macro should be used to render OpenAPI definitions
+    // possible values: ["confluence-open-api", "open-api", true]. true is the same as "confluence-open-api" for backward compatibility
+    // useOpenapiMacro = "confluence-open-api"
 }
 //end::confluenceConfig[]
 //*****************************************************************************************
@@ -184,29 +183,29 @@ jira.with {
 
     // endpoint of the JiraAPI (REST) to be used
     api = 'https://your-jira-instance'
-
+    
     /*
     WARNING: It is strongly recommended to store credentials securely instead of commiting plain text values to your git repository!!!
 
     Tool expects credentials that belong to an account which has the right permissions to read the JIRA issues for a given project.
     Credentials can be used in a form of:
-     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or
+     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or  
      - gradle variables set through gradle properties (uses the 'jiraUser' and 'jiraPass' keys)
-    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as
+    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as 
     -Pusername=myUser -Ppassword=myPassword
     */
 
     // the key of the Jira project
     project = 'PROJECTKEY'
-
+    
     // the format of the received date time values to parse
     dateTimeFormatParse = "yyyy-MM-dd'T'H:m:s.SSSz" // i.e. 2020-07-24'T'9:12:40.999 CEST
-
+    
     // the format in which the date time should be saved to output
     dateTimeFormatOutput = "dd.MM.yyyy HH:mm:ss z" // i.e. 24.07.2020 09:02:40 CEST
 
     // the label to restrict search to
-    label =
+    label = 
 
     // Legacy settings for Jira query. This setting is deprecated & support for it will soon be completely removed. Please use JiraRequests settings
     jql = "project='%jiraProject%' AND labels='%jiraLabel%' ORDER BY priority DESC, duedate ASC"
@@ -220,7 +219,7 @@ jira.with {
     // Output folder for this task inside main outputPath
     resultsFolder = 'JiraRequests'
 
-    /*
+    /* 
     List of requests to Jira API:
     These are basically JQL expressions bundled with a filename in which results will be saved.
     User can configure custom fields IDs and name those for column header,
@@ -234,16 +233,16 @@ jira.with {
         ),
         new JiraRequest(
             filename:'CurrentSprint',
-            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC",
+            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC", 
             customfields: [customfield_10026:'Story Points']
         ),
-    ]
+    ]    
 }
-
+    
 @groovy.transform.Immutable
 class JiraRequest {
     String filename  //filename (without extension) of the file in which JQL results will be saved. Extension will be determined automatically for Asciidoc or Excel file
-    String jql // Jira Query Language syntax
+    String jql // Jira Query Language syntax 
     Map<String,String> customfields // map of customFieldId:displayName values for Jira fields which don't have default names, i.e. customfield_10026:StoryPoints
 }
 //end::jiraConfig[]

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -65,7 +65,7 @@ confluence = [:]
 // - 'url': absolute URL to an asciidoc generated html file to be exported
 // - 'ancestorName' (optional): the name of the parent page in Confluence as string;
 //                             this attribute has priority over ancestorId, but if page with given name doesn't exist,
-//                             ancestorId will be used as a fallback 
+//                             ancestorId will be used as a fallback
 // - 'ancestorId' (optional): the id of the parent page in Confluence as string; leave this empty
 //                            if a new parent shall be created in the space
 // - 'preambleTitle' (optional): the title of the page containing the preamble (everything
@@ -110,9 +110,9 @@ confluence.with {
 
     Tool expects credentials that belong to an account which has the right permissions to to create and edit confluence pages in the given space.
     Credentials can be used in a form of:
-     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or  
+     - passed parameters when calling script (-PconfluenceUser=myUsername -PconfluencePass=myPassword) which can be fetched as a secrets on CI/CD or
      - gradle variables set through gradle properties (uses the 'confluenceUser' and 'confluencePass' keys)
-    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as 
+    Often, same credentials are used for Jira & Confluence, in which case it is recommended to pass CLI parameters for both entities as
     -Pusername=myUser -Ppassword=myPassword
     */
 
@@ -135,6 +135,11 @@ confluence.with {
     // Optional proxy configuration, only used to access Confluence
     // schema supports http and https
     // proxy = [host: 'my.proxy.com', port: 1234, schema: 'http']
+
+   // Optional: specify which Confluence OpenAPI Macro should be used to render OpenAPI definitions
+   // possible values: ["confluence-open-api", "open-api", true]. true is the same as "confluence-open-api" for backward compatibility
+   // useOpenapiMacro = "confluence-open-api"
+
 }
 //end::confluenceConfig[]
 //*****************************************************************************************
@@ -179,29 +184,29 @@ jira.with {
 
     // endpoint of the JiraAPI (REST) to be used
     api = 'https://your-jira-instance'
-    
+
     /*
     WARNING: It is strongly recommended to store credentials securely instead of commiting plain text values to your git repository!!!
 
     Tool expects credentials that belong to an account which has the right permissions to read the JIRA issues for a given project.
     Credentials can be used in a form of:
-     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or  
+     - passed parameters when calling script (-PjiraUser=myUsername -PjiraPass=myPassword) which can be fetched as a secrets on CI/CD or
      - gradle variables set through gradle properties (uses the 'jiraUser' and 'jiraPass' keys)
-    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as 
+    Often, Jira & Confluence credentials are the same, in which case it is recommended to pass CLI parameters for both entities as
     -Pusername=myUser -Ppassword=myPassword
     */
 
     // the key of the Jira project
     project = 'PROJECTKEY'
-    
+
     // the format of the received date time values to parse
     dateTimeFormatParse = "yyyy-MM-dd'T'H:m:s.SSSz" // i.e. 2020-07-24'T'9:12:40.999 CEST
-    
+
     // the format in which the date time should be saved to output
     dateTimeFormatOutput = "dd.MM.yyyy HH:mm:ss z" // i.e. 24.07.2020 09:02:40 CEST
 
     // the label to restrict search to
-    label = 
+    label =
 
     // Legacy settings for Jira query. This setting is deprecated & support for it will soon be completely removed. Please use JiraRequests settings
     jql = "project='%jiraProject%' AND labels='%jiraLabel%' ORDER BY priority DESC, duedate ASC"
@@ -215,7 +220,7 @@ jira.with {
     // Output folder for this task inside main outputPath
     resultsFolder = 'JiraRequests'
 
-    /* 
+    /*
     List of requests to Jira API:
     These are basically JQL expressions bundled with a filename in which results will be saved.
     User can configure custom fields IDs and name those for column header,
@@ -229,16 +234,16 @@ jira.with {
         ),
         new JiraRequest(
             filename:'CurrentSprint',
-            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC", 
+            jql:"project='%jiraProject%' AND Sprint in openSprints() ORDER BY priority DESC, duedate ASC",
             customfields: [customfield_10026:'Story Points']
         ),
-    ]    
+    ]
 }
-    
+
 @groovy.transform.Immutable
 class JiraRequest {
     String filename  //filename (without extension) of the file in which JQL results will be saved. Extension will be determined automatically for Asciidoc or Excel file
-    String jql // Jira Query Language syntax 
+    String jql // Jira Query Language syntax
     Map<String,String> customfields // map of customFieldId:displayName values for Jira fields which don't have default names, i.e. customfield_10026:StoryPoints
 }
 //end::jiraConfig[]


### PR DESCRIPTION
### All Submissions:

* [x] Does your PR affect the documentation?

* [x] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/manual`.
To "publish" it, execute `./gradlew exportContributors && ./gradlew && ./copyDocs.sh`.
This will convert the `.adoc` file to HTML and copy them to the right folder so that github pages will pick them up.

**Attention**: I haven't "published" the docs yet. May be it makes sense to publish them after the PR gets merged ?!
 
### Your first submission

* [x] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
Created [Issue](https://github.com/docToolchain/docToolchain/issues/559#issue-838043418)
* [x] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?

### New Feature Submissions:

1. [ ] Did you create new tests for your submission?
No, I didn't. I run the unit tests locally to make sure that nothing is broken. Then tested my feature "manually" (by configuring accordingly and running publishToConfluence) since it's about introducing a new  macro for confluence. Didn't find Confluence integration tests...
2. [ ] Does your submission pass all tests? (see travis check)

### Change to Documentation:

* [x] Did you build the docs and copy them to the `/docs` folder?
Just updated the docs under /sr/docs/manual, pls have a look at the diffs 
* [ ] If not, did you create an issue for doing so?

inspiration: https://github.com/stevemao/github-issue-templates
