### PR TITLE
test (dtcw): provide minimal automated test suite for dtcw

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -21,21 +21,21 @@ MAIN_CONFIG_FILE=docToolchainConfig.groovy
 
 DISTRIBUTION_URL=https://github.com/docToolchain/docToolchain/releases/download/v${DTC_VERSION}/docToolchain-${DTC_VERSION}.zip
 if [ -z "${DTC_PROJECT_BRANCH:-""}" ]; then
-  if [ -d .git ]; then
-    DTC_PROJECT_BRANCH=$(git branch --show-current)
-  else
-    DTC_PROJECT_BRANCH="-"
-  fi;
-  export DTC_PROJECT_BRANCH
+    if [ -d .git ]; then
+        DTC_PROJECT_BRANCH=$(git branch --show-current)
+    else
+        DTC_PROJECT_BRANCH="-"
+    fi
+    export DTC_PROJECT_BRANCH
 fi
 
 DTC_HEADLESS=${DTC_HEADLESS:="false"}
 if [ -t 0 ]; then
-  # do nothing - we have a tty
-  echo ""
+    # do nothing - we have a tty
+    echo ""
 else
-  echo "Using headless mode since there is no (terminal) interaction possible"
-  DTC_HEADLESS=true
+    echo "Using headless mode since there is no (terminal) interaction possible"
+    DTC_HEADLESS=true
 fi
 export DTC_HEADLESS
 
@@ -54,15 +54,15 @@ doJavaCheck=true
 arch=$(uname -m)
 os=$(uname -s)
 
-if command -v doctoolchain &> /dev/null; then
+if command -v doctoolchain &>/dev/null; then
     echo "docToolchain as CLI available"
     cli=true
 fi
-if command -v docker &> /dev/null; then
+if command -v docker &>/dev/null; then
     echo "docker available"
     docker=true
 fi
-if command -v sdk &> /dev/null; then
+if command -v sdk &>/dev/null; then
     echo "sdkman available"
     sdkman=true
 fi
@@ -96,19 +96,19 @@ Examples:
 '
     exit 1
 fi
-if [ "${1}" = "local" ] ; then
+if [ "${1}" = "local" ]; then
     echo "force use of local install"
     docker=false
     cli=false
     shift
 fi
-if [ "${1}" = "docker" ] ; then
+if [ "${1}" = "docker" ]; then
     cli=false
     homefolder=false
     echo "force use of docker"
     shift
 fi
-if [ "${1}" = "sdk" ] ; then
+if [ "${1}" = "sdk" ]; then
     cli=false
     homefolder=false
     docker=false
@@ -122,33 +122,33 @@ if [ "${1}" = "generateDeck" ]; then
         echo "please run './dtcw local install' to install it locally"
         exit 1
     else
-      if [ -d "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/resources/reveal.js/." ]; then
-          # reveal.js already installed
-          echo ""
-      else
-          echo "cloning reveal.js"
-          (cd "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/resources" && ./clone.sh)
-      fi
+        if [ -d "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/resources/reveal.js/." ]; then
+            # reveal.js already installed
+            echo ""
+        else
+            echo "cloning reveal.js"
+            (cd "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/resources" && ./clone.sh)
+        fi
     fi
 fi
 # check for apple M1 silicon
 if [ "${os}" = "Darwin" ]; then
-  if [ "${arch}" = "arm64" ]; then
-    echo "it seems that you try to run docToolchain on M1 silicon"
-    echo "please consider to switch to a x86 shell by executing"
-    echo "arch -x86_64 /bin/bash"
-    echo "in order to run docToolchain in x86 mode"
-    echo ""
-  fi
+    if [ "${arch}" = "arm64" ]; then
+        echo "it seems that you try to run docToolchain on M1 silicon"
+        echo "please consider to switch to a x86 shell by executing"
+        echo "arch -x86_64 /bin/bash"
+        echo "in order to run docToolchain in x86 mode"
+        echo ""
+    fi
 fi
-if ! ${DTC_HEADLESS} ; then
-  if [ "${docker}" = false ] ; then
-    # important for the docker file to find dependencies
-    DTC_OPTS="${DTC_OPTS} -Dgradle.user.home=${HOME}/.doctoolchain/.gradle"
-  fi
+if ! ${DTC_HEADLESS}; then
+    if [ "${docker}" = false ]; then
+        # important for the docker file to find dependencies
+        DTC_OPTS="${DTC_OPTS} -Dgradle.user.home=${HOME}/.doctoolchain/.gradle"
+    fi
 fi
 
-if [ "${docker}" = false ] ; then
+if [ "${docker}" = false ]; then
 
     # check for locally installed jdk
     if [ -d "${HOME}/.doctoolchain/jdk/." ]; then
@@ -156,23 +156,23 @@ if [ "${docker}" = false ] ; then
         java=true
 
         if [ -d "${HOME}/.doctoolchain/jdk/Contents/." ]; then
-          javaHome="${HOME}/.doctoolchain/jdk/Contents/Home"
+            javaHome="${HOME}/.doctoolchain/jdk/Contents/Home"
         else
-          javaHome="${HOME}/.doctoolchain/jdk"
+            javaHome="${HOME}/.doctoolchain/jdk"
         fi
         echo "use ${javaHome} as JDK"
         DTC_OPTS="${DTC_OPTS} '-Dorg.gradle.java.home=${javaHome}'"
         if [ -z "${JAVA_HOME+x}" ]; then
-          #if JAVA_HOME is not set, export it
-          export JAVA_HOME=${javaHome}
-        else
-          if command -v "${JAVA_HOME}/bin/java" &> /dev/null; then
-            #java is installed and JAVA_HOME is ok
-            echo ""
-          else
-            #set JAVA_HOME to our own JDK
+            #if JAVA_HOME is not set, export it
             export JAVA_HOME=${javaHome}
-          fi
+        else
+            if command -v "${JAVA_HOME}/bin/java" &>/dev/null; then
+                #java is installed and JAVA_HOME is ok
+                echo ""
+            else
+                #set JAVA_HOME to our own JDK
+                export JAVA_HOME=${javaHome}
+            fi
         fi
         doJavaCheck=false
     fi
