### PR TITLE
Add ability to upload documentation into one Confluence page

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -85,7 +85,7 @@ confluence.with {
     ]
 
     // endpoint of the confluenceAPI (REST) to be used
-    // verfiy that you got the correct endpoint by browsing to 
+    // verfiy that you got the correct endpoint by browsing to
     // https://[yourServer]/[context]/rest/api/user/current
     // you should get a valid json which describes your current user
     // a working example is https://arc42-template.atlassian.net/wiki/rest/api/user/current
@@ -98,6 +98,10 @@ confluence.with {
 
     // the title of the page containing the preamble (everything the first second level heading). Default is 'arc42'
     preambleTitle = ''
+
+    // variable to determine whether the whole document should be uploaded as just one page or split into separate
+    // pages per chapter
+    allInOnePage = false
 
     // variable to determine whether ".sect2" sections shall be split from the current page into subpages
     createSubpages = false

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -66,6 +66,7 @@ def allPages
 
 def confluenceSpaceKey
 def confluenceCreateSubpages
+def confluenceAllInOnePage
 def confluencePagePrefix
 def baseApiPath = new URI(config.confluence.api).path
 // helper functions
@@ -189,13 +190,13 @@ def uploadAttachment = { def pageId, String url, String fileName, String note ->
         }
     } else {
         http = new HTTPBuilder(config.confluence.api + 'content/' + pageId + '/child/attachment')
-        
+
     }
