### PR TITLE
Jody's edits

### DIFF
--- a/src/docs/exportMarkdownDocs.md
+++ b/src/docs/exportMarkdownDocs.md
@@ -1,5 +1,4 @@
-# exportMarkdown
+== About This Task
 
 The *exportMarkdown* task can be used to include [markdown](https://markdown.de) files into the documentation.
-
-The task is scanning the directory `/src/docs` for markdown files (`*.md`) and converts them into AsciiDoc files. The converted files can then be referenced from within the `/build`-folder.
+It scans the `/src/docs` directory for markdown (`*.md`) files and converts them into Asciidoc files. The converted files can then be referenced from within the `/build`-folder.

--- a/src/docs/exportMarkdownDocs.md
+++ b/src/docs/exportMarkdownDocs.md
@@ -1,4 +1,4 @@
-== About This Task
+# About This Task
 
 The *exportMarkdown* task can be used to include [markdown](https://markdown.de) files into the documentation.
 It scans the `/src/docs` directory for markdown (`*.md`) files and converts them into Asciidoc files. The converted files can then be referenced from within the `/build`-folder.


### PR DESCRIPTION
I don't know how to fix the heading. If you look at the http://doctoolchain.org/docToolchain/v2.0.x/015_tasks/03_task_exportMarkdown.html page in a browser, the exportMarkdown heading appears on the page which is not consistent with the other pages on the site.

### All Submissions:

* [ ] Did you update the `changelog.adoc`?
* [X] Does your PR affect the documentation?
* [X] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