@@ -180,42 +180,42 @@ fi
 
 # check if we are running on WSL
 if grep -qsi 'microsoft' /proc/version; then
-  echo " "
-  echo "Bash is running on WSL"
-  echo "this might cause problems with plantUML"
-  echo "see https://doctoolchain.github.io/docToolchain/#wsl for more details"
-  echo " "
+    echo " "
+    echo "Bash is running on WSL"
+    echo "this might cause problems with plantUML"
+    echo "see https://doctoolchain.github.io/docToolchain/#wsl for more details"
+    echo " "
 fi
 
 # url toLocation
-download ( ) {
+download() {
     url=${1}
     toLocation=${2}
     echo ">>> ${1} ${2}"
     #check that pre-requisites are met
-    if ! (command -v wget &> /dev/null); then
-      if ! (command -v curl &> /dev/null); then
-        echo "you need either wget or curl installed"
-        echo "please install it and re-run the command"
-        exit 1
-      fi
+    if ! (command -v wget &>/dev/null); then
+        if ! (command -v curl &>/dev/null); then
+            echo "you need either wget or curl installed"
+            echo "please install it and re-run the command"
+            exit 1
+        fi
     fi
-    if ! (command -v unzip &> /dev/null); then
+    if ! (command -v unzip &>/dev/null); then
         echo "you need unzip installed"
         echo "please install it and re-run the command"
         exit 1
     fi
-    if command -v curl &> /dev/null; then
-      curl -Lo "${toLocation}" "${url}"
+    if command -v curl &>/dev/null; then
+        curl -Lo "${toLocation}" "${url}"
     else
-      wgetversion=$(wget --version && true | head -1 | sed -E 's/^.* 1.([0-9]+).*$/\1/')
-      if [ "${wgetversion}" -gt 13 ]; then
-        wget "${url}" -O "${toLocation}"
-      else
-        echo "you need curl or wget (version >= 1.14) installed"
-        echo "please install or update and re-run the command"
-        exit 1
-      fi
+        wgetversion=$(wget --version && true | head -1 | sed -E 's/^.* 1.([0-9]+).*$/\1/')
+        if [ "${wgetversion}" -gt 13 ]; then
+            wget "${url}" -O "${toLocation}"
+        else
+            echo "you need curl or wget (version >= 1.14) installed"
+            echo "please install or update and re-run the command"
+            exit 1
+        fi
     fi
 }
 
@@ -243,33 +243,33 @@ java_help_and_die() {
 
 }
 check_java() {
-  if command -v java &> /dev/null; then
-      java=true
-      if java -version 2>&1 >/dev/null | grep -q "Unable to locate a Java Runtime" ; then
-        ##we are on a mac and the java command is only a shim
-        java=false
-      fi
-  fi
-  if [ "${java}" = false ] ; then
-      echo "docToolchain depends on java, but the java command couldn't be found in this shell (bash)"
-      echo ""
-      java_help_and_die
-  fi
-  javaversion=$(java -version 2>&1 | awk -F '"' '/version/ {print $0}' | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
-  echo "Java Version ${javaversion}"
-  if [ "${javaversion}" -lt 8 ]; then
-      echo "your java version ${javaversion} is too old (<8): $(which java)"
-      echo "please update your java installation and try again"
-      echo ""
-      java_help_and_die
-  else
-    if [ "${javaversion}" -gt 14 ]; then
-      echo "your java version ${javaversion} is too new (>14): $(which java)"
-      echo "please update your java installation and try again"
-      echo ""
-      java_help_and_die
+    if command -v java &>/dev/null; then
+        java=true
+        if java -version 2>&1 >/dev/null | grep -q "Unable to locate a Java Runtime"; then
+            ##we are on a mac and the java command is only a shim
+            java=false
+        fi
     fi
-  fi
+    if [ "${java}" = false ]; then
+        echo "docToolchain depends on java, but the java command couldn't be found in this shell (bash)"
+        echo ""
+        java_help_and_die
+    fi
+    javaversion=$(java -version 2>&1 | awk -F '"' '/version/ {print $0}' | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1)
+    echo "Java Version ${javaversion}"
+    if [ "${javaversion}" -lt 8 ]; then
+        echo "your java version ${javaversion} is too old (<8): $(which java)"
+        echo "please update your java installation and try again"
+        echo ""
+        java_help_and_die
+    else
+        if [ "${javaversion}" -gt 14 ]; then
+            echo "your java version ${javaversion} is too new (>14): $(which java)"
+            echo "please update your java installation and try again"
+            echo ""
+            java_help_and_die
+        fi
+    fi
 
 }
 install_local() {
@@ -279,124 +279,125 @@ install_local() {
     rm -f "${HOME}/.doctoolchain/source.zip"
 }
 
-if [ "${DTC_VERSION}" == "latest" ] || [ "${DTC_VERSION}" == "latestdev" ] ; then
+if [ "${DTC_VERSION}" == "latest" ] || [ "${DTC_VERSION}" == "latestdev" ]; then
     echo "force latest version with local install"
     docker=false
     cli=false
     mkdir -p "${HOME}/.doctoolchain"
     # check if we have to clone or just pull
     if [ -d "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/.git" ]; then
-      (cd "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}" && git pull)
+        (cd "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}" && git pull)
     else
-      if [ "${DTC_VERSION}" == "latest" ] ; then
-        git clone https://github.com/docToolchain/docToolchain.git "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}"
-      else
-        git clone git@github.com:docToolchain/docToolchain.git "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}"
-      fi
+        if [ "${DTC_VERSION}" == "latest" ]; then
+            git clone https://github.com/docToolchain/docToolchain.git "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}"
+        else
+            git clone git@github.com:docToolchain/docToolchain.git "${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}"
+        fi
     fi
     homefolder=true
 fi
-if [ "${1}" == "getJava" ] ; then
-        version=11
-        implementation=hotspot
-        heapsize=normal
-        imagetype=jdk
-        releasetype=ga
-        case "${arch}" in
-          x86_64 ) arch=x64 ;;
-          arm64 )  arch=aarch64 ;;
-        esac
-        if [[ ${os} == MINGW* ]] ; then
-            echo ""
-            echo "Error: MINGW64 is not supported"
-            echo "please use powershell or wsl"
-            exit 1
-        fi
-        case "${os}" in
-          Linux )  os=linux ;;
-          Darwin ) os=mac ;;
-          Cygwin ) os=linux ;;
-        esac
-        echo "this script assumes that you have linux as operating system (${arch} / ${os})"
-        echo "it now tries to install Java for you"
-        mkdir -p "${HOME}/.doctoolchain/jdk"
-        echo "downloading JDK Temurin 11 from Adoptium to ${HOME}/.doctoolchain/jdk.tar.gz"
-        download "https://api.adoptium.net/v3/binary/latest/${version}/${releasetype}/${os}/${arch}/${imagetype}/${implementation}/${heapsize}/eclipse?project=jdk" "${HOME}/.doctoolchain/jdk/jdk.tar.gz"
-        #wget -r -O ${HOME}/.doctoolchain/jdk/jdk.tar.gz https://api.adoptium.net/v3/binary/latest/${version}/${releasetype}/${os}/${arch}/${imagetype}/${implementation}/${heapsize}/eclipse?project=jdk
-        echo "expanding JDK"
-        tar -zxf "${HOME}/.doctoolchain/jdk/jdk.tar.gz" --strip 1 -C "${HOME}/.doctoolchain/jdk/."
-        rm -f "${HOME}/.doctoolchain/jdk.tar.gz"
-        shift
+if [ "${1}" == "getJava" ]; then
+    version=11
+    implementation=hotspot
+    heapsize=normal
+    imagetype=jdk
+    releasetype=ga
+    case "${arch}" in
+    x86_64) arch=x64 ;;
+    arm64) arch=aarch64 ;;
+    esac
+    if [[ ${os} == MINGW* ]]; then
+        echo ""
+        echo "Error: MINGW64 is not supported"
+        echo "please use powershell or wsl"
         exit 1
