### PR TITLE
Fix/confluence export

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -19,6 +19,10 @@ imageDirs = [
         /** imageDirs **/
 ]
 
+// whether the build should fail when detecting broken image references
+// if this config is set to true all images will be embedded
+failOnMissingImages = true
+
 taskInputsDirs = ["${inputPath}/images"]
 
 taskInputsFiles = []

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -17,6 +17,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * https://github.com/docToolchain/docToolchain/issues/973[#973: `dtcw getJava` doesn't work without `local`]
 * https://github.com/docToolchain/docToolchain/issues/1109[#1109: docToolchain release notes contain releases twice]
 * https://github.com/docToolchain/docToolchain/issues/1031[#1031: dtcw ignores installed Java RE when docker is installed - your java version 17 is too new]
+* https://github.com/docToolchain/docToolchain/issues/1163[#1163: upload to confluence breaks with embedded images]
 * https://github.com/docToolchain/docToolchain/issues/1161[#1161: publishToConfluence looses the id when generating level 2 page anchors]
 * various fixes in `dtcw`, `dtcw.ps1`:
 ** pick the right environment if none provided by the user
@@ -24,6 +25,8 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * https://github.com/docToolchain/docToolchain/issues/220[#220 convertToDocx and convertToEpub not working]
 
 === added
+* configure if build should fail on missing images
+** introduces configuration property `failOnMissingImages`
 
 === changed
 
@@ -59,6 +62,8 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 ** changed regexp to start with `^[A-Za-z]` as file name to allow lowercase filenames as well.
 ** certain directories are excluded from traversal. Define `excludeDirectories` in order to skip additional directories.
 * doc: replace old URL `doctoolchain.github.io` occurrences with the new `doctoolchain.org`
+* `publishToConfluence`
+** support embedded images
 
 == 2.2.1 - 2023-03-05
 

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -149,9 +149,15 @@ asciidoctorj {
         'sectanchors'         : 'true@',
         'targetDir'           : targetDir,
         'docDir'              : docDir,
-        'projectRootDir'      : "${new File(docDir).canonicalPath}@",
-        'data-uri': '',
+        'projectRootDir'      : "${new File(docDir).canonicalPath}@"
     )
+
+    def failOnMissingImages = (findProperty("failOnMissingImages")?:config.failOnMissingImages)?:true
+    if(failOnMissingImages == true){
+        attributes(
+            'data-uri': '',
+        )
+    }
 
     // Here we can add the code for extensions we write.
     docExtensions {

--- a/src/test/groovy/docToolchain/AsciidoctorSpec.groovy
+++ b/src/test/groovy/docToolchain/AsciidoctorSpec.groovy
@@ -4,10 +4,15 @@ import org.gradle.testkit.runner.GradleRunner
 import spock.lang.Specification
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class AsciidoctorSpec extends Specification {
 
+    public static final File outputPath = new File('./src/test/testAsciidoctor/build/test/docs/asciidoctor')
+
     void 'test correct handling of images'() {
+        given: 'a clean the environment'
+        outputPath.deleteDir()
         when: 'input file contains images'
         def file = new File('src/test/testAsciidoctor/docs/broken_images.adoc')
         println file.canonicalPath
@@ -32,7 +37,36 @@ class AsciidoctorSpec extends Specification {
         and: 'threw an exception to fail the build'
             result.output.contains('at org.asciidoctor.gradle.remote.ExecutorBase.failOnWarnings')
         and: 'an output file has been created'
-            new File('./build/test/docs/asciidoctor/broken_images.html').exists()
+            new File('./src/test/testAsciidoctor/build/test/docs/asciidoctor/broken_images.html').exists()
+    }
+
+    void 'test correct handling of images, ignoring missing images'() {
+        given: 'a clean the environment'
+        outputPath.deleteDir()
+        when: 'input file contains images'
+        def file = new File('src/test/testAsciidoctor/docs/broken_images.adoc')
+        println file.canonicalPath
+        def fileContent = file.text
+        then: ''
+        fileContent.contains('image:')
+        when: 'the gradle task is invoked'
+        def result = GradleRunner.create()
+            .withProjectDir(new File('.'))
+            .withArguments([
+                'asciidoctor',
+                '--info',
+                '-PfailOnMissingImages=false',
+                '-PdocDir=./src/test/testAsciidoctor',
+                '-PmainConfigFile=testAsciidoctor.groovy',
+            ])
+            .build()
+        then: 'the task has been failed'
+        result.task(":asciidoctor").outcome == SUCCESS
+        and: 'the output does not contain the warning "image to embed not found or not readable"'
+        println result.output
+            !result.output.contains('- image to embed not found or not readable:')
+        and: 'an output file has been created'
+        new File('./src/test/testAsciidoctor/build/test/docs/asciidoctor/broken_images.html').exists()
     }
 
 }

--- a/src/test/testAsciidoctor/testAsciidoctor.groovy
+++ b/src/test/testAsciidoctor/testAsciidoctor.groovy
@@ -1,7 +1,7 @@
 
 inputPath = 'docs'
 
-outputPath = '../../../build/test/docs/asciidoctor'
+outputPath = 'build/test/docs/asciidoctor'
 
 inputFiles = [
         [file: 'broken_images.adoc', formats: ['html']],

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -19,7 +19,7 @@ inputFiles = [
 //folders in which asciidoc will find images.
 //these will be copied as resources to ./images
 //folders are relative to inputPath
-// Hint: If you define an imagepath in your documents like 
+// Hint: If you define an imagepath in your documents like
 // :imagesdir: ./whatsoever
 // define it conditional like
 // ifndef::imagesdir[:imagesdir: ./whatsoever]
@@ -27,6 +27,10 @@ inputFiles = [
 imageDirs = [
     /** imageDirs **/
 ]
+
+// whether the build should fail when detecting broken image references
+// if this config is set to true all images will be embedded
+failOnMissingImages = true
 
 // these are directories (dirs) and files which Gradle monitors for a change
 // in order to decide if the docs have to be re-build


### PR DESCRIPTION
This PR addresses  #1163 
* Changes in :publishToConfluence that this task can handle embedded images
* Configure if build should fail on missing images 

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?