### PR TITLE
Change the order default value of the index page when nothing is defined.

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -13,6 +13,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * https://github.com/docToolchain/docToolchain/pull/847[#847 generateHTML & generatePDF documentation improvements]
 * https://github.com/docToolchain/docToolchain/issues/851[#851 fix duplicate TOC marker]
 * https://github.com/docToolchain/docToolchain/issues/853[#853 Hide site links when not configured]
+* https://github.com/docToolchain/docToolchain/issues/873[#873 generateSite: Fix index page location]
 
 
 === added

--- a/scripts/generateSite.gradle
+++ b/scripts/generateSite.gradle
@@ -270,7 +270,7 @@ ${color 'green', 'for you?'}\n""",
                             }
                         }
                         if (jbake.order==-1 && docname.startsWith('index')) {
-                            jbake.order = 0
+                            jbake.order = -987654321 // special 'magic value' given to index pages.
                             jbake.status = "published"
                         }
                         // news blog

--- a/src/docs/015_tasks/03_task_generateSite.adoc
+++ b/src/docs/015_tasks/03_task_generateSite.adoc
@@ -56,6 +56,7 @@ Defaults to the first headline of the file.
 
 Applies a sort order to drop-down entries.
 Defaults to a prefixed file number, such as `**04**_filename.adoc` or to the prefixed number of the second-level folder name.
+When nothing is defined the default value is `-1` or `-987654321` for `index` pages.
 
 *jbake-type*
 
@@ -143,7 +144,7 @@ You can still define the order with the name (for the example `20` because the f
 
 When there is no sub-folder, only a flat list of pages is created.
 
-NOTE: When an `index.adoc` page is defined inside the top level folder (like: `10_foo/index.adoc` or `20_bar/index.adoc`) then the page will listed in the section navigation tree in the sidebar as any other regular page.
+NOTE: When an `index.adoc` page is defined inside the top level folder (like: `10_foo/index.adoc` or `20_bar/index.adoc`) then the page will listed in the section navigation tree in the sidebar as any other regular page. By default it will be the first element of the tree, unless the value is overridden by a `:jbake-order:` attribute.
 
 [[top-menu-config]]
 ==== Configuring the top level menu

--- a/src/site/groovy/menu.groovy
+++ b/src/site/groovy/menu.groovy
@@ -103,7 +103,7 @@ def processMap(def originalEntries, String prefix, def map, boolean skipIndex) {
                 def index = originalEntries.find {it.uri == prefix + entry.key + '/index.html'}
                 if(index != null) {
                     candidate = index;
-                    if(candidate.order == 0) {
+                    if(candidate.order == -987654321) {
                         String t = entry.key;
                         def matcher = t =~ /^([0-9]+)_(.*)$/
                         if(matcher.matches()) {
@@ -113,7 +113,7 @@ def processMap(def originalEntries, String prefix, def map, boolean skipIndex) {
                     }
                 } else {
                     String t = entry.key;
-                    Integer o = null
+                    Integer o = -1
                     def matcher = t =~ /^([0-9]+)_(.*)$/
                     if(matcher.matches()) {
                         o = matcher.group(1) as Integer
@@ -146,7 +146,7 @@ def Map<String, ?> asTree(List<List<String>> list) {
 }
 
 def String findFirstUri(def entries) {
-    def indexEntry = entries.find { it.order == 0 }
+    def indexEntry = entries.find { it.order == -987654321 }
     if(indexEntry && indexEntry.uri) {
         return indexEntry.uri
     }

--- a/src/site/groovy/menu.groovy
+++ b/src/site/groovy/menu.groovy
@@ -10,7 +10,7 @@ try {
             //push all page info to the menu map
             menu[page['jbake-menu']] << [
                 title: page['jbake-title'],
-                order: page['jbake-order'],
+                order: page['jbake-order'] as Integer,
                 filename: page['filename'],
                 uri: page['uri'],
                 children: []
@@ -103,20 +103,20 @@ def processMap(def originalEntries, String prefix, def map, boolean skipIndex) {
                 def index = originalEntries.find {it.uri == prefix + entry.key + '/index.html'}
                 if(index != null) {
                     candidate = index;
-                    if(candidate.order == '0') {
-                        def t = entry.key;
+                    if(candidate.order == 0) {
+                        String t = entry.key;
                         def matcher = t =~ /^([0-9]+)_(.*)$/
                         if(matcher.matches()) {
-                            def o = matcher.group(1)
+                            Integer o = matcher.group(1) as Integer
                             candidate.order = o
                         }
                     }
                 } else {
-                    def t = entry.key;
-                    def o = null
+                    String t = entry.key;
+                    Integer o = null
                     def matcher = t =~ /^([0-9]+)_(.*)$/
                     if(matcher.matches()) {
-                        o = matcher.group(1)
+                        o = matcher.group(1) as Integer
                         t = matcher.group(2)
                     }
                     candidate = [
@@ -146,11 +146,11 @@ def Map<String, ?> asTree(List<List<String>> list) {
 }
 
 def String findFirstUri(def entries) {
-    def indexEntry = entries.find { it.order == '0' }
+    def indexEntry = entries.find { it.order == 0 }
     if(indexEntry && indexEntry.uri) {
         return indexEntry.uri
     }
-    def firstEntry = entries.sort { a, b -> a.order as Integer <=> b.order as Integer ?: a.title <=> b.title }[0]
+    def firstEntry = entries.sort { a, b -> a.order <=> b.order ?: a.title <=> b.title }[0]
     if (firstEntry) {
         if(firstEntry.uri) {
             return firstEntry.uri

--- a/src/site/templates/submenu.gsp
+++ b/src/site/templates/submenu.gsp
@@ -10,7 +10,7 @@
             String htmlClass = (index == 0) ? 'td-sidebar-nav__section pr-md-3 ' : '';
             result = result + """
                         <ul class="${htmlClass}ul-$index">"""
-            entries?.sort{a, b ->a.order as Integer <=> b.order as Integer ?: a.title <=> b.title }.each { entry ->
+            entries?.sort{a, b ->a.order <=> b.order ?: a.title <=> b.title }.each { entry ->
                 def hasChild = (entry.children) ? 'with-child' : 'without-child'
                 def isActive = (c.uri==entry.uri) ? 'active' : ''
                 result = result + """

