### PR TITLE
publishToConfluence: support swagger-open-api

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -141,7 +141,7 @@ confluence.with {
     // proxy = [host: 'my.proxy.com', port: 1234, schema: 'http']
 
     // Optional: specify which Confluence OpenAPI Macro should be used to render OpenAPI definitions
-    // possible values: ["confluence-open-api", "open-api", true]. true is the same as "confluence-open-api" for backward compatibility
+    // possible values: ["confluence-open-api", "open-api", "swagger-open-api", true]. true is the same as "confluence-open-api" for backward compatibility
     // useOpenapiMacro = "confluence-open-api"
 }
 //end::confluenceConfig[]

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -39,6 +39,9 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === added
 
+2022-03-16::
+* https://github.com/docToolchain/docToolchain/pull/825[#825 - publishToConfluence: support swagger-open-api]
+
 2021-12-09::
 * https://github.com/docToolchain/docToolchain/pull/714[#714 - Update exportExcel.gradle]
 

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -409,29 +409,38 @@ def rewriteCodeblocks = { body ->
 }
 
 def rewriteOpenAPI = { org.jsoup.nodes.Element body ->
-         if (config.confluence.useOpenapiMacro == true || config.confluence.useOpenapiMacro == 'confluence-open-api') {
-            body.select('div.openapi  pre > code').each { code ->
-                def parent=code.parent()
-                def rawYaml=code.wholeText()
-                code.parent()
-                        .wrap('<ac:structured-macro ac:name="confluence-open-api" ac:schema-version="1" ac:macro-id="1dfde21b-6111-4535-928a-470fa8ae3e7d"></ac:structured-macro>')
-                        .unwrap()
-                code.wrap("<ac:plain-text-body>${CDATA_PLACEHOLDER_START}${CDATA_PLACEHOLDER_END}</ac:plain-text-body>")
-                        .replaceWith(new TextNode(rawYaml))
-            }
-         }
-        else if (config.confluence.useOpenapiMacro == 'open-api') {
-            body.select('div.openapi  pre > code').each { code ->
-                def parent=code.parent()
-                def rawYaml=code.wholeText()
-                code.parent()
-                        .wrap('<ac:structured-macro ac:name="open-api" ac:schema-version="1" data-layout="default" ac:macro-id="4302c9d8-fca4-4f14-99a9-9885128870fa"></ac:structured-macro>')
-                        .unwrap()
-                // default: show download button
-                code.before('<ac:parameter ac:name="showDownloadButton">true</ac:parameter>')
-                code.wrap("<ac:plain-text-body>${CDATA_PLACEHOLDER_START}${CDATA_PLACEHOLDER_END}</ac:plain-text-body>")
-                        .replaceWith(new TextNode(rawYaml))
-            }
+    if (config.confluence.useOpenapiMacro == true || config.confluence.useOpenapiMacro == 'confluence-open-api') {
+        body.select('div.openapi  pre > code').each { code ->
+            def parent=code.parent()
+            def rawYaml=code.wholeText()
+            code.parent()
+                    .wrap('<ac:structured-macro ac:name="confluence-open-api" ac:schema-version="1" ac:macro-id="1dfde21b-6111-4535-928a-470fa8ae3e7d"></ac:structured-macro>')
+                    .unwrap()
+            code.wrap("<ac:plain-text-body>${CDATA_PLACEHOLDER_START}${CDATA_PLACEHOLDER_END}</ac:plain-text-body>")
+                    .replaceWith(new TextNode(rawYaml))
+        }
+    } else if (config.confluence.useOpenapiMacro == 'swagger-open-api') {
+        body.select('div.openapi  pre > code').each { code ->
+            def parent=code.parent()
+            def rawYaml=code.wholeText()
+            code.parent()
+                    .wrap('<ac:structured-macro ac:name="swagger-open-api" ac:schema-version="1" ac:macro-id="f9deda8a-1375-4488-8ca5-3e10e2e4ee70"></ac:structured-macro>')
+                    .unwrap()
+            code.wrap("<ac:plain-text-body>${CDATA_PLACEHOLDER_START}${CDATA_PLACEHOLDER_END}</ac:plain-text-body>")
+                    .replaceWith(new TextNode(rawYaml))
+        }
+    } else if (config.confluence.useOpenapiMacro == 'open-api') {
+        body.select('div.openapi  pre > code').each { code ->
+            def parent=code.parent()
+            def rawYaml=code.wholeText()
+            code.parent()
+                    .wrap('<ac:structured-macro ac:name="open-api" ac:schema-version="1" data-layout="default" ac:macro-id="4302c9d8-fca4-4f14-99a9-9885128870fa"></ac:structured-macro>')
+                    .unwrap()
+            // default: show download button
+            code.before('<ac:parameter ac:name="showDownloadButton">true</ac:parameter>')
+            code.wrap("<ac:plain-text-body>${CDATA_PLACEHOLDER_START}${CDATA_PLACEHOLDER_END}</ac:plain-text-body>")
+                    .replaceWith(new TextNode(rawYaml))
+        }
     }
 }
 

--- a/src/docs/015_tasks/03_task_publishToConfluence.adoc
+++ b/src/docs/015_tasks/03_task_publishToConfluence.adoc
@@ -108,7 +108,7 @@ If you need to provide proxy to access Confluence, you can set a map with the ke
 
 *useOpenapiMacro*
 
-If this option is present and equal to `confluence-open-api` then any source block marked with `class openapi` will be wrapped in the Elitesoft Swagger Editor macro (see https://marketplace.atlassian.com/apps/1218914/open-api-swagger-editor-for-confluence[Elitesoft Swagger Editor]).
+If this option is present and equal to `confluence-open-api` or `swagger-open-api` then any source block marked with `class openapi` will be wrapped in the Elitesoft Swagger Editor macro (see https://marketplace.atlassian.com/apps/1218914/open-api-swagger-editor-for-confluence[Elitesoft Swagger Editor]). The key depends on the version of the macro.
 
 For backward compatibility, if this option is present and equal to `true`, then again the Elitesoft Swagger Editor macro will be used.
 

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -66,5 +66,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/JodyWinter[Jody Winter]
 - https://github.com/CollierCZ[Aaron Collier]
 - https://github.com/Bennykillua[Ifeanyi Benedict Iheagwara]
+- https://github.com/Vierheller[Jan-Niklas Vierheller]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

### Problem
The current implementation supports two OpenAPI editors. Our company uses an OpenAPI integration with the swagger-open-api key. It is the same plugin as confluence-open-api, but using other ids. This is probably due to a new version.

### Proposal
Add another branch to the "rewriteOpenAPI"-function to support the swagger-open-api plugin.

### Testing
Not sure how to provide you with an integrated testing possibility. I can say that the forked version is already in use with our confluence instance and works like a charm.

### Your first submission

* [x] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [x] Have you added your name to the list of [contributors.adoc](https://github.com/docToolchain/docToolchain/blob/master/src/docs/manual/05_contributors.adoc)?