+    fi
+    case "${os}" in
+    Linux) os=linux ;;
+    Darwin) os=mac ;;
+    Cygwin) os=linux ;;
+    esac
+    echo "this script assumes that you have linux as operating system (${arch} / ${os})"
+    echo "it now tries to install Java for you"
+    mkdir -p "${HOME}/.doctoolchain/jdk"
+    echo "downloading JDK Temurin 11 from Adoptium to ${HOME}/.doctoolchain/jdk.tar.gz"
+    download "https://api.adoptium.net/v3/binary/latest/${version}/${releasetype}/${os}/${arch}/${imagetype}/${implementation}/${heapsize}/eclipse?project=jdk" "${HOME}/.doctoolchain/jdk/jdk.tar.gz"
+    #wget -r -O ${HOME}/.doctoolchain/jdk/jdk.tar.gz https://api.adoptium.net/v3/binary/latest/${version}/${releasetype}/${os}/${arch}/${imagetype}/${implementation}/${heapsize}/eclipse?project=jdk
+    echo "expanding JDK"
+    tar -zxf "${HOME}/.doctoolchain/jdk/jdk.tar.gz" --strip 1 -C "${HOME}/.doctoolchain/jdk/."
+    rm -f "${HOME}/.doctoolchain/jdk.tar.gz"
+    shift
+    exit 1
 fi
 #if bakePreview is called, deactivate daemon
-if [ "${1}" = "bakePreview" ] ; then
+if [ "${1}" = "bakePreview" ]; then
     DTC_OPTS="${DTC_OPTS} -Dorg.gradle.daemon=false"
 fi
 
-if [ "${cli}" = true ] ; then
+if [ "${cli}" = true ]; then
     command="$(which doctoolchain) . ${*} ${DTC_OPTS}"
     echo "use cli install $(which doctoolchain)"
 else
-    if [ "${homefolder}" = true ] ; then
-      command="${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/bin/doctoolchain . ${*} ${DTC_OPTS}"
-      echo "use local homefolder install ${HOME}/.doctoolchain/"
+    if [ "${homefolder}" = true ]; then
+        command="${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/bin/doctoolchain . ${*} ${DTC_OPTS}"
+        echo "use local homefolder install ${HOME}/.doctoolchain/"
     else
-      if [ "${docker}" = true ] ; then
-	  if ! docker info >/dev/null 2>&1; then
-	      echo "Docker does not seem to be running, run it first and retry"
-	      echo "if you want to use a local installation of doctoolchain instead"
-	      echo "use 'local' as first argument to force the installation and use of a local install."
+        if [ "${docker}" = true ]; then
+            if ! docker info >/dev/null 2>&1; then
+                echo "Docker does not seem to be running, run it first and retry"
+                echo "if you want to use a local installation of doctoolchain instead"
+                echo "use 'local' as first argument to force the installation and use of a local install."
 
-	      exit 1
-	  fi
-          docker_cmd=$(which docker)
-          echo "${docker_cmd}"
-          if command -v cygpath &>/dev/null; then
-              pwd=$(cygpath -w "${PWD}")
-          else
-              pwd=${PWD}
-          fi
-          command="'${docker_cmd}' run --platform linux/amd64 -u $(id -u):$(id -g) --name doctoolchain${DTC_VERSION} -e DTC_HEADLESS=1 -e DTC_SITETHEME -e DTC_PROJECT_BRANCH=${DTC_PROJECT_BRANCH} -p 8042:8042 --rm -i --entrypoint /bin/bash -v '${pwd}:/project' doctoolchain/doctoolchain:v${DTC_VERSION} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
-          doJavaCheck=false
-	  echo "use docker installation"
-      else
+                exit 1
+            fi
+            docker_cmd=$(which docker)
+            echo "${docker_cmd}"
+            if command -v cygpath &>/dev/null; then
+                pwd=$(cygpath -w "${PWD}")
+            else
+                pwd=${PWD}
+            fi
+            command="'${docker_cmd}' run --platform linux/amd64 -u $(id -u):$(id -g) --name doctoolchain${DTC_VERSION} -e DTC_HEADLESS=1 -e DTC_SITETHEME -e DTC_PROJECT_BRANCH=${DTC_PROJECT_BRANCH} -p 8042:8042 --rm -i --entrypoint /bin/bash -v '${pwd}:/project' doctoolchain/doctoolchain:v${DTC_VERSION} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
+            doJavaCheck=false
+            echo "use docker installation"
+        else
 