--- a/src/test/groovy/site/MenuSpec.groovy
+++ b/src/test/groovy/site/MenuSpec.groovy
@@ -110,7 +110,7 @@ class MenuSpec extends Specification {
                 ['jbake-menu': 'foo', 'jbake-title': 'Lorem Ipsum', 'jbake-order': '10', uri : 'foo/10_lorem-ipsum.html'],
                 ['jbake-menu': 'foo', 'jbake-title': 'Section kaz', 'jbake-order': '35', uri : 'foo/kaz/index.html'], // simulate a ':jbake-order: 35' present in the page
                 ['jbake-menu': 'foo', 'jbake-title': 'Kaz Page', 'jbake-order': '100', uri : 'foo/kaz/100_page.html'],
-                ['jbake-menu': 'foo', 'jbake-title': 'Section bar', 'jbake-order': '0', uri : 'foo/22_bar/index.html'], // simulate no ':jbake-order:' attribute present in the page
+                ['jbake-menu': 'foo', 'jbake-title': 'Section bar', 'jbake-order': '-987654321', uri : 'foo/22_bar/index.html'], // simulate no ':jbake-order:' attribute present in the page
                 ['jbake-menu': 'foo', 'jbake-title': 'Adipiscing elit', 'jbake-order': '10', uri : 'foo/22_bar/10_adipiscing_elit.html'],
                 ['jbake-menu': 'foo', 'jbake-title': 'Dolor sit amet', 'jbake-order': '20', uri : 'foo/22_bar/20_dolor_sit_amet.html']
             ]
