### PR TITLE
Improve DTC_PROJECT_BRANCH management

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -12,6 +12,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * fixed ExportMarkdownSpec
 * fixed GenerateDeckSpec
 * allow numeric ancestorIds for confluence export
+* https://github.com/docToolchain/docToolchain/pull/951[#951 Improve DTC_PROJECT_BRANCH management]
 
 === added
 

--- a/dtcw
+++ b/dtcw
@@ -16,7 +16,9 @@ MAIN_CONFIG_FILE=docToolchainConfig.groovy
 VERSION=2.1.0
 
 DISTRIBUTION_URL=https://github.com/docToolchain/docToolchain/releases/download/v${VERSION}/docToolchain-${VERSION}.zip
-export DTC_PROJECT_BRANCH=$(git branch --show-current)
+if [ -z "$DTC_PROJECT_BRANCH" ]; then
+    export DTC_PROJECT_BRANCH=$(git branch --show-current)
+fi
 
 DTC_HEADLESS=${DTC_HEADLESS:="false"}
 if [ -t 0 ]; then
@@ -351,7 +353,7 @@ else
           else
               pwd=$PWD
           fi
-          command="'$docker_cmd' run -u $(id -u):$(id -g) --name doctoolchain${version} -e DTC_HEADLESS=1 -e DTC_SITETHEME -p 8042:8042 --rm -i --entrypoint /bin/bash -v '${pwd}:/project' doctoolchain/doctoolchain:v${VERSION} -c \"doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 $DTC_OPTS && exit\""
+          command="'$docker_cmd' run -u $(id -u):$(id -g) --name doctoolchain${version} -e DTC_HEADLESS=1 -e DTC_SITETHEME -e DTC_PROJECT_BRANCH=$DTC_PROJECT_BRANCH -p 8042:8042 --rm -i --entrypoint /bin/bash -v '${pwd}:/project' doctoolchain/doctoolchain:v${VERSION} -c \"doctoolchain . $1 $2 $3 $4 $5 $6 $7 $8 $9 $DTC_OPTS && exit\""
           doJavaCheck=false
 	  echo "use docker installation"
       else


### PR DESCRIPTION
Fixes #950

* This sets `DTC_PROJECT_BRANCH` only if it was not already set from an other process
* It propagates the `DTC_PROJECT_BRANCH` value to the process running inside docker.

* [x] Did you update the `changelog.adoc`?
