### PR TITLE
Call Exit() of repository class to terminate the EA process on demand.

### DIFF
--- a/scripts/exportEAP.vbs
+++ b/scripts/exportEAP.vbs
@@ -366,6 +366,8 @@
         End If
       End If
       EAapp.Repository.CloseFile()
+      ' Since EA 15.2 the Enterprise Architect background process hangs without calling Exit explicitly
+      EAapp.Repository.Exit()
     End Sub
 
   Private connectionString


### PR DESCRIPTION
As described in bug #570, with newer version of Enterprise Architect the script exportEA hangs while waiting for termination of the background process. To trigger this, the Repository API offers the Exit() method. 
Reference text: "Notes: Shuts down Enterprise Architect immediately. Used by .NET programmers where the garbage collector does not immediately release all referenced COM objects."

After adding this call, the script automatically proceeds until it ends successfully. It is tested with online connections and local eap files (even with combinations of both).
As this bug prevents us from periodical, automatic document generation, this pull request is from importance for us.