### PR TITLE
Collect includes/allow lowercase files

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -344,7 +344,7 @@ collectIncludes.with {
 
 //    separatorChar = "_" // define the allowed separators after prefix. default: "-_"
 
-//    cleanOutputFolder = true // should the output folder be emptied before generation? defailt: false
+//    cleanOutputFolder = true // should the output folder be emptied before generation? default: false
 }
 //end::collectIncludesConfig[]
 
@@ -360,7 +360,7 @@ structurizr.with {
         // path = 'src/docs/structurizr'
 
         // By default `exportStructurizr` looks for a file '${structurizr.workspace.path}/workspace.dsl'
-        // You can customize this behavior with 'filename'. Note that the workspace filename is provided without '.dsl' extension. 
+        // You can customize this behavior with 'filename'. Note that the workspace filename is provided without '.dsl' extension.
         // filename = 'workspace'
     }
 
@@ -373,7 +373,7 @@ structurizr.with {
 
         // Format of the exported diagrams. Defaults to 'plantuml' if the parameter is not provided.
         //
-        // Following formats are supported: 
+        // Following formats are supported:
         // - 'plantuml': the same as 'plantuml/structurizr'
         // - 'plantuml/structurizr': exports views to PlantUML
         // - 'plantuml/c4plantuml': exports views to PlantUML with https://github.com/plantuml-stdlib/C4-PlantUML

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -17,6 +17,8 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 * brushed up some hints when running `dtcw.ps1` and `dtcw`
 * add environment variable `DTC_CONFIG_FILE` in `dtcw` and `dtcw.ps1` to specify a configuration file other than than `docToolchainConfig.groovy` in the project root folder.
+* `collectIncludes`
+** changed regexp to start with `^[A-Za-z]` as file name to allow lowercase filenames as well.
 
 == 2.2.1 - 2023-03-05
 

--- a/scripts/collectIncludes.gradle
+++ b/scripts/collectIncludes.gradle
@@ -52,7 +52,7 @@ task collectIncludes(
         String maxPrefixLength = config.collectIncludes.maxPrefixLength?:""
         String separatorChar = config.collectIncludes.separatorChar?:"-_"
 
-        String prefixRegEx = "[A-Z]{" + minPrefixLength + "," + maxPrefixLength + "}"
+        String prefixRegEx = "[A-Za-z]{" + minPrefixLength + "," + maxPrefixLength + "}"
         String separatorCharRegEx = "[" + separatorChar + "]"
         String fileFilterRegEx = "^" + prefixRegEx + separatorCharRegEx + ".*[.](" + fileFilter + ")\$"
 
@@ -61,7 +61,7 @@ task collectIncludes(
         sourceFolder.traverse(type: FILES) { file ->
             if (file.name ==~ fileFilterRegEx) {
                 String typeRegEx = "^(" + prefixRegEx + ")" + separatorCharRegEx + ".*\$"
-                def type = file.name.replaceAll(typeRegEx,'\$1')
+                def type = file.name.replaceAll(typeRegEx,'\$1').toUpperCase()
                 if (!collections[type]) {
                     collections[type] = []
                 }

--- a/src/docs/015_tasks/03_task_collectIncludes.adoc
+++ b/src/docs/015_tasks/03_task_collectIncludes.adoc
@@ -21,7 +21,7 @@ In order to include these files in your documentation, you have to add the file 
 
 This task will handle it for you!
 
-Just stick to this file-naming pattern `^[A-Z]{3,}[-\_].\*` (begin with at least three uppercase letters and a dash/underscore) and this task will collect the file and write it to your build folder.
+Just stick to this file-naming pattern `^[A-Za-z]{3,}[-\_].\*` (begin with at least three letters and a dash/underscore) and this task will collect the file and write it to your build folder.
 You only have to include this generated file from within your documentation.
 If you provide templates for the documents, those templates are skipped if the name matches the pattern `^.\*[-\_][tT]emplate
 [-\_].*`.

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -85,5 +85,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/beji[Björn Erlwein]
 - https://github.com/camminati[Tulio Camminati]
 - https://github.com/RoettingerJ[Joachim Röttinger]
+- https://github.com/PacoVK[Pascal Euhus]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -464,7 +464,7 @@ collectIncludes.with {
 
     separatorChar = "_" // define the allowed separators after prefix. default: "-_"
 
-    cleanOutputFolder = true // should the output folder be emptied before generation? defailt: false
+    cleanOutputFolder = true // should the output folder be emptied before generation? default: false
 }
 //end::collectIncludesConfig[]
 
@@ -480,7 +480,7 @@ structurizr.with {
         // path = 'src/docs/structurizr'
 
         // By default `exportStructurizr` looks for a file '${structurizr.workspace.path}/workspace.dsl'.
-        // You can customize this behavior with 'filename'. Note that the workspace filename is provided without '.dsl' extension. 
+        // You can customize this behavior with 'filename'. Note that the workspace filename is provided without '.dsl' extension.
         // filename = 'workspace'
     }
 
@@ -493,7 +493,7 @@ structurizr.with {
 
         // Format of the exported diagrams. Defaults to 'plantuml' if the parameter is not provided.
         //
-        // Following formats are supported: 
+        // Following formats are supported:
         // - 'plantuml': the same as 'plantuml/structurizr'
         // - 'plantuml/structurizr': exports views to PlantUML
         // - 'plantuml/c4plantuml': exports views to PlantUML with https://github.com/plantuml-stdlib/C4-PlantUML


### PR DESCRIPTION
This PR allows to collect lowercase-named files with `collectIncludes` and makes docToolchain less opinionated about the naming conventions of files. :) 
 
### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

### Your first submission

* [x] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?

