### PR TITLE
replace doctoolchain.github.io by doctoolchain.org

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -52,6 +52,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * `collectIncludes`
 ** changed regexp to start with `^[A-Za-z]` as file name to allow lowercase filenames as well.
 ** certain directories are excluded from traversal. Define `excludeDirectories` in order to skip additional directories.
+* replace old URL `doctoolchain.github.io` occurrences with the new `doctoolchain.org`
 
 == 2.2.1 - 2023-03-05
 

--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -47,7 +47,7 @@ Now, download `dtcw` into your project directory and make the script executable 
 [source, bash]
 ----
 cd <your project>
-curl -Lo dtcw doctoolchain.github.io/dtcw
+curl -Lo dtcw doctoolchain.org/dtcw
 chmod +x dtcw
 ----
 
@@ -56,7 +56,7 @@ If you don't have `curl` installed, you can also use `wget`:
 [source, bash]
 ----
 cd <your project>
-wget doctoolchain.github.io/dtcw
+wget doctoolchain.org/dtcw
 chmod +x dtcw
 ----
 
@@ -69,7 +69,7 @@ chmod +x dtcw
 [source, powershell]
 ----
 cd <your project>
-Invoke-WebRequest doctoolchain.github.io/dtcw.ps1 -Outfile dtcw.ps1
+Invoke-WebRequest doctoolchain.org/dtcw.ps1 -Outfile dtcw.ps1
 ----
 
 NOTE: Got an error message that you are not allowed to execute powershell scripts?
@@ -83,7 +83,7 @@ Try to switch to an unrestricted powershell by executing `powershell.exe -Execut
 [source, cmd]
 ----
 cd <your project>
-curl -Lo dtcw.bat doctoolchain.github.io/dtcw.bat
+curl -Lo dtcw.bat doctoolchain.org/dtcw.bat
 ----
 
 NOTE: `dtcw.bat` wraps the `dtcw.ps1` script and executes it in powershell. This might be easier to use if you haven't yet configured your powershell as a developer.

--- a/src/docs/020_tutorial/070_publishToConfluence.adoc
+++ b/src/docs/020_tutorial/070_publishToConfluence.adoc
@@ -22,7 +22,7 @@ To get around this, you can set up a fresh copy of the arc42 template in docTool
 
 In this tutorial, you'll learn how to publish the arc42 template to a Confluence cloud instance.
 
-=== Step 1. Set Up docToolchain 
+=== Step 1. Set Up docToolchain
 
 If you  have completed instructions http://doctoolchain.org/docToolchain/v2.0.x/020_tutorial/010_Install.html[install docToolchain] and http://doctoolchain.org/docToolchain/v2.0.x/020_tutorial/020_arc42.html[get the arc42 template] you can skip this part.
 
@@ -35,15 +35,15 @@ NOTE: For this tutorial, we assume that you work with a MacOs/Linux-based system
 ----
 mkdir publishToConfluenceDemo
 cd publishToConfluenceDemo
-curl -Lo dtcw doctoolchain.github.io/dtcw`
+curl -Lo dtcw doctoolchain.org/dtcw`
 ----
-+ 
++
 The result is as follows:
 +
 [%collapsible]
 ====
 ```
-gitpod /workspace/publishToConfluenceDemo (main) $ curl -Lo dtcw doctoolchain.github.io/dtcw
+gitpod /workspace/publishToConfluenceDemo (main) $ curl -Lo dtcw doctoolchain.org/dtcw
 % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
 Dload  Upload   Total   Spent    Left  Speed
 100   162  100   162    0     0   1306      0 --:--:-- --:--:-- --:--:--  1317
@@ -277,7 +277,7 @@ input = [
 api = 'https://[yourServer]/[context]/rest/api/'
 ----
 +
-In this case, the correct endpoint is `https://arc42-template.atlassian.net/wiki/rest/api/`. 
+In this case, the correct endpoint is `https://arc42-template.atlassian.net/wiki/rest/api/`.
 +
 .. Verify your endpoint and paste `https://[yourServer]/[context]/rest/api/**user/current**` in your browser, such as https://arc42-template.atlassian.net/wiki/rest/api/user/current.
 +
@@ -313,7 +313,7 @@ spaceKey = '8FE'
 
 ==== Step 2.1. Configure Confluence Authentication
 
-===== Step 2.1a. CLI Authentication with username and password (insecure) 
+===== Step 2.1a. CLI Authentication with username and password (insecure)
 
 WARNING: This method is not recommended. Instead of passing your password, you can use a Personal Access Token,
 which can easily be revoked on the event of a compromise. See
@@ -364,7 +364,7 @@ NOTE: Here is the https://id.atlassian.com/manage-profile/security/api-tokens[sh
 
 If you do not want to pass your password and you are not an admin of your Confluence instance, you can use a Personal Access Token (PAT). Follow the
 https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html#UsingPersonalAccessTokens-CreatingPATsintheapplication[Confluence
-documentation] to generate one. 
+documentation] to generate one.
 
 In the Terminal, type the following to publish to Confluence with your PAT:
 [source,shell]

--- a/src/docs/020_tutorial/120_self-contained-dtc.adoc
+++ b/src/docs/020_tutorial/120_self-contained-dtc.adoc
@@ -24,7 +24,7 @@ Start on an unrestricted system and download the docToolchain wrapper:
 ----
 mkdir dtc-self-contained
 cd dtc-self-contained
-curl -Lo dtcw doctoolchain.github.io/dtcw
+curl -Lo dtcw doctoolchain.org/dtcw
 chmod +x dtcw
 ----
 
@@ -66,12 +66,12 @@ To fetch the remaining dependencies, execute
 this will fetch the remaining dependencies and download them to `$HOME/.doctoolchain/.gradle`
 
 ==== Get an offline gradle binary
-The last needed step is to download an offline version of `gradle` for docToolchain to use.  
+The last needed step is to download an offline version of `gradle` for docToolchain to use.
 This was inspired by https://chengl.com/gradle-offline-build/.
 
 .Steps
-. Download a `gradle` binary-zip from https://services.gradle.org/distributions/ 
-. Place it in the folder `.doctoolchain/docToolchain-$VERSION/gradle/wrapper` (replace $VERSION with current docToolchain version that you installed) 
+. Download a `gradle` binary-zip from https://services.gradle.org/distributions/
+. Place it in the folder `.doctoolchain/docToolchain-$VERSION/gradle/wrapper` (replace $VERSION with current docToolchain version that you installed)
 . Go to folder `.doctoolchain/docToolchain-$VERSION/gradle/wrapper` and open the file `gradle-wrapper.properties`
 .  change the `distributionUrl` to `distributionUrl=gradle-$GRADLEVERSION-bin.zip` (replace $GRADLEVERSION with the version of the binary-zip you just downloaded)
 


### PR DESCRIPTION
closes #1106 

### All Submissions:

* [x] Did you update the `changelog.adoc`?