### PR TITLE
Remove redundant sentence with broken link

### DIFF
--- a/src/docs/10_about/20_what-is-doctoolchain.adoc
+++ b/src/docs/10_about/20_what-is-doctoolchain.adoc
@@ -7,7 +7,7 @@ include::_config.adoc[]
 include::../_feedback.adoc[]
 
 === Introduction
-https://github.com/docToolchain/docToolchain[docToolchain] is a documentation generation tool that uses the https://www.writethedocs.org/guide/docs-as-code/[Docs as Code] approach as a basis for its architecture, plus some additional automation provided by the https://arc42.org[arc42 template]. Learn all about the project <link to About the Project page>[here].
+https://github.com/docToolchain/docToolchain[docToolchain] is a documentation generation tool that uses the https://www.writethedocs.org/guide/docs-as-code/[Docs as Code] approach as a basis for its architecture, plus some additional automation provided by the https://arc42.org[arc42 template].
 
 === Docs as Code
 ‘Docs as code’ refers to a philosophy that you should write documentation using the same tools as you use to write code. If you need to write technical docs for your software project, why not use the same tools and processes as you use for your source code? There are so many benefits:


### PR DESCRIPTION
### All Submissions:

* [ ] Did you update the `changelog.adoc`?
* [X] Does your PR affect the documentation?
* [X] If yes, did you update the documentation or create an issue for updating it?

Originally, I wanted to fix the link but the sentence makes no sense, regardless. You're already in the "about" section when you read this; so linking back to the top page makes little sense.
