### PR TITLE
exportEA: Add check if diagrams shall be overwritten

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -9,6 +9,9 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === added
 
+2021-11-30::
+* https://github.com/docToolchain/docToolchain/pull/706[#706 - exportEA: Add check if diagrams shall be overwritten]
+
 2021-11-13::
 * https://github.com/docToolchain/docToolchain/pull/686[#686 - Add resourceDirs option]
 

--- a/scripts/exportEA.gradle
+++ b/scripts/exportEA.gradle
@@ -207,6 +207,10 @@ use `gradle exportEA` to re-export files
         if (!config.exportEA.diagramAttributes.isEmpty()) {
             scriptParameterString = scriptParameterString + " -da \"$config.exportEA.diagramAttributes\""
         }
+        //configure additional diagram attributes to be exported
+        if (!config.exportEA.additionalOptions.isEmpty()) {
+            scriptParameterString = scriptParameterString + " -ao \"$config.exportEA.additionalOptions\""
+        }
         //make sure path for notes exists
         //and remove old notes
         new File(exportPath, 'ea').deleteDir()
@@ -220,6 +224,7 @@ use `gradle exportEA` to re-export files
         new File(exportPath, 'ea/readme.ad').write(readme)
 
         //execute through cscript in order to make sure that we get WScript.echo right
+        logger.info("docToolchain > exportEA: parameters: " + scriptParameterString)
         "%SystemRoot%\\System32\\cscript.exe //nologo ${projectDir}/scripts/exportEAP.vbs ${scriptParameterString}".executeCmd()
         //the VB Script is only capable of writing iso-8859-1-Files.
         //we now have to convert them to UTF-8

--- a/scripts/exportEAP.vbs
+++ b/scripts/exportEAP.vbs
@@ -8,10 +8,10 @@
     Dim FS 'As Scripting.FileSystemObject
 
     Dim projectInterface 'As EA.Project
-    
+
     Const   ForAppending = 8
     Const   ForWriting = 2
-    
+
     ' Helper
     ' http://windowsitpro.com/windows/jsi-tip-10441-how-can-vbscript-create-multiple-folders-path-mkdir-command
     Function MakeDir (strPath)
@@ -34,7 +34,7 @@
        re.Global = True
        NormalizeName = re.Replace(theName, "_")
     End Function
-    
+
     Sub WriteNote(currentModel, currentElement, notes, prefix)
         If (Left(notes, 6) = "{adoc:") Then
             strFileName = Mid(notes,7,InStr(notes,"}")-7)
@@ -53,7 +53,7 @@
                 post = "_"
             End If
             MakeDir(path&prefix&post)
-            
+
             set objFile = objFSO.OpenTextFile(path&prefix&post&strFileName&".ad",ForAppending, True)
             name = currentElement.Name
             name = Replace(name,vbCr,"")
@@ -134,14 +134,14 @@
         End If
     End Sub
 
-    ' This sub routine checks if the format string defined in diagramAttributes 
-    ' does contain any characters. It replaces the known placeholders: 
+    ' This sub routine checks if the format string defined in diagramAttributes
+    ' does contain any characters. It replaces the known placeholders:
     ' %DIAGRAM_AUTHOR%, %DIAGRAM_CREATED%, %DIAGRAM_GUID%, %DIAGRAM_MODIFIED%,
     ' %DIAGRAM_NAME%, %DIAGRAM_NOTES%
     ' with the attribute values read from the EA diagram object.
     ' None, one or multiple number of placeholders can be used to create a diagram attribute
     ' to be added to the document. The attribute string is stored as a file with the same
-    ' path and name as the diagram image, but with suffix .ad. So, it can 
+    ' path and name as the diagram image, but with suffix .ad. So, it can
     ' easily be included in an asciidoc file.
     Sub SaveDiagramAttribute(currentDiagram, path, diagramName)
         If Len(diagramAttributes) > 0 Then
@@ -151,9 +151,9 @@
             set objFile = objFSO.OpenTextFile(filename, ForWriting, True)
             filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_AUTHOR%",   currentDiagram.Author)
             filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_CREATED%",  currentDiagram.CreatedDate)
