### PR TITLE
upgrade org.asciidoctor.asciidoctorj-diagram to latest version 2.2.7

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -44,6 +44,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 ** 'com.github.ben-manes.versions:0.46.0'
 ** 'com.athaydes:spock-reports:2.3.2-groovy-3.0'
 ** 'org.spockframework:spock-core:2.3-groovy-3.0'
+** 'org.asciidoctor.asciidoctorj-diagram:2.2.7'
 * `dtcw` and `dtcw.ps1`:
 ** improve output with hints to guide the user
 ** add `--version` option

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -131,7 +131,7 @@ asciidoctorj {
     version = '2.5.7'
     modules {
         diagram.use()
-        diagram.version '1.5.16'
+        diagram.version '2.2.7'
     }
     fatalWarnings ~/image to embed not found or not readable/
 


### PR DESCRIPTION
Fixes #1136  with the upgrade of a very old version of org.asciidoctor.asciidoctorj-diagram 1.5.16 --> 2.2.7

### All Submissions:

* [x] Did you update the `changelog.adoc`?