### PR TITLE
Improve failure handling for transitive task configuration

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -20,6 +20,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * various fixes in `dtcw`, `dtcw.ps1`:
 ** pick the right environment if none provided by the user
 ** support of JAVA_HOME which was silently ignored.
+* https://github.com/docToolchain/docToolchain/issues/220[#220 convertToDocx and convertToEpub not working]
 
 === added
 

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -220,9 +220,7 @@ task generateHTML (
         backends = ['html5']
     }
 
-    def sourceFilesHTML = sourceFiles.findAll {
-                                'html' in it.formats
-                            }
+    def sourceFilesHTML = findSourceFilesByType(['html'])
 //    onlyIf {
 //        sourceFilesHTML
 //    }
@@ -253,16 +251,14 @@ task generateHTML (
         }
     }
 
-doFirst {
-    if (sourceFilesHTML.size()==0) {
-        throw new Exception ("""
-
->> No source files defined for type HTML.
->> Please specify at least one inputFile in your docToolchainConfig.groovy
-""")
+    doFirst {
+        if (sourceFilesHTML.size()==0) {
+            throw new Exception ("""
+            >> No source files defined for type 'html'.
+            >> Please specify at least one inputFile in your docToolchainConfig.groovy
+            """)
+        }
     }
-
-}
 }
 //end::generateHTML[]
 
@@ -284,9 +280,7 @@ task generatePDF (
         'imagesoutdir'        : file("${docDir}/${config.outputPath}/images/").path
     )
 
-    def sourceFilesPDF = sourceFiles.findAll {
-        'pdf' in it.formats
-    }
+    def sourceFilesPDF = findSourceFilesByType(['pdf'])
 //    onlyIf {
 //        sourceFilesPDF
 //    }
@@ -309,6 +303,15 @@ task generatePDF (
         backends = ['pdf']
     }
 
+    doFirst {
+        if (sourceFilesPDF.size()==0) {
+            throw new Exception ("""
+            >> No source files defined for type 'pdf'.
+            >> Please specify at least one inputFile in your docToolchainConfig.groovy
+            """)
+        }
+    }
+
     /**
     //check if a remote pdfTheme is defined
     def pdfTheme = System.getenv('DTC_PDFTHEME')
@@ -318,16 +321,6 @@ task generatePDF (
         //TODO: finish this...
     }
     **/
-    doFirst {
-            if (sourceFilesPDF.size()==0) {
-                throw new Exception ("""
-
-    >> No source files defined for type PDF.
-    >> Please specify at least one inputFile in your docToolchainConfig.groovy
-    """)
-            }
-
-    }
 }
 //end::generatePDF[]
 
@@ -337,9 +330,7 @@ task generateDocbook (
         group: 'docToolchain',
         description: 'use docbook as asciidoc backend') {
 
-    def sourceFilesDOCBOOK = sourceFiles.findAll {
-        'docbook' in it.formats
-    }
+    def sourceFilesDOCBOOK = findSourceFilesByType(['docbook', 'epub', 'docx'])
 //    onlyIf {
 //        sourceFilesDOCBOOK
 //    }
@@ -365,21 +356,19 @@ task generateDocbook (
     doFirst {
         if (sourceFilesDOCBOOK.size()==0) {
             throw new Exception ("""
-
-    >> No source files defined for type docbook.
-    >> Please specify at least one inputFile in your docToolchainConfig.groovy
-    """)
+            >> No source files defined for type of '[docbook, epub, docx]'.
+            >> Please specify at least one inputFile in your docToolchainConfig.groovy
+            """)
         }
-
     }
 }
 //end::generateDocbook[]
 
 //tag::generateDeck[]
 task generateDeck (
-        type: AsciidoctorJRevealJSTask,
-        group: 'docToolchain',
-        description: 'use revealJs as asciidoc backend to create a presentation') {
+    type: AsciidoctorJRevealJSTask,
+    group: 'docToolchain',
+    description: 'use revealJs as asciidoc backend to create a presentation') {
 
     // corresponding Asciidoctor reveal.js config
     // :revealjs_theme:
@@ -406,9 +395,7 @@ task generateDeck (
         'docinfo1': '',
     )
 
-    def sourceFilesREVEAL = sourceFiles.findAll {
-        'revealjs' in it.formats
-    }
+    def sourceFilesREVEAL = findSourceFilesByType(['revealjs'])
 
     sources {
         sourceFilesREVEAL.each {
@@ -437,11 +424,10 @@ task generateDeck (
     doFirst {
         if (sourceFilesREVEAL.size()==0) {
             throw new Exception ("""
-    >> No source files defined for type 'revealjs'.
-    >> Please specify at least one inputFile in your docToolchainConfig.groovy
-    """)
+            >> No source files defined for type 'revealjs'.
+            >> Please specify at least one inputFile in your docToolchainConfig.groovy
+            """)
         }
-
     }
 }
 generateDeck.dependsOn asciidoctorGemsPrepare
