### PR TITLE
Docs: Add a backslash to improve rendering

### DIFF
--- a/src/docs/015_tasks/03_task_generateSite.adoc
+++ b/src/docs/015_tasks/03_task_generateSite.adoc
@@ -119,7 +119,7 @@ This code is translated through the configuration to the menu named `title2`.
 * `demo3.adoc` will have a menu-code `code1` because it is located in the folder `code3`.
 This code is translated through the configuration to the special menu `-` which will not be displayed.
 This is an easy way to hide a menu in the rendered microsite.
-* `_demo4.adoc` starts with an underscore `_` and thus will be handled as `draft` (`:jbake-status: draft`).
+* `\_demo4.adoc` starts with an underscore `_` and thus will be handled as `draft` (`:jbake-status: draft`).
 It will not be rendered as part of any menu, but it will be available in the microsite as "hidden" `_demo4-draft.html`.
 Feel free to remove these draft rendereings before you publish your microsite.
 


### PR DESCRIPTION
Very small change to fix a rendering issue:

The `_` of the filename `_demo4.adoc` is considered as the beginning of an italic part that ends at the second `_` present in the text. See current rendering:

<img width="448" alt="Screenshot 2022-06-28 at 16 00 58" src="https://user-images.githubusercontent.com/1222165/176198060-2e6a493a-327b-4c97-8df9-34db8361da31.png">

With this backslash, the underscore is rendered:
<img width="466" alt="Screenshot 2022-06-28 at 16 13 40" src="https://user-images.githubusercontent.com/1222165/176201117-0b57cb2a-9b3e-41f7-b0da-176da121bb80.png">

Screenshot taken from https://deploy-preview-863--dtc-docs-preview.netlify.app/015_tasks/03_task_generatesite