-          echo "docToolchain not installed."
-          if [ "${sdkman}" = true ] ; then
-              echo "please use sdkman to install docToolchain"
-              echo "$ sdk install doctoolchain ${DTC_VERSION}"
-              exit
-          else
-              echo "sdkman not found"
-              if [ "${DTC_HEADLESS}" == true ] ; then
-                  # just download
-                  install_local
-              else
-                  echo "Do you wish to install doctoolchain to '${HOME}/.doctoolchain'?"
-                  select yn in "Yes" "No"; do
-                    case ${yn} in
-                      Yes ) echo "installing doctoolchain";
+            echo "docToolchain not installed."
+            if [ "${sdkman}" = true ]; then
+                echo "please use sdkman to install docToolchain"
+                echo "$ sdk install doctoolchain ${DTC_VERSION}"
+                exit
+            else
+                echo "sdkman not found"
+                if [ "${DTC_HEADLESS}" == true ]; then
+                    # just download
+                    install_local
+                else
+                    echo "Do you wish to install doctoolchain to '${HOME}/.doctoolchain'?"
+                    select yn in "Yes" "No"; do
+                        case ${yn} in
+                        Yes)
+                            echo "installing doctoolchain"
                             install_local
                             break
-                        ;;
-                      No )
+                            ;;
+                        No)
                             echo "you need docToolchain as CLI-Tool installed or docker."
                             echo "to install docToolchain as CLI-Tool, please install"
                             echo "sdkman and re-run this command."
                             echo "https://sdkman.io/install"
                             echo "\$ curl -s \"https://get.sdkman.io\" | bash"
                             exit 1
-                        ;;
-                    esac
-                  done
-             fi
-		     command="${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/bin/doctoolchain . ${*} ${DTC_OPTS}"
-         fi
-       fi
+                            ;;
+                        esac
+                    done
+                fi
+                command="${HOME}/.doctoolchain/docToolchain-${DTC_VERSION}/bin/doctoolchain . ${*} ${DTC_OPTS}"
+            fi
+        fi
     fi
 fi
-if [ "${doJavaCheck}" = true ] ; then
+if [ "${doJavaCheck}" = true ]; then
     check_java
 fi
 

--- a/dtcw
+++ b/dtcw
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright 2022 - 2023, Ralf D. Müller and the docToolchain contributors
 
 set -e
 set -u
@@ -29,13 +31,14 @@ if [ -z "${DTC_PROJECT_BRANCH:-""}" ]; then
     export DTC_PROJECT_BRANCH
 fi
 
-DTC_HEADLESS=${DTC_HEADLESS:="false"}
-if [ -t 0 ]; then
-    # do nothing - we have a tty
-    echo ""
-else
-    echo "Using headless mode since there is no (terminal) interaction possible"
-    DTC_HEADLESS=true
+# If DTC_HEADLESS provided (from tests), don't change it.
+if [ -z ${DTC_HEADLESS+x} ]; then
+    if [ -t 0 ]; then
+        DTC_HEADLESS=false
+    else
+        echo "Using headless mode since there is no (terminal) interaction possible"
+        DTC_HEADLESS=true
+    fi
 fi
 export DTC_HEADLESS
 
@@ -208,14 +211,7 @@ download() {
     if command -v curl &>/dev/null; then
         curl -Lo "${toLocation}" "${url}"
     else
-        wgetversion=$(wget --version && true | head -1 | sed -E 's/^.* 1.([0-9]+).*$/\1/')
-        if [ "${wgetversion}" -gt 13 ]; then
-            wget "${url}" -O "${toLocation}"
-        else
-            echo "you need curl or wget (version >= 1.14) installed"
-            echo "please install or update and re-run the command"
-            exit 1
-        fi
+        wget "${url}" -O "${toLocation}"
     fi
 }
 
