### PR TITLE
Add tests for 'src/site/groovy/menu.groovy'

### DIFF
--- a/src/test/groovy/site/MenuSpec.groovy
+++ b/src/test/groovy/site/MenuSpec.groovy
@@ -1,0 +1,56 @@
+package docToolchain
+import spock.lang.*
+import org.gradle.testkit.runner.GradleRunner
+import static org.gradle.testkit.runner.TaskOutcome.*
+
+class MenuSpec extends Specification {
+
+    class ContentFixture {
+        def menu
+        def entriesMap
+        def newEntries
+    }
+
+    void 'test empty published content'() {
+        given: 'empty published_content'
+            Binding binding = new Binding()
+            binding.published_content = []
+        when: 'run the `menu.groovy` script'
+            runMenuScript(binding)
+        then: 'arrays are empty'
+            binding.content.menu == [:]
+            binding.content.entriesMap == [:]
+            binding.content.newEntries == []
+    }
+
+    void 'test with published content'() {
+        given: '3 pages in published_content'
+            Binding binding = new Binding()
+            binding.published_content = [
+                ['jbake-menu': 'foo', 'jbake-title': 'Lorem Ipsum', 'jbake-order': 10, uri : 'foo/10_lorem-ipsum.html'],
+                ['jbake-menu': 'foo', 'jbake-title': 'Dolor sit amet', 'jbake-order': 20, uri : 'foo/20_dolor_sit_amet.html'],
+                ['jbake-menu': 'bar', 'jbake-title': 'Adipiscing elit', 'jbake-order': 10, uri : 'bar/10_adipiscing_elit.html']
+            ]
+        when: 'run the `menu.groovy` script'
+            runMenuScript(binding)
+        then: 'arrays are computed'
+            binding.content.menu == [
+                foo:[
+                    [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'foo/10_lorem-ipsum.html'],
+                    [title: 'Dolor sit amet', order: 20, filename: null, uri: 'foo/20_dolor_sit_amet.html']
+                ],
+                bar:[
+                    [title: 'Adipiscing elit', order: 10, filename: null, uri: 'bar/10_adipiscing_elit.html']
+                ]
+            ]
+            binding.content.entriesMap == [:]
+            binding.content.newEntries == []
+    }
+
+    def runMenuScript(Binding binding) {
+        binding.content = new ContentFixture()
+        GroovyShell shell = new GroovyShell(binding)
+        Script script = shell.parse(new File('src/site/groovy/menu.groovy'))
+        script.run()
+    }
+}


### PR DESCRIPTION
While working on #692, I noticed there is no test class for the `src/site/groovy/menu.groovy` script.

This PR is an attempt to write such a test class and to collect feedback (to know if I go in a good direction or not).

This test class is supposed to be extended when working on #692.

---

In my opinion there is no need to document this in the `changelog.adoc` file, since there is no change to the code. If you have an other opinion, I am happy to add an entry.
