### PR TITLE
Set duplicates strategy 

### DIFF
--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -452,3 +452,7 @@ task install (
         System.out.println ("docToolchain is installed");
     }
 }
+
+tasks.withType(Copy).configureEach {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}


### PR DESCRIPTION
Set the duplicates strategy for copy tasks. Closes #1119 

There are [alternatives](https://docs.gradle.org/7.5.1/javadoc/org/gradle/api/file/DuplicatesStrategy.html), my suggestion is to use INCLUDE