### PR TITLE
Correct confluence password parameter name

### DIFF
--- a/src/docs/015_tasks/03_task_publishToConfluence.adoc
+++ b/src/docs/015_tasks/03_task_publishToConfluence.adoc
@@ -51,7 +51,7 @@ To avoid having your password or api-token versioned through git, you can store 
 e.g. you can do things like `credentials = "user:${new File("/home/me/apitoken").text}".bytes.encodeBase64().toString()`
 
 To simplify the injection of credentials from external sources there is a fallback. Should you leave the credentials field empty,
-the variables `confluenceUser` and `confluencePassword` from the build environment will be used for authentication. You can set these through any means
+the variables `confluenceUser` and `confluencePass` from the build environment will be used for authentication. You can set these through any means
 allowed by gradle like the `gradle.properties` file in the project or your home directory, environment variables or command-line flags.
 For all ways to set these variables, have a look at the https://docs.gradle.org/current/userguide/build_environment.html[gradle manual].
 


### PR DESCRIPTION
I had problems using the publish to confluence feature because i could not figure out how to pass the credentials. I finally found that i misstyped the password parameter. The documentation says that i can use "-PconfluencePassword" but it's actually "-PconfluencePass".

I'm a little confused about the branches. Is "ng" the right branch to fix this? Should i fix it on other branches to?