### PR TITLE
CI build: upgrade GHA to use node16 instead of node12

### DIFF
--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install used packages
         run: sudo apt-get install -y graphviz shellcheck pandoc
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
           find . -type f -perm 0755 -exec egrep -l '^#!(/bin/bash|/usr/bin/env bash)' {} + | xargs shellcheck
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: ${{ matrix.jdk }}
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
Removes warning in the CI build. For more information, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/