### PR TITLE
Revert "publishToConfluence: Use the configured proxy for the label API calls"

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -9,8 +9,6 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === fixes
 
-* use the configured proxy when publishing labels to confluence pages
-
 === added
 
 === changed

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -134,9 +134,6 @@ def addLabels = { def pageId, def labelsArray ->
     def api = new RESTClient(config.confluence.api)
     //this fixes the encoding (dierk42: Is this needed here? Don't know)
     api.encoderRegistry = new EncoderRegistry( charset: 'utf-8' )
-    if (config.confluence.proxy) {
-        api.setProxy(config.confluence.proxy.host, config.confluence.proxy.port, config.confluence.proxy.schema ?: 'http')
-    }
     def headers = getHeaders()
     // Attach each label in a API call of its own. The only prefix possible
     // in our own Confluence is 'global'

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -82,6 +82,5 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/Zheng-Bote[ZHENG Bote]
 - https://github.com/apparatchick[Miranda Boerlage]
 - https://github.com/gusoer[Guido Sörmann]
-- https://github.com/beji[Björn Erlwein]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
Reverts docToolchain/docToolchain#1050