### PR TITLE
fix (dtcw): JAVA_HOME unbound variable (closed #1043)

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -152,7 +152,7 @@ if [ "${docker}" = false ] ; then
         fi
         echo "use ${javaHome} as JDK"
         DTC_OPTS="${DTC_OPTS} '-Dorg.gradle.java.home=${javaHome}'"
-        if [ -z "${JAVA_HOME}" ]; then
+        if [ -z "${JAVA_HOME+x}" ]; then
           #if JAVA_HOME is not set, export it
           export JAVA_HOME=${javaHome}
         else


### PR DESCRIPTION
Use shell parameter expansion to avoid error if `JAVA_HOME` is not set.