### PR TITLE
Use real name for elements when exporting notes

### DIFF
--- a/scripts/exportEAP.vbs
+++ b/scripts/exportEAP.vbs
@@ -55,7 +55,7 @@
             MakeDir(path&prefix&post)
             
             set objFile = objFSO.OpenTextFile(path&prefix&post&strFileName&".ad",ForAppending, True)
-            name = NormalizeName(currentElement.Name)
+            name = currentElement.Name
             name = Replace(name,vbCr,"")
             name = Replace(name,vbLf,"")
 


### PR DESCRIPTION
When notes are exported there is no need to normalize the string.

Instead it is rather confusing when reading the notes to see e.g.
_dev_i2c instead of /dev/i2c.

Signed-off-by: Rosi2143 <Schrott.Micha@web.de>

### All Submissions:

* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/manual`.
To "publish" it, execute `./gradlew exportContributors && ./gradlew && ./copyDocs.sh`.
This will convert the `.adoc` file to HTML and copy them to the right folder so that github pages will pick them up.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?

### New Feature Submissions:

1. [ ] Did you create new tests for your submission?
2. [ ] Does your submission pass all tests? (see travis check)

### Changes to Core Features:

* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Change to Documentation:

* [ ] Did you build the docs and copy them to the `/docs` folder?
* [ ] If not, did you create an issue for doing so?

inspiration: https://github.com/stevemao/github-issue-templates
