### PR TITLE
Improve robustness of confluence ancestorId configuration

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -11,6 +11,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 * fixed ExportMarkdownSpec
 * fixed GenerateDeckSpec
+* allow numeric ancestorIds for confluence export
 
 === added
 

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -668,7 +668,8 @@ def parseBody =  { body, anchors, pageAnchors ->
 
 // the create-or-update functionality for confluence pages
 // #342-dierk42: added parameter 'keywords'
-def pushToConfluence = { pageTitle, pageBody, String parentId, anchors, pageAnchors, keywords ->
+def pushToConfluence = { pageTitle, pageBody, parentId, anchors, pageAnchors, keywords ->
+    parentId = parentId.toString()
     def api = new RESTClient(config.confluence.api)
     def headers = getHeaders()
     String realTitleLC = realTitle(pageTitle).toLowerCase()

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -72,5 +72,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/devMaFi[Martin Fischer]
 - https://github.com/wonderbird[Stefan Boos]
 - https://github.com/adrpar[Adrian Partl]
+- https://github.com/bjkastel[Bjoern Kasteleiner]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
Configuring the confluence ancestorId as integer resulted in a "No signature of method" failure.
This change allows to enter an numeric ancestorId within the configuration of the confluence export.

### All Submissions:

* [X] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [X] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [X] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
