### PR TITLE
Update asciidoc2confluence.groovy to handle attachements without hash

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -7,6 +7,10 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 == Unreleased
 
+=== fixes
+2021-12-06::
+* https://github.com/docToolchain/docToolchain/pull/711[#712 - publishToConfluence fails when no hash is available for an uploaded image]
+
 === added
 
 2021-11-30::
@@ -22,7 +26,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === fixed
 
-2921-11-15::
+2021-11-15::
 * https://github.com/docToolchain/docToolchain/pull/696[#696 - exportContributors - not everybody is rendered]
 * https://github.com/docToolchain/docToolchain/pull/697[#697 - exportToMarkdown docs are not referenced correctly]
 

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -193,7 +193,10 @@ def uploadAttachment = { def pageId, String url, String fileName, String note ->
     def http
     if (attachment.size==1) {
         // attachment exists. need an update?
-        def remoteHash = attachment.results[0].extensions.comment.replaceAll("(?sm).*#([^#]+)#.*",'$1')
+        def remoteHash = 0
+        if (attachment.results[0].extensions.comment != null) {
+            remoteHash = attachment.results[0].extensions.comment.replaceAll("(?sm).*#([^#]+)#.*",'$1')
+        }
         if (remoteHash!=localHash) {
             //hash is different -> attachment needs to be updated
             http = new HTTPBuilder(config.confluence.api + 'content/' + pageId + '/child/attachment/' + attachment.results[0].id + '/data')
@@ -201,12 +204,12 @@ def uploadAttachment = { def pageId, String url, String fileName, String note ->
         }
     } else {
         http = new HTTPBuilder(config.confluence.api + 'content/' + pageId + '/child/attachment')
-        
+
     }
-    if (http) {																												
+    if (http) {
 		if (config.confluence.proxy) {
             http.setProxy(config.confluence.proxy.host, config.confluence.proxy.port, config.confluence.proxy.schema ?: 'http')
-        } 
+        }
 		
         http.request(Method.POST) { req ->
             requestContentType: "multipart/form-data"
@@ -386,7 +389,7 @@ def rewriteJiraLinks = { body ->
     // find links to jira tickets and replace them with jira macros
     body.select('a[href]').each { a ->
         def href = a.attr('href')
-        if (href.startsWith(config.jira.api + "/browse/")) { 
+        if (href.startsWith(config.jira.api + "/browse/")) {
                 def ticketId = a.text()
                 a.before("""<ac:structured-macro ac:name=\"jira\" ac:schema-version=\"1\">
                      <ac:parameter ac:name=\"key\">${ticketId}</ac:parameter>


### PR DESCRIPTION
Somebody managed to upload attachments without a hash, that broke the job publishToConfluence.

This change checks first if a hash is available before extracting it. Otherwise hash will be set to 0 - which is at least different to the real hash.

Signed-off-by: Michael Roßner Schrott.Micha@web.de

### All Submissions:

* [ ] Did you update the `changelog.adoc`?
  * yes
* [ ] Does your PR affect the documentation?
  * no
* [ ] If yes, did you update the documentation or create an issue for updating it?