### PR TITLE
scripts/AsciiDocBasics.gradle: fulfill different plantUML path requirements by backends

### DIFF
--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -124,7 +124,6 @@ tasks.withType(org.asciidoctor.gradle.AsciidoctorTask) { docTask ->
     //        'pdf-fontsdir': "${docDir}/fonts",
             'source-highlighter': 'coderay@',
             'imagesdir': 'images@',
-            'plantUMLDir'         : file("${docDir}/${config.outputPath}/images/plantUML/").path,
             'toc': 'left@',
             'icons': 'font@',
             'javaVersion'         : "$javaVersion",
@@ -163,6 +162,9 @@ task generateHTML (
         type: AsciidoctorTask,
         group: 'docToolchain',
         description: 'use html5 as asciidoc backend') {
+        attributes (
+            'plantUMLDir'         : file("${docDir}/${config.outputPath}/html5").toURI().relativize(new File("${docDir}/${config.outputPath}/html5/plantUML/").toURI()).getPath()
+        )
 
     onlyIf {
         !sourceFiles.findAll {
@@ -198,6 +200,9 @@ task generatePDF (
         type: AsciidoctorTask,
         group: 'docToolchain',
         description: 'use pdf as asciidoc backend') {
+        attributes (
+            'plantUMLDir'         : file("${docDir}/${config.outputPath}/pdf/images/plantUML/").path
+        )
 
     attributes (
         'data-uri': 'true',


### PR DESCRIPTION
The commit

    97df9b9 scripts/AsciiDocBasics.gradle: fix inline plantuml referencing

introduces same path for all backends to save generated images from inline
plantUML code.  Unfortunately, it introduces a bug for Concluence backends
and amplifies a bug for the HTML5 backend.

This commit moves the plantUMLDir back to html5 and pdf backend, which should
avoid harming Confluence backend at all. Further, the value for the html5
backend is computed to a relative path for deploying the entire directory
structure to various locations.

https://github.com/docToolchain/docToolchain/issues/582 should be fixed by
this change.

Signed-off-by: Jens Rehsack <sno@netbsd.org>

### All Submissions:

* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/manual`.
To "publish" it, execute `./gradlew exportContributors && ./gradlew && ./copyDocs.sh`.
This will convert the `.adoc` file to HTML and copy them to the right folder so that github pages will pick them up.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?

### New Feature Submissions:

1. [ ] Did you create new tests for your submission?
2. [ ] Does your submission pass all tests? (see travis check)

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Change to Documentation:

* [ ] Did you build the docs and copy them to the `/docs` folder?
* [ ] If not, did you create an issue for doing so?

inspiration: https://github.com/stevemao/github-issue-templates
