### PR TITLE
Update changelog.adoc

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -13,6 +13,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * fixed ExportMarkdownSpec
 * fixed GenerateDeckSpec
 * fixed GenerateDeck / Reveal.js
+* fixed exportEA hangs by EA v16.1 
 * allow numeric ancestorIds for confluence export
 * https://github.com/docToolchain/docToolchain/pull/951[#951 Improve DTC_PROJECT_BRANCH management]
 * https://github.com/docToolchain/docToolchain/issues/976[#976 dtcw shows a fatal error when not in git repository]


### PR DESCRIPTION
fixed exportEA hangs by EA v16.1 (fix #996, issue #991)

### All Submissions:

* [ ] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