-    if (http) {																												
+    if (http) {
 		if (config.confluence.proxy) {
             http.setProxy(config.confluence.proxy.host, config.confluence.proxy.port, config.confluence.proxy.schema ?: 'http')
-        } 
-		
+        }
+
         http.request(Method.POST) { req ->
             requestContentType: "multipart/form-data"
             MultipartEntity multiPartContent = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE)
@@ -374,7 +375,7 @@ def rewriteJiraLinks = { body ->
     // find links to jira tickets and replace them with jira macros
     body.select('a[href]').each { a ->
         def href = a.attr('href')
-        if (href.startsWith(config.jira.api + "/browse/")) { 
+        if (href.startsWith(config.jira.api + "/browse/")) {
                 def ticketId = a.text()
                 a.before("""<ac:structured-macro ac:name=\"jira\" ac:schema-version=\"1\">
                      <ac:parameter ac:name=\"key\">${ticketId}</ac:parameter>
@@ -795,14 +796,14 @@ def getHeaders(){
     if(config.confluence.bearerToken){
         headers = [
                 'Authorization': 'Bearer ' + config.confluence.bearerToken,
-                'X-Atlassian-Token':'no-check'            
-        ]         
-         println 'Start using bearer auth'     
+                'X-Atlassian-Token':'no-check'
+        ]
+         println 'Start using bearer auth'
     } else {
         headers = [
                 'Authorization': 'Basic ' + config.confluence.credentials,
                 'X-Atlassian-Token':'no-check'
-        ]     
+        ]
         //Add api key and value to REST API request header if configured - required for authentification.
         if (config.confluence.apikey){
             headers.keyid = config.confluence.apikey
@@ -815,7 +816,7 @@ if(config.confluence.inputHtmlFolder) {
     htmlFolder = "${docDir}/${config.confluence.inputHtmlFolder}"
     println "Starting processing files in folder: " + config.confluence.inputHtmlFolder
     def dir = new File(htmlFolder)
-    
+
     dir.eachFileRecurse (FILES) { fileName ->
         if (fileName.isFile()){
             def map = [file: config.confluence.inputHtmlFolder+fileName.getName()]
@@ -839,6 +840,12 @@ config.confluence.input.each { input ->
     //  assignend, but never used in pushToConfluence(...) (fixed here)
         confluenceSpaceKey = input.spaceKey ?: config.confluence.spaceKey
         confluenceCreateSubpages = (input.createSubpages != null) ? input.createSubpages : config.confluence.createSubpages
+        confluenceAllInOnePage = (input.allInOnePage != null) ? input.allInOnePage : config.confluence.allInOnePage
+        if (confluenceAllInOnePage && confluenceCreateSubpages) {
+            println "ERROR:"
+            println "Conflicting config: One one of confluenceAllInOnePage or confluenceCreateSubpages can be true."
+            throw new RuntimeException("config problem")
+        }
     //  hard to read in case of using :sectnums: -> so we add a suffix
         confluencePagePrefix = input.pagePrefix ?: config.confluence.pagePrefix
     //  added
@@ -879,54 +886,68 @@ config.confluence.input.each { input ->
             }
             println "Keywords:" + keywords
         }
-        // let's try to select the "first page" and push it to confluence
-        dom.select('div#preamble div.sectionbody').each { pageBody ->
-            pageBody.select('div.sect2').unwrap()
-            def preamble = [
-                title: confluencePreambleTitle ?: "arc42",
-                body: pageBody,
-                children: [],
-                parent: parentId
-            ]
-            pages << preamble
-            sections = preamble.children
-            parentId = null
-            anchors.putAll(parseAnchors(preamble))
-        }
-        // <div class="sect1"> are the main headings
-        // let's extract these
-        dom.select('div.sect1').each { sect1 ->
-            Elements pageBody = sect1.select('div.sectionbody')
-            def currentPage = [
-                title: sect1.select('h2').text(),
-                body: pageBody,
-                children: [],
-                parent: parentId
-            ]
-            pageAnchors.putAll(recordPageAnchor(sect1.select('h2')))
-
-            if (confluenceCreateSubpages) {
-                pageBody.select('div.sect2').each { sect2 ->
-                    def title = sect2.select('h3').text()
-                    pageAnchors.putAll(recordPageAnchor(sect2.select('h3')))
-                    sect2.select('h3').remove()
-                    def body = Jsoup.parse(sect2.toString(),'utf-8', Parser.xmlParser())
-                    body.outputSettings(new Document.OutputSettings().prettyPrint(false))
-                    def subPage = [
-                        title: title,
-                        body: body
-                    ]
-                    currentPage.children << subPage
-                    promoteHeaders sect2, 4, 3
-                    anchors.putAll(parseAnchors(subPage))
-                }
-                pageBody.select('div.sect2').remove()
-            } else {
+        if (confluenceAllInOnePage) {
+            dom.select('div#content').each { pageBody ->
                 pageBody.select('div.sect2').unwrap()
-                promoteHeaders sect1, 3, 2
+                def page = [title   : confluencePreambleTitle ?: "arc42",
+                            body    : pageBody,
+                            children: [],
+                            parent  : parentId]
+                pages << page
+                sections = page.children
+                parentId = null
+                anchors.putAll(parseAnchors(page))
             }
-            sections << currentPage
-            anchors.putAll(parseAnchors(currentPage))
+        } else {
+            // let's try to select the "first page" and push it to confluence
+            dom.select('div#preamble div.sectionbody').each { pageBody ->
+                pageBody.select('div.sect2').unwrap()
+                def preamble = [
+                    title: confluencePreambleTitle ?: "arc42",
+                    body: pageBody,
+                    children: [],
+                    parent: parentId
+                ]
+                pages << preamble
+                sections = preamble.children
+                parentId = null
+                anchors.putAll(parseAnchors(preamble))
+            }
+            // <div class="sect1"> are the main headings
+            // let's extract these
+            dom.select('div.sect1').each { sect1 ->
+                Elements pageBody = sect1.select('div.sectionbody')
+                def currentPage = [
+                    title: sect1.select('h2').text(),
+                    body: pageBody,
+                    children: [],
+                    parent: parentId
+                ]
+                pageAnchors.putAll(recordPageAnchor(sect1.select('h2')))
+
+                if (confluenceCreateSubpages) {
+                    pageBody.select('div.sect2').each { sect2 ->
+                        def title = sect2.select('h3').text()
+                        pageAnchors.putAll(recordPageAnchor(sect2.select('h3')))
+                        sect2.select('h3').remove()
+                        def body = Jsoup.parse(sect2.toString(),'utf-8', Parser.xmlParser())
+                        body.outputSettings(new Document.OutputSettings().prettyPrint(false))
+                        def subPage = [
+                            title: title,
+                            body: body
+                        ]
+                        currentPage.children << subPage
+                        promoteHeaders sect2, 4, 3
+                        anchors.putAll(parseAnchors(subPage))
+                    }
+                    pageBody.select('div.sect2').remove()
+                } else {
+                    pageBody.select('div.sect2').unwrap()
+                    promoteHeaders sect1, 3, 2
+                }
+                sections << currentPage
+                anchors.putAll(parseAnchors(currentPage))
+            }
         }
 
         pushPages pages, anchors, pageAnchors, keywords

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -71,5 +71,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/schowave[David Schowalter]
 - https://github.com/devMaFi[Martin Fischer]
 - https://github.com/wonderbird[Stefan Boos]
+- https://github.com/adrpar[Adrian Partl]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -164,6 +164,8 @@ to configure a different parent page for each file.
 The following four keys can also be used in the global section below
 
 - `spaceKey` (optional): page specific variable for the key of the confluence space to write to
+- 'allInOnePage' (optional): page specific variable to determine whether documentation is written to just one
+                             Confluence page or separate ones per chapter (default)
 - `createSubpages` (optional): page specific variable to determine whether ".sect2" sections shall be split from the current page into subpages
 - `pagePrefix` (optional): page specific variable, the pagePrefix will be a prefix for the page title and it's sub-pages
                            use this if you only have access to one confluence space but need to store several
@@ -194,6 +196,10 @@ confluence.with {
 
     // the title of the page containing the preamble (everything the first second level heading). Default is 'arc42'
     preambleTitle = ''
+
+    // variable to determine whether the whole document should be uploaded as just one page or split into separate
+    // pages per chapter
+    allInOnePage = false
 
     // variable to determine whether ".sect2" sections shall be split from the current page into subpages
     createSubpages = false


### PR DESCRIPTION
First let me thank you all for creating this awesome tool!
I would like to add the following small feature to the code base:

`publishToConfluence` creates a separate Confluence page per level 1 section / chapter.

However I have the use case where the whole documentation should be rendered into just one Confluence page.

I created a new option that enables users to upload the generated documentation into just one Confluence page.

### All Submissions:

* [ ] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

### Your first submission

* [x] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [x] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