@@ -169,7 +169,7 @@ class MenuSpec extends Specification {
 
             binding.content.menu == [
                 foo:[
-                    [title: 'bar', order: null, filename: null, uri: null, children: [
+                    [title: 'bar', order: -1, filename: null, uri: null, children: [
                             [title: 'Adipiscing elit', order: 10, filename: null, uri: 'foo/bar/10_adipiscing_elit.html', children:[]],
                             [title: 'Dolor sit amet', order: 100, filename: null, uri: 'foo/bar/100_dolor_sit_amet.html', children:[]]
                         ]
@@ -186,7 +186,7 @@ class MenuSpec extends Specification {
 
             binding.content.entriesMap ==  [
                 foo:[ 'My Title', [
-                        [title: 'bar', order: null, filename: null, uri: null, children: [
+                        [title: 'bar', order: -1, filename: null, uri: null, children: [
                                 [title: 'Adipiscing elit', order: 10, filename: null, uri: 'foo/bar/10_adipiscing_elit.html', children:[]],
                                 [title: 'Dolor sit amet', order: 100, filename: null, uri: 'foo/bar/100_dolor_sit_amet.html', children:[]]
                             ]
@@ -213,7 +213,7 @@ class MenuSpec extends Specification {
             binding.config = [site_menu: [foo: 'Some FOO']]
             binding.published_content = [
                 // Simulate no 'jbake-order' defined in the pages:
-                ['jbake-menu': 'foo', 'jbake-title': 'Lorem Ipsum', 'jbake-order': '0', uri : 'foo/index.html'],
+                ['jbake-menu': 'foo', 'jbake-title': 'Lorem Ipsum', 'jbake-order': '-987654321', uri : 'foo/index.html'],
                 ['jbake-menu': 'foo', 'jbake-title': 'Dolor sit amet', 'jbake-order': '-1', uri : 'foo/page.html']
             ]
         when: 'run the `menu.groovy` script'
@@ -221,13 +221,13 @@ class MenuSpec extends Specification {
         then: 'arrays are computed'
             binding.content.menu == [
                 foo:[
-                    [title: 'Lorem Ipsum', order: 0, filename: null, uri: 'foo/index.html', children:[]],
+                    [title: 'Lorem Ipsum', order: -987654321, filename: null, uri: 'foo/index.html', children:[]],
                     [title: 'Dolor sit amet', order: -1, filename: null, uri: 'foo/page.html', children:[]]
                 ]
             ]
             binding.content.entriesMap ==  [
                 foo:[ 'Some FOO', [
-                        [title: 'Lorem Ipsum', order: 0, filename: null, uri: 'foo/index.html', children:[]],
+                        [title: 'Lorem Ipsum', order: -987654321, filename: null, uri: 'foo/index.html', children:[]],
                         [title: 'Dolor sit amet', order: -1, filename: null, uri: 'foo/page.html', children:[]]
                     ]
                 ]
@@ -252,12 +252,12 @@ class MenuSpec extends Specification {
         then: 'arrays are computed'
             binding.content.menu == [
                 p:[
-                    [title: 'x', order: null, filename: null, uri: null, children: [
+                    [title: 'x', order: -1, filename: null, uri: null, children: [
                             [title: 'A', order: 10, filename: null, uri: 'p/x/a.html', children:[]],
                             [title: 'B', order: 10, filename: null, uri: 'p/x/b.html', children:[]]
                         ]
                     ],
-                    [title: 'y', order: null, filename: null, uri: null, children: [
+                    [title: 'y', order: -1, filename: null, uri: null, children: [
                             [title: 'C', order: 10, filename: null, uri: 'p/y/c.html', children:[]],
                             [title: 'D', order: 10, filename: null, uri: 'p/y/d.html', children:[]]
                         ]
@@ -266,12 +266,12 @@ class MenuSpec extends Specification {
             ]
             binding.content.entriesMap ==  [
                 p:[ 'My pages', [
-                        [title: 'x', order: null, filename: null, uri: null, children: [
+                        [title: 'x', order: -1, filename: null, uri: null, children: [
                                 [title: 'A', order: 10, filename: null, uri: 'p/x/a.html', children:[]],
                                 [title: 'B', order: 10, filename: null, uri: 'p/x/b.html', children:[]]
                             ]
                         ],
-                        [title: 'y', order: null, filename: null, uri: null, children: [
+                        [title: 'y', order: -1, filename: null, uri: null, children: [
                                 [title: 'C', order: 10, filename: null, uri: 'p/y/c.html', children:[]],
                                 [title: 'D', order: 10, filename: null, uri: 'p/y/d.html', children:[]]
                             ]

--- a/src/test/groovy/site/MenuSpec.groovy
+++ b/src/test/groovy/site/MenuSpec.groovy
@@ -40,21 +40,21 @@ class MenuSpec extends Specification {
         then: 'arrays are computed'
             binding.content.menu == [
                 foo:[
-                    [title: 'Lorem Ipsum', order: '10', filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
-                    [title: 'Dolor sit amet', order: '20', filename: null, uri: 'foo/20_dolor_sit_amet.html', children:[]]
+                    [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
+                    [title: 'Dolor sit amet', order: 20, filename: null, uri: 'foo/20_dolor_sit_amet.html', children:[]]
                 ],
                 bar:[
-                    [title: 'Adipiscing elit', order: '10', filename: null, uri: 'bar/10_adipiscing_elit.html', children:[]]
+                    [title: 'Adipiscing elit', order: 10, filename: null, uri: 'bar/10_adipiscing_elit.html', children:[]]
                 ]
             ]
             binding.content.entriesMap ==  [
                 foo:[ 'foo', [
-                        [title: 'Lorem Ipsum', order: '10', filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
-                        [title: 'Dolor sit amet', order: '20', filename: null, uri: 'foo/20_dolor_sit_amet.html', children:[]]
+                        [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
+                        [title: 'Dolor sit amet', order: 20, filename: null, uri: 'foo/20_dolor_sit_amet.html', children:[]]
                     ]
                 ],
                 bar:[ 'bar', [
-                        [title: 'Adipiscing elit', order: '10', filename: null, uri: 'bar/10_adipiscing_elit.html', children:[]]
+                        [title: 'Adipiscing elit', order: 10, filename: null, uri: 'bar/10_adipiscing_elit.html', children:[]]
                     ]
                 ]
             ]
@@ -78,21 +78,21 @@ class MenuSpec extends Specification {
         then: 'arrays are computed'
             binding.content.menu == [
                 code1:[
-                    [title: 'Lorem Ipsum', order: '10', filename: null, uri: 'pages/10_lorem-ipsum.html', children:[]],
-                    [title: 'Dolor sit amet', order: '20', filename: null, uri: 'pages/20_dolor_sit_amet.html', children:[]]
+                    [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'pages/10_lorem-ipsum.html', children:[]],
+                    [title: 'Dolor sit amet', order: 20, filename: null, uri: 'pages/20_dolor_sit_amet.html', children:[]]
                 ],
                 code2:[
-                    [title: 'Adipiscing elit', order: '30', filename: null, uri: 'pages/30_adipiscing_elit.html', children:[]]
+                    [title: 'Adipiscing elit', order: 30, filename: null, uri: 'pages/30_adipiscing_elit.html', children:[]]
                 ]
             ]
             binding.content.entriesMap ==  [
                 code1:[ 'title1', [
-                        [title: 'Lorem Ipsum', order: '10', filename: null, uri: 'pages/10_lorem-ipsum.html', children:[]],
-                        [title: 'Dolor sit amet', order: '20', filename: null, uri: 'pages/20_dolor_sit_amet.html', children:[]]
+                        [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'pages/10_lorem-ipsum.html', children:[]],
+                        [title: 'Dolor sit amet', order: 20, filename: null, uri: 'pages/20_dolor_sit_amet.html', children:[]]
                     ]
                 ],
                 code2:[ 'title2', [
-                        [title: 'Adipiscing elit', order: '30', filename: null, uri: 'pages/30_adipiscing_elit.html', children:[]]
+                        [title: 'Adipiscing elit', order: 30, filename: null, uri: 'pages/30_adipiscing_elit.html', children:[]]
                     ]
                 ]
             ]
@@ -119,28 +119,28 @@ class MenuSpec extends Specification {
         then: 'arrays are computed'
             binding.content.menu == [
                 foo:[
-                    [title: 'Lorem Ipsum', order: '10', filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
-                    [title: 'Section bar', order: '22', filename: null, uri: 'foo/22_bar/index.html', children: [
-                            [title: 'Adipiscing elit', order: '10', filename: null, uri: 'foo/22_bar/10_adipiscing_elit.html', children:[]],
-                            [title: 'Dolor sit amet', order: '20', filename: null, uri: 'foo/22_bar/20_dolor_sit_amet.html', children:[]]
+                    [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
+                    [title: 'Section bar', order: 22, filename: null, uri: 'foo/22_bar/index.html', children: [
+                            [title: 'Adipiscing elit', order: 10, filename: null, uri: 'foo/22_bar/10_adipiscing_elit.html', children:[]],
+                            [title: 'Dolor sit amet', order: 20, filename: null, uri: 'foo/22_bar/20_dolor_sit_amet.html', children:[]]
                         ]
                     ],
-                    [title: 'Section kaz', order: '35', filename: null, uri: 'foo/kaz/index.html', children: [
-                            [title: 'Kaz Page', order: '100', filename: null, uri: 'foo/kaz/100_page.html', children:[]]
+                    [title: 'Section kaz', order: 35, filename: null, uri: 'foo/kaz/index.html', children: [
+                            [title: 'Kaz Page', order: 100, filename: null, uri: 'foo/kaz/100_page.html', children:[]]
                         ]
                     ]
                 ]
             ]
             binding.content.entriesMap ==  [
                 foo:[ 'foo', [
-                        [title: 'Lorem Ipsum', order: '10', filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
-                        [title: 'Section bar', order: '22', filename: null, uri: 'foo/22_bar/index.html', children: [
-                                [title: 'Adipiscing elit', order: '10', filename: null, uri: 'foo/22_bar/10_adipiscing_elit.html', children:[]],
-                                [title: 'Dolor sit amet', order: '20', filename: null, uri: 'foo/22_bar/20_dolor_sit_amet.html', children:[]]
+                        [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
+                        [title: 'Section bar', order: 22, filename: null, uri: 'foo/22_bar/index.html', children: [
+                                [title: 'Adipiscing elit', order: 10, filename: null, uri: 'foo/22_bar/10_adipiscing_elit.html', children:[]],
+                                [title: 'Dolor sit amet', order: 20, filename: null, uri: 'foo/22_bar/20_dolor_sit_amet.html', children:[]]
                             ]
                         ],
-                        [title: 'Section kaz', order: '35', filename: null, uri: 'foo/kaz/index.html', children: [
-                                [title: 'Kaz Page', order: '100', filename: null, uri: 'foo/kaz/100_page.html', children:[]]
+                        [title: 'Section kaz', order: 35, filename: null, uri: 'foo/kaz/index.html', children: [
+                                [title: 'Kaz Page', order: 100, filename: null, uri: 'foo/kaz/100_page.html', children:[]]
                             ]
                         ]
                     ]
@@ -166,18 +166,19 @@ class MenuSpec extends Specification {
         when: 'run the `menu.groovy` script'
             runMenuScript(binding)
         then: 'arrays are computed'
+
             binding.content.menu == [
                 foo:[
                     [title: 'bar', order: null, filename: null, uri: null, children: [
-                            [title: 'Adipiscing elit', order: '10', filename: null, uri: 'foo/bar/10_adipiscing_elit.html', children:[]],
-                            [title: 'Dolor sit amet', order: '100', filename: null, uri: 'foo/bar/100_dolor_sit_amet.html', children:[]]
+                            [title: 'Adipiscing elit', order: 10, filename: null, uri: 'foo/bar/10_adipiscing_elit.html', children:[]],
+                            [title: 'Dolor sit amet', order: 100, filename: null, uri: 'foo/bar/100_dolor_sit_amet.html', children:[]]
                         ]
                     ],
-                    [title: 'Lorem Ipsum', order: '10', filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
-                    [title: 'baz', order: '30', filename: null, uri: null, children: [
-                            [title: 'One', order: '10', filename: null, uri: 'foo/30_baz/10_one.html', children:[]],
-                            [title: 'Two', order: '20', filename: null, uri: 'foo/30_baz/20_two.html', children:[]],
-                            [title: 'Three', order: '30', filename: null, uri: 'foo/30_baz/30_three.html', children:[]]
+                    [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
+                    [title: 'baz', order: 30, filename: null, uri: null, children: [
+                            [title: 'One', order: 10, filename: null, uri: 'foo/30_baz/10_one.html', children:[]],
+                            [title: 'Two', order: 20, filename: null, uri: 'foo/30_baz/20_two.html', children:[]],
+                            [title: 'Three', order: 30, filename: null, uri: 'foo/30_baz/30_three.html', children:[]]
                         ]
                     ]
                 ]
@@ -186,15 +187,15 @@ class MenuSpec extends Specification {
             binding.content.entriesMap ==  [
                 foo:[ 'My Title', [
                         [title: 'bar', order: null, filename: null, uri: null, children: [
-                                [title: 'Adipiscing elit', order: '10', filename: null, uri: 'foo/bar/10_adipiscing_elit.html', children:[]],
-                                [title: 'Dolor sit amet', order: '100', filename: null, uri: 'foo/bar/100_dolor_sit_amet.html', children:[]]
+                                [title: 'Adipiscing elit', order: 10, filename: null, uri: 'foo/bar/10_adipiscing_elit.html', children:[]],
+                                [title: 'Dolor sit amet', order: 100, filename: null, uri: 'foo/bar/100_dolor_sit_amet.html', children:[]]
                             ]
                         ],
-                        [title: 'Lorem Ipsum', order: '10', filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
-                        [title: 'baz', order: '30', filename: null, uri: null, children: [
-                                [title: 'One', order: '10', filename: null, uri: 'foo/30_baz/10_one.html', children:[]],
-                                [title: 'Two', order: '20', filename: null, uri: 'foo/30_baz/20_two.html', children:[]],
-                                [title: 'Three', order: '30', filename: null, uri: 'foo/30_baz/30_three.html', children:[]]
+                        [title: 'Lorem Ipsum', order: 10, filename: null, uri: 'foo/10_lorem-ipsum.html', children:[]],
+                        [title: 'baz', order: 30, filename: null, uri: null, children: [
+                                [title: 'One', order: 10, filename: null, uri: 'foo/30_baz/10_one.html', children:[]],
+                                [title: 'Two', order: 20, filename: null, uri: 'foo/30_baz/20_two.html', children:[]],
+                                [title: 'Three', order: 30, filename: null, uri: 'foo/30_baz/30_three.html', children:[]]
                             ]
                         ]
                     ]
@@ -220,14 +221,14 @@ class MenuSpec extends Specification {
         then: 'arrays are computed'
             binding.content.menu == [
                 foo:[
-                    [title: 'Lorem Ipsum', order: '0', filename: null, uri: 'foo/index.html', children:[]],
-                    [title: 'Dolor sit amet', order: '-1', filename: null, uri: 'foo/page.html', children:[]]
+                    [title: 'Lorem Ipsum', order: 0, filename: null, uri: 'foo/index.html', children:[]],
+                    [title: 'Dolor sit amet', order: -1, filename: null, uri: 'foo/page.html', children:[]]
                 ]
             ]
             binding.content.entriesMap ==  [
                 foo:[ 'Some FOO', [
-                        [title: 'Lorem Ipsum', order: '0', filename: null, uri: 'foo/index.html', children:[]],
-                        [title: 'Dolor sit amet', order: '-1', filename: null, uri: 'foo/page.html', children:[]]
+                        [title: 'Lorem Ipsum', order: 0, filename: null, uri: 'foo/index.html', children:[]],
+                        [title: 'Dolor sit amet', order: -1, filename: null, uri: 'foo/page.html', children:[]]
                     ]
                 ]
             ]
@@ -252,13 +253,13 @@ class MenuSpec extends Specification {
             binding.content.menu == [
                 p:[
                     [title: 'x', order: null, filename: null, uri: null, children: [
-                            [title: 'A', order: '10', filename: null, uri: 'p/x/a.html', children:[]],
-                            [title: 'B', order: '10', filename: null, uri: 'p/x/b.html', children:[]]
+                            [title: 'A', order: 10, filename: null, uri: 'p/x/a.html', children:[]],
+                            [title: 'B', order: 10, filename: null, uri: 'p/x/b.html', children:[]]
                         ]
                     ],
                     [title: 'y', order: null, filename: null, uri: null, children: [
-                            [title: 'C', order: '10', filename: null, uri: 'p/y/c.html', children:[]],
-                            [title: 'D', order: '10', filename: null, uri: 'p/y/d.html', children:[]]
+                            [title: 'C', order: 10, filename: null, uri: 'p/y/c.html', children:[]],
+                            [title: 'D', order: 10, filename: null, uri: 'p/y/d.html', children:[]]
                         ]
                     ]
                 ]
@@ -266,13 +267,13 @@ class MenuSpec extends Specification {
             binding.content.entriesMap ==  [
                 p:[ 'My pages', [
                         [title: 'x', order: null, filename: null, uri: null, children: [
-                                [title: 'A', order: '10', filename: null, uri: 'p/x/a.html', children:[]],
-                                [title: 'B', order: '10', filename: null, uri: 'p/x/b.html', children:[]]
+                                [title: 'A', order: 10, filename: null, uri: 'p/x/a.html', children:[]],
+                                [title: 'B', order: 10, filename: null, uri: 'p/x/b.html', children:[]]
                             ]
                         ],
                         [title: 'y', order: null, filename: null, uri: null, children: [
-                                [title: 'C', order: '10', filename: null, uri: 'p/y/c.html', children:[]],
-                                [title: 'D', order: '10', filename: null, uri: 'p/y/d.html', children:[]]
+                                [title: 'C', order: 10, filename: null, uri: 'p/y/c.html', children:[]],
+                                [title: 'D', order: 10, filename: null, uri: 'p/y/d.html', children:[]]
                             ]
                         ]
                     ]


### PR DESCRIPTION
Fixes: #873. Change the default value of the index page when no order is defined.

Impact on the docToolchain docs: the index page in the "news" section should be at the top.

The Netlify preview is not correct due to #876.

### All Submissions:

* [X] Did you update the `changelog.adoc`?
* [X] Does your PR affect the documentation?
