### PR TITLE
docs: :memo: Add section about gradle build error

### DIFF
--- a/src/docs/010_manual/50_Frequently_asked_Questions.adoc
+++ b/src/docs/010_manual/50_Frequently_asked_Questions.adoc
@@ -194,7 +194,7 @@ An easy way to test your configuration is to run `xeyes` in WSL.
 Make sure that your WSL is up to date by running `wsl --update`. This is not part of your regular Windows update!
 ====
 
-=== I get an error 'Failed to create parent directory /project/.gradle'
+=== I get a `Failed to create parent directory /project/.gradle` error
 
 ----
 > Gradle could not start your build.
@@ -205,8 +205,7 @@ Make sure that your WSL is up to date by running `wsl --update`. This is not par
 .Answer
 [%collapsible]
 ====
-This issue might occure in CI enviroments (e.g. Bamboo) with resticted permissions in the working folder where files or directories created outside the container might not be accessible inside the container. Therefore before starting the container you can set e.g. the working directory with max permissions for allowing access from the user inside the docker container.
-
+This issue can occur in CI enviroments (such as Bamboo) that have resticted permissions in the working folder where files or directories created outside the container might not be accessible inside the container. Before starting the container, give the working directory maximum permissions for allowing access to the user inside the Docker container.
 
 ```
 chmod -R o+rwx ${bamboo.working.directory}
@@ -215,7 +214,7 @@ chmod -R o+rwx ${bamboo.working.directory}
 ```
 ====
 
-=== Q: I get an error that Gradle dependencies cannot be downloaded because a proxy is restricting internet access.
+=== Q: I get an error stating that Gradle dependencies cannot be downloaded because a proxy is restricting internet access
 
 .Answer
 [%collapsible]

--- a/src/docs/010_manual/50_Frequently_asked_Questions.adoc
+++ b/src/docs/010_manual/50_Frequently_asked_Questions.adoc
@@ -193,3 +193,24 @@ An easy way to test you configuration is to run `xeyes` in WSL.
 
 NOTE:: Please make sure that you wsl is up-to-date bei executing `wsl --update` - this is not part of your regular windows update!
 ====
+
+=== I get an error 'Failed to create parent directory /project/.gradle'
+
+----
+> Gradle could not start your build.
+> Could not create service of type CrossBuildFileHashCache using BuildSessionServices.createCrossBuildFileHashCache().
+   > Failed to create parent directory '/project/.gradle' when creating directory '/project/.gradle/6.7.1/fileHashes'
+----
+
+.Answer
+[%collapsible]
+====
+This issue might occure in CI enviroments (e.g. Bamboo) with resticted permissions in the working folder where files or directories created outside the container might not be accessible inside the container. Therefore before starting the container you can set e.g. the working directory with max permissions for allowing access from the user inside the docker container.
+
+
+```
+chmod -R o+rwx ${bamboo.working.directory}
+./dtcw generateSite
+
+```
+====

--- a/src/docs/010_manual/50_Frequently_asked_Questions.adoc
+++ b/src/docs/010_manual/50_Frequently_asked_Questions.adoc
@@ -194,7 +194,7 @@ An easy way to test your configuration is to run `xeyes` in WSL.
 Make sure that your WSL is up to date by running `wsl --update`. This is not part of your regular Windows update!
 ====
 
-=== I get a `Failed to create parent directory /project/.gradle` error
+=== Q: I get a `Failed to create parent directory /project/.gradle` error
 
 ----
 > Gradle could not start your build.


### PR DESCRIPTION
In some CI environments permissions are restricted and gradle can not build the project from the docker image using the volume '-v '${PWD}:/project''

### All Submissions:

* [ ] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation ~or create an issue for updating it~?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