@@ -457,4 +443,16 @@ task install (
 
 tasks.withType(Copy).configureEach {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
+def findSourceFilesByType (types) {
+    List<Object> sourceFilesForTask = []
+    if(sourceFiles){
+        types.each { format ->
+            sourceFilesForTask << sourceFiles.findAll {
+                format in it.formats
+            }
+        }
+    }
+    return sourceFilesForTask.flatten()
 }

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -353,6 +353,8 @@ task generateDocbook (
         backends = ['docbook']
     }
 
+    outputDir = file(targetDir+'/docbook/')
+
     doFirst {
         if (sourceFilesDOCBOOK.size()==0) {
             throw new Exception ("""

--- a/scripts/pandoc.gradle
+++ b/scripts/pandoc.gradle
@@ -6,6 +6,10 @@ task convertToDocx (
 ) {
     // All files with option `docx` in config.groovy is converted to docbook and then to docx.
     def sourceFilesDocx = sourceFiles.findAll { 'docx' in it.formats }
+    def explicitSourceFilesCount = sourceFilesDocx.size()
+    if(explicitSourceFilesCount==0){
+        sourceFilesDocx = sourceFiles.findAll { 'docbook' in it.formats }
+    }
     sourceFilesDocx.each {
         def sourceFile = it.file.replace('.adoc', '.xml')
         def targetFile = sourceFile.replace('.xml', '.docx')
@@ -28,6 +32,9 @@ task convertToDocx (
     }
     doFirst {
         new File("$targetDir/docx/").mkdirs()
+        if(explicitSourceFilesCount==0) {
+            logger.warn('WARNING: No source files defined for type "docx". Converting with best effort')
+        }
     }
 }
 //end::convertToDocx[]
@@ -40,6 +47,10 @@ task convertToEpub (
 ) {
     // All files with option `epub` in config.groovy is converted to docbook and then to epub.
     def sourceFilesEpub = sourceFiles.findAll { 'epub' in it.formats }
+    def explicitSourceFilesCount = sourceFilesEpub.size()
+    if(explicitSourceFilesCount==0){
+        sourceFilesEpub = sourceFiles.findAll { 'docbook' in it.formats }
+    }
     sourceFilesEpub.each {
         def sourceFile = it.file.replace('.adoc', '.xml')
         def targetFile = sourceFile.replace('.xml', '.epub')
@@ -53,6 +64,9 @@ task convertToEpub (
     }
     doFirst {
         new File("$targetDir/epub/").mkdirs()
+        if(explicitSourceFilesCount==0) {
+            logger.warn('WARNING: No source files defined for type "epub". Converting with best effort')
+        }
     }
 }
 //end::convertToEpub[]
@@ -72,12 +86,12 @@ task createReferenceDoc (
     args = ["-o", "${docDir}/${referenceDocFile}",
             "--print-default-data-file",
             "reference.docx"]
-    
+
     doFirst {
         if(!(referenceDocFile?.trim())) {
             throw new GradleException("Option `referenceDocFile` is not defined in config.groovy or has an empty value.")
         }
-    }   
+    }
 }
 //end::createReferenceDoc[]
 

--- a/scripts/pandoc.gradle
+++ b/scripts/pandoc.gradle
@@ -1,3 +1,27 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
+task verifyPandoc {
+    doLast{
+        def result = exec{
+            def command = "pandoc"
+            ignoreExitValue = true
+            if(DefaultNativePlatform.currentOperatingSystem.isWindows()){
+                executable = "cmd"
+                args "/C", command
+            } else {
+                executable = "bash"
+                args "-c", command
+            }
+        }
+        if(result.getExitValue()!=0){
+            throw new Exception ("""
+            >> Task requires 'pandoc'.
+            >> Please ensure your system has 'pandoc' installed https://pandoc.org/installing.html
+            """)
+        }
+    }
+}
+
 //tag::convertToDocx[]
 task convertToDocx (
         group: 'docToolchain',
@@ -14,6 +38,10 @@ task convertToDocx (
         def sourceFile = it.file.replace('.adoc', '.xml')
         def targetFile = sourceFile.replace('.xml', '.docx')
 
+        new File("$targetDir/docx/$targetFile")
+            .getParentFile()
+            .getAbsoluteFile().mkdirs()
+
         workingDir "$targetDir/docbook"
         executable = "pandoc"
 
@@ -26,12 +54,17 @@ task convertToDocx (
         } else {
             args = ["-r","docbook",
                     "-t","docx",
-                    "-o","../docx/$targetFile",
+                    "-o","./../docx/$targetFile",
                     sourceFile]
         }
     }
     doFirst {
-        new File("$targetDir/docx/").mkdirs()
+        if(sourceFilesDocx.size()==0){
+            throw new Exception ("""
+            >> No source files defined for type 'docx'.
+            >> Please specify at least one inputFile in your docToolchainConfig.groovy
+            """)
+        }
         if(explicitSourceFilesCount==0) {
             logger.warn('WARNING: No source files defined for type "docx". Converting with best effort')
         }
@@ -55,6 +88,10 @@ task convertToEpub (
         def sourceFile = it.file.replace('.adoc', '.xml')
         def targetFile = sourceFile.replace('.xml', '.epub')
 
+        new File("$targetDir/epub/$targetFile")
+            .getParentFile()
+            .getAbsoluteFile().mkdirs()
+
         workingDir "$targetDir/docbook"
         executable = "pandoc"
         args = ['-r','docbook',
@@ -63,7 +100,12 @@ task convertToEpub (
                 sourceFile]
     }
     doFirst {
-        new File("$targetDir/epub/").mkdirs()
+        if(sourceFilesEpub.size()==0){
+            throw new Exception ("""
+            >> No source files defined for type 'epub'.
+            >> Please specify at least one inputFile in your docToolchainConfig.groovy
+            """)
+        }
         if(explicitSourceFilesCount==0) {
             logger.warn('WARNING: No source files defined for type "epub". Converting with best effort')
         }
@@ -71,6 +113,8 @@ task convertToEpub (
 }
 //end::convertToEpub[]
 project.afterEvaluate {
+    project.tasks.convertToDocx.dependsOn verifyPandoc
+    project.tasks.convertToEpub.dependsOn verifyPandoc
     project.tasks.convertToDocx.dependsOn generateDocbook
     project.tasks.convertToEpub.dependsOn generateDocbook
 }

--- a/src/test/groovy/docToolchain/GenerateDeckSpec.groovy
+++ b/src/test/groovy/docToolchain/GenerateDeckSpec.groovy
@@ -32,9 +32,8 @@ class GenerateDeckSpec extends Specification {
                     .withArguments(['generateDeck','--info', '-PinputPath=src/test/docs','-PmainConfigFile=src/test/config_without_revealjs.groovy'])
                     .build()
         then: 'we get an exception'
-            def e = thrown java.lang.Exception
+        def e = thrown java.lang.Exception
         and: 'it contains some info about the problem'
-            e.message.contains('Please specify at least one inputFile in your docToolchainConfig.groovy')
+        e.message.contains('Please specify at least one inputFile in your docToolchainConfig.groovy')
     }
-
 }

--- a/src/test/groovy/docToolchain/PandocSpec.groovy
+++ b/src/test/groovy/docToolchain/PandocSpec.groovy
@@ -1,0 +1,88 @@
+package docToolchain
+
+import org.gradle.testkit.runner.GradleRunner
+import spock.lang.Requires
+import spock.lang.Specification
+
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class PandocSpec extends Specification {
+
+    void 'test pandoc verification on linux'() {
+        when: 'the gradle task is invoked on linux'
+        def result = GradleRunner.create()
+            .withProjectDir(new File('.'))
+            .withArguments([
+                'verifyPandoc',
+                '--info',
+            ])
+            .build()
+        then: 'pandoc exists and the task succeeded'
+            result.task(":verifyPandoc").outcome == SUCCESS
+    }
+
+    @Requires({ os.windows })
+    void 'test pandoc verification on windows'() {
+        when: 'the gradle task is invoked on windows'
+        def result = GradleRunner.create()
+            .withProjectDir(new File('.'))
+            .withArguments([
+                'verifyPandoc',
+                '--info',
+            ])
+            .build()
+        then: 'pandoc exists and the task succeeded'
+        result.task(":verifyPandoc").outcome == SUCCESS
+    }
+
+    void 'test convert to docx with "docx" configuration'() {
+        when: 'convertToDocx task is invoked with explicit docx configuration'
+        def result = GradleRunner.create()
+            .withProjectDir(new File('.'))
+            .withArguments([
+                'convertToDocx',
+                '-PoutputPath=../../../build/test/docs/pandoc/explicit',
+                '-PmainConfigFile=./src/test/testPandoc/config.groovy',
+                '--info',
+            ])
+            .build()
+        then: 'the task succeeded'
+        result.task(":convertToDocx").outcome == SUCCESS
+        and: 'the output does not contain the warning'
+            !result.output.contains('WARNING: No source files defined for type "docx".')
+    }
+
+    void 'test convert to docx without "docx" but with "docbook" configuration'() {
+        when: 'convertToDocx task is invoked without explicit docx configuration'
+        def result = GradleRunner.create()
+            .withProjectDir(new File('.'))
+            .withArguments([
+                'convertToDocx',
+                '-PoutputPath=../../../build/test/docs/pandoc/implicit',
+                '-PmainConfigFile=./src/test/testPandoc/implicit_config.groovy',
+                '--info',
+            ])
+            .build()
+        then: 'the task succeeded'
+        result.task(":convertToDocx").outcome == SUCCESS
+        and: 'the output does contain the warning'
+            result.output.contains('WARNING: No source files defined for type "docx".')
+    }
+
+    void 'test convert to docx without required configuration'() {
+        when: 'convertToDocx task is invoked with missing configuration'
+        def result = GradleRunner.create()
+            .withProjectDir(new File('.'))
+            .withArguments([
+                'convertToDocx',
+                '-PmainConfigFile=./src/test/testPandoc/missing_config.groovy',
+                '--info',
+            ])
+            .buildAndFail()
+        then: 'the task failed'
+        result.task(":convertToDocx").outcome == FAILED
+        and: 'threw an exception'
+        result.output.contains('No source files defined for type \'docx\'')
+    }
+}

--- a/src/test/testPandoc/config.groovy
+++ b/src/test/testPandoc/config.groovy
@@ -1,0 +1,16 @@
+
+inputPath = 'src/test/testPandoc/docs'
+
+outputPath = 'build/test/docs/pandoc'
+
+inputFiles = [
+        [file: 'simple.adoc', formats: ['docx']],
+             ]
+
+taskInputsDirs = [
+    "${inputPath}/",
+]
+
+taskInputsFiles = [
+    "${inputPath}/simple.adoc"
+]

--- a/src/test/testPandoc/docs/simple.adoc
+++ b/src/test/testPandoc/docs/simple.adoc
@@ -1,0 +1,5 @@
+= Simple Test
+
+== Foo
+
+Content in document.

--- a/src/test/testPandoc/implicit_config.groovy
+++ b/src/test/testPandoc/implicit_config.groovy
@@ -1,0 +1,16 @@
+
+inputPath = 'src/test/testPandoc/docs'
+
+outputPath = 'build/test/docs/pandoc'
+
+inputFiles = [
+        [file: 'simple.adoc', formats: ['docbook']],
+             ]
+
+taskInputsDirs = [
+    "${inputPath}/",
+]
+
+taskInputsFiles = [
+    "${inputPath}/simple.adoc"
+]

--- a/src/test/testPandoc/missing_config.groovy
+++ b/src/test/testPandoc/missing_config.groovy
@@ -1,0 +1,16 @@
+
+inputPath = 'src/test/testPandoc/docs'
+
+outputPath = 'build/test/docs/pandoc'
+
+inputFiles = [
+        [file: 'simple.adoc', formats: ['html']],
+             ]
+
+taskInputsDirs = [
+    "${inputPath}/",
+]
+
+taskInputsFiles = [
+    "${inputPath}/simple.adoc"
+]


### PR DESCRIPTION
Closes #220 

print warning instead of throwing an exception when config for input files is missing. Default will convert all files registered as input

### All Submissions:

* [x] Did you update the `changelog.adoc`?
