### PR TITLE
Run docker with --platform argument

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -374,7 +374,7 @@ else
           else
               pwd=${PWD}
           fi
-          command="'${docker_cmd}' run -u $(id -u):$(id -g) --name doctoolchain${version} -e DTC_HEADLESS=1 -e DTC_SITETHEME -e DTC_PROJECT_BRANCH=${DTC_PROJECT_BRANCH} -p 8042:8042 --rm -i --entrypoint /bin/bash -v '${pwd}:/project' doctoolchain/doctoolchain:v${DTC_VERSION} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
+          command="'${docker_cmd}' run --platform linux/amd64 -u $(id -u):$(id -g) --name doctoolchain${version} -e DTC_HEADLESS=1 -e DTC_SITETHEME -e DTC_PROJECT_BRANCH=${DTC_PROJECT_BRANCH} -p 8042:8042 --rm -i --entrypoint /bin/bash -v '${pwd}:/project' doctoolchain/doctoolchain:v${DTC_VERSION} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
           doJavaCheck=false
 	  echo "use docker installation"
       else


### PR DESCRIPTION
Hey, 
Adding the `--platform linux/amd64` argument to `docker run` within the script get's rid of an unecessary warning on arm systesm. This shouldn't influence running on other systems. 

On my Mac M1 running dtcw through `arch -x86_64 /bin/bash` resulted in frozen processes (could also be due to docker emulation). Running it through docker (`./dtcw docker ...`) worked fine however.


### All Submissions:

* [ ] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [x] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