@@ -275,7 +271,7 @@ check_java() {
 install_local() {
     mkdir -p "${HOME}/.doctoolchain"
     download "${DISTRIBUTION_URL}" "${HOME}/.doctoolchain/source.zip"
-    unzip "${HOME}/.doctoolchain/source.zip" -d "${HOME}/.doctoolchain/."
+    unzip -q "${HOME}/.doctoolchain/source.zip" -d "${HOME}/.doctoolchain/."
     rm -f "${HOME}/.doctoolchain/source.zip"
 }
 

--- a/test/README.adoc
+++ b/test/README.adoc
@@ -1,0 +1,90 @@
+dtcw Automated Tests
+--------------------
+:license: MIT
+
+**Pre-requisites**: installed container runtime (Docker or Podman).
+
+This directory contains automated tests for the `dtcw` Bash wrapper script.
+The tests use https://github.com/bats-core/bats-core[bats-core], a Bash automated testing system.
+
+Documentation for `bats-core` can be found at https://bats-core.readthedocs.io/.
+Detailed documentation to the helper libraries can be found in their git repositories:
+
+- https://github.com/bats-core/bats-assert[bats-assert]
+- https://github.com/bats-core/bats-file[bats-file]
+- https://github.com/bats-core/bats-support[bats-support]
+
+
+The test suite is executed in a container with an image provided from the `bats-core` project.
+This ensures a deterministic test setup and prevents a pollution with test artifacts.
+
+NOTE: `bats-core` provides a container images which is based on https://musl.libc.org/[musl libc].
+The musl C library causes problems with Java. So we use a Debian based test container with a standard glibc.
+
+Test Execution
+~~~~~~~~~~~~~~
+
+The test suite is executed with the following command from the `docToolchain` project root directory,
+
+```sh
+# From the docToolchain project root
+➜ docker run -it -e BATS_LIB_PATH=/usr/lib/bats -v "${PWD}/dtcw:/code/dtcw"  -v "${PWD}/test:/code/test" maxh/bats:latest test
+```
+
+The environment variable `BATS_LIB_PATH` assures our test code can load the `bat-core` helper libraries which are part of the container image at `/usr/lib/bats`.
+The volume bind mounts make `dtcw` and the test code available at `/code`.
+For more details check the https://github.com/mh182/bats-core/blob/docker_debian/Dockerfile[bats-coder/Dockerfile]
+
+This setup provides a clean project setup and avoids possible pitfalls to access resources from the docToolchain project directory.
+
+```sh
+# In the container we have a pristine project which used the docToolchain
+code
+├── dtcw
+└── test
+    ├── pristine_environment.bats
+    └── README.adoccode
+```
+
+You probably want to create an alias to run the test suite
+
+```sh
+➜ alias tdtcw='docker run -it -e BATS_LIB_PATH=/usr/lib/bats -v "${PWD}/dtcw:/code/dtcw"  -v "${PWD}/test:/code/test" maxh/bats:latest'
+➜ tdtcw test
+```
+
+Tests are tagged so the test set execution may be adapted with the `--filter-tags` option.
+Currently followinf tags are used:
+
+- `download`: test is downloading external packages with `curl`, `wget` or https://sdkman.io/[`sdk`]
+
+For example to run all tests, except the tests downloading packages use
+
+```sh
+➜ tdtcw test --filter-tags \!download
+```
+
+Additional information about how you can tweak test execution start the container with the `--help` option
+
+```sh
+➜ tdtcw --help
+```
+
+Debugging
+~~~~~~~~~
+
+To access the test environment in the container call `bash` as entrypoint,
+
+```sh
+➜ docker run -it -e BATS_LIB_PATH=/usr/lib/bats -v "${PWD}/dtcw:/code/dtcw" -v "${PWD}/test:/code/test" --entrypoint bash maxh/bats:latest
+bash-5.2#
+```
+
+Creating the bats-core Test Image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+```
+➜ git clone -b docker_debian git@github.com:mh182/bats-core.git && cd bats-core
+➜ docker build --tag maxh/bats:latest .
+➜ docker image push maxh/bats:latest
+```

--- a/test/docker_environment.bats
+++ b/test/docker_environment.bats
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023, Max Hofer and the docToolchain contributors
+
+# Test dtcw wrapper in a pure docker environment
+
+setup_file() {
+    load 'test_helper.bash'
+    mock_create docker
+}
+
+teardown_file() {
+    mock_delete docker
+}
+
+setup() {
+    bats_load_library 'bats-support'
+    bats_load_library 'bats-assert'
+
+    # Needed for use of 'run -<expected_exit_code>', otherwise we get BW02 errors
+    bats_require_minimum_version 1.5.0
+}
+
+@test "forward call to docker" {
+    run -0 ./dtcw tasks --group doctoolchain
+    assert_line --partial "dtcw - docToolchain wrapper"
+    assert_line --partial "docToolchain"
+    assert_line "docker available"
+    assert_line "/usr/local/bin/docker"
+    assert_line "use docker installation"
+    assert_line --partial "docker mock called"
+}

--- a/test/local_installation.bats
+++ b/test/local_installation.bats
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023, Max Hofer and the docToolchain contributors
+
+# Test installation on a clean environment
+
+# This means: no docToolchain, no Java, no SDKMAN!, no docker
+#
+# The tests follow the installation instructions based on the output provided by `dtcw`.
+# They download external software packages (Java, docToolchain) which makes them slow.
+#
+# ATTENTION: contrary to good test patterns, the tests in this file depend on
+# each other to keep the test execution (and downloads) as short as possible.
+#
+# TODO: write mocks for wget/curl which use a local cache instead of downloading
+# the packages each time.
+# See https://advancedweb.hu/how-to-mock-in-bash-tests/
+
+setup() {
+    bats_load_library 'bats-support'
+    bats_load_library 'bats-assert'
+    bats_load_library 'bats-file'
+
+    # Needed for use of 'run -<expected_exit_code>', otherwise we get BW02 errors
+    bats_require_minimum_version 1.5.0
+
+    load 'test_helper.bash'
+}
+
+teardown() {
+    mock_delete docker
+}
+
+teardown_file() {
+    echo "disable teardown"
+    rm -rf $HOME/.doctoolchain
+    rm -rf docToolchainConfig.groovy
+}
+
+# bats test_tags=download
+@test "install docToolchain locally" {
+    # TODO: bug - why do we return an error even when docToolchain was installed successfully?
+    DTC_HEADLESS=false run -1 ./dtcw tasks --group doctoolchain <<< "1"
+
+    # Output from wget and unzip - changes on environment/version
+    # assert_line --partial 'Connecting to github.com'
+    # assert_line "saving to '/root/.doctoolchain/source.zip'"
+    # assert_line "'/root/.doctoolchain/source.zip' saved"
+
+    # TODO: unzip is too spammy
+    assert_line "docToolchain depends on java, but the java command couldn't be found in this shell (bash)"
+    assert_line 'it might be that you have installed the needed version java in another shell from which you started dtcw'
+    assert_line 'dtcw is running in bash and uses the PATH to find java'
+    assert_line 'to install a local java for docToolchain, you can run'
+    assert_line './dtcw getJava'
+    assert_line 'another way to install or update java is to install'
+    assert_line 'sdkman and then java via sdkman'
+    assert_line 'https://sdkman.io/install'
+    assert_line '$ curl -s "https://get.sdkman.io" | bash'
+    assert_line '$ sdk install java'
+    assert_line 'or you can download it from https://adoptium.net/'
+    assert_line 'make sure that your java version is between 8 and 14'
+    assert_line 'If you do not want to use a local java installation, you can also use docToolchain as docker container.'
+    assert_line "In that case, specify 'docker' as first parameter in your statement."
+    assert_line 'example: ./dtcw docker generateSite'
+}
+
+# bats test_tags=download
+@test "install java with getJava" {
+    # TODO: bug - why do we return an error even when Java was installed successfully?
+    run -1 ./dtcw getJava
+
+    assert_line 'this script assumes that you have linux as operating system (x64 / linux)'
+    assert_line 'it now tries to install Java for you'
+    assert_line 'downloading JDK Temurin 11 from Adoptium to /root/.doctoolchain/jdk.tar.gz'
+    # TODO: download is really spammy
+
+    # Output from wget and unzip - changes on environment/version
+    # assert_line --partial 'Connecting to api.adoptium.net'
+    # assert_line --partial 'Connecting to github.com'
+    # assert_line --partial 'Connecting to objects.githubusercontent.com'
+    # assert_line "saving to '/root/.doctoolchain/jdk/jdk.tar.gz'"
+    # assert_line "'/root/.doctoolchain/jdk/jdk.tar.gz' saved"
+    assert_line 'expanding JDK'
+
+    run -0 "${HOME}/.doctoolchain/jdk/bin/java" --version
+}
+
+# bats test_tags=download
+@test "skip create docToolchainConfig" {
+    # The answer if want to create the default configuration with "n"
+    DTC_HEADLESS=false run -1 ./dtcw tasks --group doctoolchain <<< "n"
+
+    # TODO: Gradle  materiaization/start is spammy - can we turn it off?
+
+    # Use '--partial' due to color codes in the console output
+    assert_line --partial "Config file '/code/docToolchainConfig.groovy' does not exist"
+    assert_line --partial "do you want me to create a default one for you?"
+
+    assert_line "FAILURE: Build failed with an exception."
+    assert_line "* What went wrong:"
+    assert_line "A problem occurred evaluating script."
+    assert_line "> can't continue without a config file"
+}
+
+# bats test_tags=download
+@test "create docToolchainConfig" {
+    # The answer if want to create the default configuration with "n"
+    DTC_HEADLESS=false run -0 ./dtcw tasks --group doctoolchain <<< "y"
+
+    # TODO: 'gradlew' is not available
+    assert_line "To see all tasks and more detail, run gradlew tasks --all"
+    assert_line "To see more detail about a task, run gradlew help --task <task>"
+}
+
+# bats test_tags=download
+@test "fail on unknown task" {
+    # Once eveything is installed an error is shown for an unknown task
+    run -1 ./dtcw unknown_task
+
+    assert_line "FAILURE: Build failed with an exception."
+    assert_line "* What went wrong:"
+    assert_line "Task 'unknown_task' not found in root project 'docToolchain'."
+}
+
+# bats test_tags=download
+@test "use sdk with local installation" {
+    # TODO: bug - why here no error code?
+    run -0 ./dtcw sdk tasks
+
+    assert_line "home folder exists"
+    assert_line "force use of sdkman"
+    assert_line "local java JDK found"
+    assert_line "use /root/.doctoolchain/jdk as JDK"
+    # TODO: bug - this is clearly wrong - docToolchain is installed
+    assert_line "docToolchain not installed."
+    # TODO: bug - sdkman is not installed - so we should tell to install it
+    assert_line "please use sdkman to install docToolchain"
+    # TODO: test will fail on version change
+    assert_line "$ sdk install doctoolchain 2.2.0"
+
+}
+
+# bats test_tags=download
+@test "use docker with local installation" {
+    skip "this use case is completly buggy"
+
+    run ./dtcw docker tasks
+
+    assert_line "home folder exists"
+    assert_line "force use of docker"
+    # TODO: bug - if we use docker we don't care about Java
+    assert_line "local java JDK found"
+    assert_line "use /root/.doctoolchain/jdk as JDK"
+    # TODO: bug - this is clearly wrong - docToolchain is installed
+    assert_line "docToolchain not installed."
+    # TODO: bug - if we use docker we don't care abouf sdkman
+    assert_line "please use sdkman to install docToolchain"
+    assert_line "sdkman not found"
+    # TODO: bug
+    # Do you wish to install doctoolchain to '/root/.doctoolchain'?
+    # 1) Yes
+    # 2) No
+    # #? 2
+    # you need docToolchain as CLI-Tool installed or docker.
+    # to install docToolchain as CLI-Tool, please install
+    # sdkman and re-run this command.
+    # https://sdkman.io/install
+    # $ curl -s "https://get.sdkman.io" | bash
+}
+
+# bats test_tags=download
+@test "no side effect when installing docker" {
+    mock_create docker
+
+    # The installation of docker should not have any effect
+    run -1 ./dtcw tasks --group doctoolchain
+
+    assert_line "docker available"
+    assert_line "home folder exists"
+    assert_line "use local homefolder install /root/.doctoolchain/"
+
+    # TODO: bug - instaling docker should not affect the current installation
+    # We have local Java installed.
+    assert_line "docToolchain depends on java, but the java command couldn't be found in this shell (bash)"
+}

--- a/test/pristine_environment.bats
+++ b/test/pristine_environment.bats
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023, Max Hofer and the docToolchain contributors
+
+# Test behavior on a clean environment
+
+#
+# One of the following pre-condition have to be met to run:
+# - local install: wget or curl, unzip
+# - sdkman
+# - container runtime (like docker)
+#
+
+#
+# This means: no wget, no curl, no docToolchain, no Java, no SDKMAN!, no docker
+#
+
+setup() {
+    bats_load_library 'bats-support'
+    bats_load_library 'bats-assert'
+
+    # Needed for use of 'run -<expected_exit_code>', otherwise we get BW02 errors
+    bats_require_minimum_version 1.5.0
+
+    load 'test_helper.bash'
+}
+
+teardown() {
+    # Restore environment
+    enable_command unzip
+    enable_command curl
+    enable_command wget
+}
+
+@test "no arguments shows usage" {
+    run -1 ./dtcw
+    assert_line 'Usage: ./dtcw [option...] [task...]'
+    assert_line 'Use "./dtcw tasks --group doctoolchain" to see available tasks.'
+    assert_line 'Use "local", "sdk" or "docker" as first argument to force the use of a local, sdkman or docker install.'
+}
+
+@test "any argument asks for local installation - No" {
+    # TODO: Why do we exit here with an error if we say don't install anything
+    DTC_HEADLESS=false run -1 ./dtcw tasks --group doctoolchain <<< "2"
+
+    assert_line 'docToolchain not installed.'
+    assert_line 'sdkman not found'
+    assert_line "Do you wish to install doctoolchain to '/root/.doctoolchain'?"
+    assert_line '1) Yes'
+    assert_line '2) No'
+    assert_line '#? you need docToolchain as CLI-Tool installed or docker.'
+    assert_line 'to install docToolchain as CLI-Tool, please install'
+    assert_line 'sdkman and re-run this command.'
+    assert_line 'https://sdkman.io/install'
+    assert_line '$ curl -s "https://get.sdkman.io" | bash'
+}
+
+# TODO: split test for wget and curl. We have to add curl to our test image
+@test "no curl/wget/docker installed" {
+    disable_command wget
+    disable_command curl
+
+    # Asks for installation even if no curl/wget/sdkman/docker installed
+    # TODO: Should quit with error messages explaining the preconditions are not
+    # met before trying to download.
+    DTC_HEADLESS=false run -1 ./dtcw tasks --group doctoolchain <<< "1"
+
+    assert_line "Do you wish to install doctoolchain to '/root/.doctoolchain'?"
+    assert_line "#? installing doctoolchain"
+    assert_line --partial ">>> https://github.com/docToolchain/docToolchain/releases/download/"
+    assert_line "you need either wget or curl installed"
+    assert_line "please install it and re-run the command"
+}
+
+@test "wget installed, but no unzip" {
+    disable_command unzip
+
+    # Asks for installation even if no unzip installed
+    # TODO: Should quit with error messages explaining the preconditions are not
+    # met before trying to download.
+    DTC_HEADLESS=false run -1 ./dtcw tasks --group doctoolchain <<< "1"
+
+    assert_line "Do you wish to install doctoolchain to '/root/.doctoolchain'?"
+    assert_line "#? installing doctoolchain"
+    assert_line --partial ">>> https://github.com/docToolchain/docToolchain/releases/download/"
+    assert_line "you need unzip installed"
+    assert_line "please install it and re-run the command"
+}
+
+@test "sdk tasks" {
+    # TODO: bug - why here no error code?
+    run -0 ./dtcw sdk tasks
+
+    assert_line "force use of sdkman"
+    assert_line "docToolchain not installed."
+    assert_line "please use sdkman to install docToolchain"
+    # TODO: test will fail on version change
+    assert_line "$ sdk install doctoolchain 2.2.0"
+}
+
+@test "docker tasks" {
+    DTC_HEADLESS=false run -1 ./dtcw docker tasks <<< "2"
+
+    assert_line "force use of docker"
+    assert_line "docToolchain not installed."
+    assert_line "sdkman not found"
+    # TODO: bug - here we should abort since docker is not installed
+    assert_line "Do you wish to install doctoolchain to '/root/.doctoolchain'?"
+    # 1) Yes
+    # 2) No
+    # #? 2
+    # you need docToolchain as CLI-Tool installed or docker.
+    # to install docToolchain as CLI-Tool, please install
+    # sdkman and re-run this command.
+    # https://sdkman.io/install
+    # $ curl -s "https://get.sdkman.io" | bash
+}

--- a/test/sdk_installation.bats
+++ b/test/sdk_installation.bats
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023, Max Hofer and the docToolchain contributors
+
+# Test installation of docToolchain with SDKMAN! on a clean environment
+
+# System setup: SDKMAN! (which implies curl, unzip, zip) installed, no docToolchain, no Java, no docker
+#
+# The tests follow the installation instructions based on the output provided by `dtcw`.
+# They download external software packages (Java, docToolchain) which makes them slow.
+#
+# ATTENTION: contrary to good test patterns, the tests in this file depend on
+# each other to keep the test execution (and downloads) as short as possible.
+#
+# TODO: write mocks for wget/curl which use a local cache instead of downloading
+# the packages each time.
+# See https://advancedweb.hu/how-to-mock-in-bash-tests/
+
+setup_file() {
+    apt install -y curl zip
+    export SDKMAN_DIR="$HOME/.local/share/sdkman"
+    curl -s "https://get.sdkman.io" | bash
+
+    # The installation with sdk doesn't make the component available in the tests.
+    # This means we have to adjust the PATH manually.
+    # TODO: Is there is a better way to set this?
+    PATH="${SDKMAN_DIR}/candidates/doctoolchain/current/bin":$PATH
+    export PATH="${SDKMAN_DIR}/candidates/java/current/bin":$PATH
+}
+
+setup() {
+    bats_load_library 'bats-support'
+    bats_load_library 'bats-assert'
+
+    # Needed for use of 'run -<expected_exit_code>', otherwise we get BW02 errors
+    bats_require_minimum_version 1.5.0
+
+    load 'test_helper.bash'
+}
+
+teardown() {
+    mock_delete docker
+}
+
+teardown_file() {
+    rm -rf "$SDKMAN_DIR"
+    rm -rf docToolchainConfig.groovy
+    apt purge -y curl zip
+}
+
+@test "any argument show how to install docToolchain with sdk" {
+    # TODO: Why do we exit here with an error if we say don't install anything
+    DTC_HEADLESS=false run -1 ./dtcw tasks --group doctoolchain <<< "2"
+
+    # TODO: Instead of asking to install locally we show the installation
+    # instructions how to install docToolchain with sdkman. Or the alternative
+    # how to install  docToolchain locally with './dtcw local tasks ...'
+    # > sdk install doctoolchain 2.2.0
+    assert_line 'docToolchain not installed.'
+    # TODO: bug - sdkman is not found
+    assert_line 'sdkman not found'
+    assert_line "Do you wish to install doctoolchain to '/root/.doctoolchain'?"
+    assert_line '1) Yes'
+    assert_line '2) No'
+    assert_line '#? you need docToolchain as CLI-Tool installed or docker.'
+    assert_line 'to install docToolchain as CLI-Tool, please install'
+    assert_line 'sdkman and re-run this command.'
+    assert_line 'https://sdkman.io/install'
+    assert_line '$ curl -s "https://get.sdkman.io" | bash'
+}
+
+# bats test_tags=download
+@test "install docToolchain with sdk" {
+    # Test setup
+    source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+    sdk install doctoolchain 2.2.0
+
+    # Error since we still miss JDK
+    run -1 ./dtcw tasks --group doctoolchain
+
+    # Shows which docToolchain we use
+    assert_line "docToolchain as CLI available"
+    assert_line "use cli install /root/.local/share/sdkman/candidates/doctoolchain/current/bin/doctoolchain"
+
+    # Shows information about missing JDK
+    assert_line "docToolchain depends on java, but the java command couldn't be found in this shell (bash)"
+    assert_line 'it might be that you have installed the needed version java in another shell from which you started dtcw'
+    # TODO Since docToolchain was installed with sdkman, prefer sdkman for the java installation.
+    # Provide the java version which docToolchain needs!
+    assert_line 'dtcw is running in bash and uses the PATH to find java'
+    assert_line 'to install a local java for docToolchain, you can run'
+    assert_line './dtcw getJava'
+    assert_line 'another way to install or update java is to install'
+    assert_line 'sdkman and then java via sdkman'
+    assert_line 'https://sdkman.io/install'
+    assert_line '$ curl -s "https://get.sdkman.io" | bash'
+    assert_line '$ sdk install java'
+    assert_line 'or you can download it from https://adoptium.net/'
+    assert_line 'make sure that your java version is between 8 and 14'
+    assert_line 'If you do not want to use a local java installation, you can also use docToolchain as docker container.'
+    assert_line "In that case, specify 'docker' as first parameter in your statement."
+    assert_line 'example: ./dtcw docker generateSite'
+}
+
+# TODO: test if system already available from system
+# - correct java version
+# - java version is not the one we expect
+
+# bats test_tags=download
+@test "create docToolchainConfig" {
+    # Test setup - fix missing precondition
+    source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+
+    # TODO: where do we get this version?
+    run -0 sdk install java 11.0.18-tem
+
+    run -0 java --version
+
+    # The answer if want to create the default configuration with "y"
+    DTC_HEADLESS=false run -0 ./dtcw tasks --group doctoolchain <<< "y"
+
+    assert_line "Java Version 11"
+
+    # TODO: 'gradlew' is not available
+    assert_line "To see all tasks and more detail, run gradlew tasks --all"
+    assert_line "To see more detail about a task, run gradlew help --task <task>"
+}
+
+# bats test_tags=download
+@test "use local with sdk installation" {
+    # Pre-conditions
+    run -0 java --version
+    run -1 doctoolchain
+
+    # Will ask for a local installation which we reject
+    DTC_HEADLESS=false run -1 ./dtcw local tasks --group doctoolchain <<< "2"
+
+    assert_line "force use of local install"
+    # TODO: bug - this is misleading - docToolchain is not installed locally
+    assert_line "docToolchain not installed."
+    # TODO: bug - this is wrong
+    assert_line "sdkman not found"
+
+    assert_line "Do you wish to install doctoolchain to '/root/.doctoolchain'?"
+    assert_line '1) Yes'
+    assert_line '2) No'
+    assert_line "#? you need docToolchain as CLI-Tool installed or docker."
+    assert_line "to install docToolchain as CLI-Tool, please install"
+    assert_line "sdkman and re-run this command."
+    assert_line "https://sdkman.io/install"
+    assert_line '$ curl -s "https://get.sdkman.io" | bash'
+}
+
+# bats test_tags=download
+@test "use docker with sdk installation" {
+    skip "this use case is completly buggy"
+
+    run ./dtcw docker tasks
+
+    # TODO: same output as the test case with "local" - and buggy
+    assert_line "force use of docker"
+}
+
+# bats test_tags=download
+@test "no side effect when installing docker" {
+    mock_create docker
+
+    # The installation of docker should not have any effect
+    run -0 ./dtcw tasks --group doctoolchain
+
+    assert_line "docToolchain as CLI available"
+    assert_line "docker available"
+    assert_line "use cli install /root/.local/share/sdkman/candidates/doctoolchain/current/bin/doctoolchain"
+    assert_line "Java Version 11"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023, Max Hofer and the docToolchain contributors
+
+# Helper functions used by more  than one test suite
+
+disable_command() {
+    local cmd=$1
+    local abs_path
+    if abs_path=$(command -v $cmd); then
+        mv -n "${abs_path}" "${abs_path}.disabled"
+    else
+        return 0
+    fi
+}
+
+enable_command() {
+    local cmd=$1
+    local abs_path
+    if abs_path=$(command -v "$cmd.disabled"); then
+        mv "${abs_path}" "${abs_path%.disabled}"
+    else
+        return 0
+    fi
+}
+
+function mock_create() {
+    local file_name=/usr/local/bin/$1
+    cat << EOF >"${file_name}"
+echo "docker mock called: \$@"
+EOF
+    chmod +x "${file_name}"
+}
+
+function mock_delete() {
+    rm -f "/usr/local/bin/$1"
+}


### PR DESCRIPTION
Here is a minimal example how I think we could provide a test suite for `dtcw`.

Detailed information about the test suite may be found in `test/README.adoc`.

What I would like to discuss is:
- Should we include this test suite as it is, which adds a development dependency to `bats-core` docker container?
- Location of test cases in `${project_root}/test`: I put it there since `dtcw` is located in the project root and not part of `docToolchain`
- Integration in the CI pipeline: when should we run the tests?
    - Required to be run before releasing `dtcw`
    - Note: the runtime of those tests may be quite long. 
    - Please note that long-running tests may be filtered

