### PR TITLE
Add confluenceBearerToken property

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -23,6 +23,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === added
 
+* Add `confluenceBearerToken` property
 * rubyExtensions configuration
 * CZ as language for downloadTemplate
 * Enable to use a particular version of DTC from the wrapper by setting the environment variable 'DTC_VERSION' accordingly.
@@ -30,6 +31,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === changed
 
+* The `publishToConfluence` guide now contains 3 modes for authentication (username & password, username & API key, personal access token)
 * Improve confluence export performance when only ancestorIds are given
 * https://github.com/docToolchain/docToolchain/issues/937[#937 Confluence publish nested pages by heading]
 +

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -63,7 +63,7 @@ if (project.hasProperty('confluenceUser') && project.hasProperty('confluencePass
 }
 if (project.hasProperty('confluenceBearerToken')) {
     logger.info("Found passed Confluence bearerToken")
-    config.confluence.bearerToken = project.getProperty('bearerToken')
+    config.confluence.bearerToken = project.getProperty('confluenceBearerToken')
 }
 if (project.hasProperty('username') && project.hasProperty('password')) {
     logger.info("Found passed common Jira & Confluence credentials")

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -61,6 +61,10 @@ if (project.hasProperty('confluenceUser') && project.hasProperty('confluencePass
     logger.info("Found passed Confluence credentials")
     config.confluence.credentials = "${project.getProperty('confluenceUser')}:${project.getProperty('confluencePass')}".bytes.encodeBase64().toString()
 }
+if (project.hasProperty('confluenceBearerToken')) {
+    logger.info("Found passed Confluence bearerToken")
+    config.confluence.bearerToken = project.getProperty('bearerToken')
+}
 if (project.hasProperty('username') && project.hasProperty('password')) {
     logger.info("Found passed common Jira & Confluence credentials")
     config.jira.credentials = "${project.getProperty('username')}:${project.getProperty('password')}".bytes.encodeBase64().toString()

--- a/src/docs/015_tasks/03_task_publishToConfluence.adoc
+++ b/src/docs/015_tasks/03_task_publishToConfluence.adoc
@@ -110,6 +110,12 @@ The API-token cannot be added to the credentials because it's used for user and 
 Therefore the API-token can be added as parameter `apikey`, which makes the addition of the token a separate header field with key: `keyId` and value of `apikey`.
 An example (including storing of the real value outside this configuration) is: `apikey = "${new File("/home/me/apitoken").text}"`.
 
+*bearerToken*
+
+You can pass a https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html[Confluence
+Personal Access Token] as the `bearerToken`. It is an alternative to
+`credentials`. Do not confuse it with `apiKey`.
+
 *extraPageContent*
 
 If you need to prefix your pages with a warning stating that 'this is generated content', this is where you do it.

--- a/src/docs/020_tutorial/070_publishToConfluence.adoc
+++ b/src/docs/020_tutorial/070_publishToConfluence.adoc
@@ -316,7 +316,7 @@ Simply pass your username (which can be your email address) and password to the 
 
 [source,shell]
 ----
-`./dtcw publishToConfluence -PconfluenceUser=<your username> -PconfluencePass=<your password>`
+./dtcw publishToConfluence -PconfluenceUser=<your username> -PconfluencePass=<your password>
 ----
 
 ===== Step 2.1b: Authentication with username and API key

--- a/src/docs/020_tutorial/070_publishToConfluence.adoc
+++ b/src/docs/020_tutorial/070_publishToConfluence.adoc
@@ -312,7 +312,7 @@ WARNING: Instead of passing your password, you can use a personal access token,
 which can easily be revoked on the event of a compromise. See
 xref:personal-access-token[Authentication using Personal Access Token].
 
-Simply pass your username and password to the dctw command:
+Simply pass your username (which can be your email address) and password to the dctw command:
 
 [source,shell]
 ----

--- a/src/docs/020_tutorial/070_publishToConfluence.adoc
+++ b/src/docs/020_tutorial/070_publishToConfluence.adoc
@@ -303,7 +303,25 @@ So I configure it accordingly:
 Now comes the hardest part.
 The configuration of the credentials.
 
-Since I use a cloud instance, I can use an access token.
+
+==== Step 2.1: Authentication
+
+===== Step 2.1a: Authentication with username and password (insecure)
+
+WARNING: Instead of passing your password, you can use a personal access token,
+which can easily be revoked on the event of a compromise. See
+xref:personal-access-token[Authentication using Personal Access Token].
+
+Simply pass your username and password to the dctw command:
+
+[source,shell]
+----
+`./dtcw publishToConfluence -PconfluenceUser=<your username> -PconfluencePass=<your password>`
+----
+
+===== Step 2.1b: Authentication with username and API key
+
+Since I use a cloud instance, I can use an API token.
 This has to be generated from my central Atlassian account.
 
 Navigate to your `Profile`
@@ -330,7 +348,32 @@ To keep things simple, I will copy this token to the config.
 
 So we don't store the credentials in the config file, we pass them with the `./dtcw` command:
 
-.`./dtcw publishToConfluence -PconfluenceUser=<your email> -PconfluencePass=<your api-token>`
+[source,shell]
+----
+./dtcw publishToConfluence -PconfluenceUser=<your email> -PconfluencePass=<your api-token>
+----
+
+
+[[personal-access-token]]
+
+===== Step 2.1c: Authentication using Personal Access Token
+
+If you neither want to pass your password to the command nor are you an admin in
+your Confluence instance, you can use a Personal Access Token. You can follow
+the
+https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html#UsingPersonalAccessTokens-CreatingPATsintheapplication[Confluence
+documentation] to generate one. Once you have it, you can pass it to
+DocToolchain as the following:
+
+[source,shell]
+----
+./dtcw publishToConfluence -PconfluenceBearerToken=<your personal access token>
+----
+
+
+=== Step 3: Publish all pages
+
+.`./dtcw publishToConfluence <extra arguments>`
 [%collapsible]
 ====
 ```

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -78,5 +78,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/ascheman[Gerd Aschemann]
 - https://github.com/aklemp[Andreas Klemp]
 - https://github.com/anchialas[Adi König]
+- https://github.com/bencehornak[Bence Hornák]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it? --> please help with this!

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [x] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?

### Details
I created a `confluenceBearerToken` property, because currently the only way to set a bearer token is embedding it into the config file, which can leak the credential if put under VCS.

I also updated the publish to Confluence guide, so that it reflects all possible ways to authenticate.

Fixes #992
Fixes #1006 