### PR TITLE
Clarify that ng branch is the future in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ If you want to sponsor an issue, just use the sponsor link on top of this page.
 ====
 If you have used docToolchain in the past, please be aware that the master branch is undergoing some changes.
 
-If you are looking for a fresh version and are willing to accept changes in the configuration, the master branch is the right thing for you.
+If you are looking for a fresh version and are willing to accept changes in the configuration, this `ng` branch is the right thing for you.
 
 If you are looking for what you are used to, then download https://github.com/docToolchain/docToolchain/releases[the V1.0.0 release]
 ====


### PR DESCRIPTION
The README in the ng branch said "master is the right thing" while
the README in the master branch said "ng is the right thing".
From the discussion in issue #716 I conclude that master is deprecated
and ng is the branch to go (supported by the fact that ng is default).
See also: https://github.com/docToolchain/docToolchain/issues/716#issuecomment-993917342

### All Submissions:

* [n.a.] Did you update the `changelog.adoc`?
* [yes, minor cosmetics] Does your PR affect the documentation?
* [no, because minor cosmetics] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

### Your first submission

* [Thanks] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [not required for such a small change] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
:-)