### PR TITLE
exportEAP.vbs - EA 16.1 bg process hangs (issue #991)

### DIFF
--- a/scripts/exportEAP.vbs
+++ b/scripts/exportEAP.vbs
@@ -387,7 +387,13 @@
       End If
       EAapp.Repository.CloseFile()
       ' Since EA 15.2 the Enterprise Architect background process hangs without calling Exit explicitly
-      EAapp.Repository.Exit()
+      EAapp.Repository.Exit()      
+      ' fix for EA 16.1 where Enterprise Architect background process hangs 
+      On Error Resume Next
+        EAapp.Repository.CloseFile()
+        EAapp.Repository.Exit()
+        EAapp.Repository = null
+      ' end fix EA 16.1
     End Sub
 
   Private connectionString


### PR DESCRIPTION
using dtc exportEAP, the EA 16.1 Enterprise Architect background process hangs. Calling Exit is not enough anymore.

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