-            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_GUID%",     currentDiagram.DiagramGUID)                        
+            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_GUID%",     currentDiagram.DiagramGUID)
             filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_MODIFIED%", currentDiagram.ModifiedDate)
-            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_NAME%",     currentDiagram.Name)                        
+            filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_NAME%",     currentDiagram.Name)
             filledDiagAttr = Replace(filledDiagAttr, "%DIAGRAM_NOTES%",    currentDiagram.Notes)
             filledDiagAttr = Replace(filledDiagAttr, "%NEWLINE%",          vbCrLf)
             objFile.WriteLine(filledDiagAttr)
@@ -161,6 +161,8 @@
         End If
     End Sub
     Sub SaveDiagram(currentModel, currentDiagram)
+        Dim exportDiagram ' As Boolean
+
         ' Open the diagram
         Repository.OpenDiagram(currentDiagram.DiagramID)
 
@@ -174,23 +176,39 @@
         End If
         path = objFSO.GetAbsolutePathName(path)
         MakeDir(path)
-        
+
         diagramName = currentDiagram.Name
         diagramName = Replace(diagramName,vbCr,"")
         diagramName = Replace(diagramName,vbLf,"")
         diagramName = NormalizeName(diagramName)
         filename = objFSO.BuildPath(path, diagramName & ".png")
 
-        projectInterface.SaveDiagramImageToFile(filename)
-        WScript.echo " extracted image to " & filename
-        If Not IsEmpty(diagramAttributes) Then
-            SaveDiagramAttribute currentDiagram, path, diagramName
+        exportDiagram = True
+        If objFSO.FileExists(filename) Then
+            WScript.echo " --- " & filename & " already exists."
+            If Len(additionalOptions) > 0 Then
+                If InStr(additionalOptions, "KeepFirstDiagram") > 0 Then
+                    WScript.echo " --- Skipping export -- parameter 'KeepFirstDiagram' set."
+                Else
+                    WScript.echo " --- Overwriting -- parameter 'KeepFirstDiagram' not set."
+                    exportDiagram = False
+                End If
+            Else
+                WScript.echo " --- Overwriting -- parameter 'KeepFirstDiagram' not set."
+            End If
+        End If
+        If exportDiagram Then
+          projectInterface.SaveDiagramImageToFile(filename)
+          WScript.echo " extracted image to " & filename
+          If Not IsEmpty(diagramAttributes) Then
+              SaveDiagramAttribute currentDiagram, path, diagramName
+          End If
         End If
         Repository.CloseDiagram(currentDiagram.DiagramID)
 
-        ' Write the note of the diagram 
+        ' Write the note of the diagram
         WriteNote currentModel, currentDiagram, currentDiagram.Notes, diagramName&"_notes"
-        
+
         For Each diagramElement In currentDiagram.DiagramObjects
             Set currentElement = Repository.GetElementByID(diagramElement.ElementID)
             WriteNote currentModel, currentElement, currentElement.Notes, diagramName&"_notes"
@@ -224,8 +242,8 @@
                 DumpDiagrams currentElement,currentModel
             End If
         Next
-        
-        
+
+
         ' Iterate through all diagrams in the current package
         For Each currentDiagram In currentPackage.Diagrams
             SyncJira currentModel, currentDiagram
@@ -281,7 +299,7 @@
           call DumpDiagrams(package, currentModel)
         End If
     End Function
-    
+
     Function FormatStringToJSONString(inputString)
         outputString = Replace(inputString, "\", "\\")
         outputString = Replace(outputString, """", "\""")
@@ -290,7 +308,7 @@
         outputString = Replace(outputString, vbCr, "\n")
         FormatStringToJSONString = outputString
     End Function
-    
+
     'If a valid file path is set, the glossary terms are read from EA repository,
     'formatted in a JSON compatible format and written into file.
     'The file is read and reformatted by the exportEA gradle task afterwards.
@@ -301,9 +319,9 @@
             GUID = Replace(GUID,"}","")
             currentGlossaryFile = objFSO.BuildPath(glossaryFilePath,"/"&GUID&".ad")
             set objFile = objFSO.OpenTextFile(currentGlossaryFile,ForAppending, True)
-            
+
             Set glossary = EArepo.Terms()
-            objFile.WriteLine("[") 
+            objFile.WriteLine("[")
             dim counter
             counter = 0
             For Each term In glossary
@@ -314,9 +332,9 @@
                 objFile.WriteLine(" ""termID"" : """&FormatStringToJSONString(term.termID)&""", ""type"" : """&FormatStringToJSONString(term.type)&""" }")
                 counter = counter + 1
             Next
-            objFile.WriteLine("]") 
-            
-            objFile.Close        
+            objFile.WriteLine("]")
+
+            objFile.Close
         End If
     End Function
 
@@ -376,12 +394,13 @@
   Private searchPath
   Private glossaryFilePath
   Private diagramAttributes
-  
+  Private additionalOptions
+
   exportDestination = "./src/docs"
   searchPath = "./src"
   Set packageFilter = CreateObject("System.Collections.ArrayList")
   Set objArguments = WScript.Arguments
-  
+
   Dim argCount
   argCount = 0
   While objArguments.Count > argCount+1
@@ -396,12 +415,14 @@
         searchPath = objArguments(argCount+1)
       Case "-g"
         glossaryFilePath = objArguments(argCount+1)
-      Case "-da" 
+      Case "-da"
         diagramAttributes = objArguments(argCount+1)
+      Case "-ao"
+        additionalOptions = objArguments(argCount+1)
     End Select
     argCount = argCount + 2
   WEnd
-  set fso = CreateObject("Scripting.fileSystemObject") 
+  set fso = CreateObject("Scripting.fileSystemObject")
   WScript.echo "Image extractor"
 
   ' Check both types in parallel - 1st check Enterprise Architect database connection, 2nd look for local project files

--- a/src/docs/015_tasks/03_task_exportEA.adoc
+++ b/src/docs/015_tasks/03_task_exportEA.adoc
@@ -67,13 +67,24 @@ diagramAttributes::
 Beside the diagram image, an EA diagram offers several useful attributes which
 could be required in the resulting document. If set, the string is used to create
 and store the diagram attributes to be included in the document.
-These placeholders are defined and filled with the diagram attributes if used in the
-diagramAttributes string: %DIAGRAM_AUTHOR%, %DIAGRAM_CREATED%, %DIAGRAM_GUID%, %DIAGRAM_MODIFIED%, %DIAGRAM_NAME%. %DIAGRAM_NOTES%,
+These placeholders are defined and filled with the diagram attributes, if used in the
+diagramAttributes string: +
+`%DIAGRAM_AUTHOR%`, +
+`%DIAGRAM_CREATED%`, +
+`%DIAGRAM_GUID%`, +
+`%DIAGRAM_MODIFIED%`, +
+`%DIAGRAM_NAME%`, +
+`%DIAGRAM_NOTES%`, +
+`%NEWLINE%` +
 Example: diagramAttributes = "Last modification: %DIAGRAM_MODIFIED%" +
 You can add the string %NEWLINE% where a line break shall be added. +
 The resulting text is stored beside the diagram image using same path and file named,
 but different file extension (.ad). This can included in the document if required.
 If diagramAttributes is not set or string is empty, no file is written.
+
+additionalOptions::
+This parameter is used to define specific behavior of the export. Currently these options are supported: +
+`KeepFirstDiagram` - in case a diagrams are not names uniquely, the last diagram will be saved. If you want to prevent that diagrams are overwritten, add this parameter to additionalOptions.
 
 
 == Glossary export


### PR DESCRIPTION
Add one more parameter "additionalOptions"

Add one more parameter to e.g. let the user decide if diagrams shall be overwritten if the diagramname exists multiple times

If diagrams have the same name they are currently always overwritten (Windows: also if the name differs in lower/upper case).

Allow user to make a decision by adding additional option

New parameter "additionalOptions" added with currently supported value
* KeepFirstDiagram

Signed-off-by: Michael Roßner <Schrott.Micha@web.de>

### All Submissions:

* [ ] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
