### PR TITLE
Gradle 8 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,14 +5,12 @@ import java.util.zip.ZipFile
  */
 
 plugins {
-    id "org.aim42.htmlSanityCheck" version "1.1.6"
-    id "com.github.ben-manes.versions" version "0.46.0"
-    id "org.openapi.generator" version "6.6.0"
-    id "de.undercouch.download" version "5.4.0"
-    id 'org.jbake.site' version '5.5.0'
-    //gretty 4.0.0 does not work with java 8
-    //gretty 3.0.8 has another problem -> #920
-    id 'org.gretty' version '3.0.6'
+    alias(libs.plugins.htmlSanityCheck)
+    alias(libs.plugins.versions)
+    alias(libs.plugins.openapi.generator)
+    alias(libs.plugins.undercouch.download)
+    alias(libs.plugins.jbake.site)
+    alias(libs.plugins.gretty)
 }
 
 apply plugin:'groovy'
@@ -27,23 +25,21 @@ dependencies {
             url mavenRepository
         }
     }
-    testImplementation('com.athaydes:spock-reports:2.3.2-groovy-3.0') {
+    testImplementation(libs.spock.reports) {
         exclude group: 'org.codehaus.groovy', module: 'groovy-xml'
     }
     testImplementation(
-            ('org.junit.jupiter:junit-jupiter-api:5.9.3'),
-            ('org.spockframework:spock-core:2.3-groovy-3.0'),
+            (libs.junit),
+            (libs.spock.core),
             //('org.slf4j:slf4j-api:1.7.13'),
             //('org.slf4j:slf4j-simple:1.7.13'),
             gradleTestKit(),
             //for the renderToConfluence Task
-            ('org.apache.httpcomponents:httpmime:4.5.10'),
-            ('org.jsoup:jsoup:1.16.1'),
-            ('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2')
+            (libs.httpmime),
+            (libs.jsoup),
+            (libs.http.builder)
     )
-    testRuntimeOnly(
-        "net.bytebuddy:byte-buddy:1.14.4"
-    )
+    testRuntimeOnly(libs.byte.buddy)
 }
 
 test {

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -33,7 +33,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 === changed
 
 * add support for Java 17, drop support for Java 8
-* upgrade Gradle to 7.5.1
+* upgrade Gradle to 8.1.1
 * upgrade dependencies
 ** 'com.athaydes:spock-reports:2.3.2-groovy-3.0'
 ** 'com.github.ben-manes.versions:0.46.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,0 +1,68 @@
+[versions]
+groovy = "3.0.13"
+# Plugins
+htmlSanityCheck = "1.1.6"
+versions = "0.46.0"
+openapi = "6.6.0"
+undercouch-download = "5.4.0"
+jbake = "5.5.0"
+# gretty 4.0.0 does not work with java 8
+# gretty 3.0.8 has another problem -> #920
+gretty = "3.0.6"
+
+# Libs
+asciidoctor-jvm = "4.0.0-alpha.1"
+jsoup = "1.16.1"
+apache-poi = "5.2.3"
+markdown-to-asciidoc = "1.1"
+structurizr-dsl = "1.29.1"
+structurizr-export = "1.14.0"
+structurizr-graphviz = "2.0.0"
+structurizr-d2-exporter = "1.2.0"
+openai-gpt3 = "0.12.0"
+asciidoctorj-diagram = "2.2.7"
+pebble = "3.2.0"
+
+# Test
+spock = "2.3-groovy-3.0"
+spock-reports = "2.3.2-groovy-3.0"
+junit = "5.9.3"
+httpmime = "4.5.14"
+http-builder = "0.7.2"
+byte-buddy = "1.14.4"
+
+[plugins]
+htmlSanityCheck = { id = "org.aim42.htmlSanityCheck", version.ref = "htmlSanityCheck"}
+versions = { id = "com.github.ben-manes.versions", version.ref = "versions"}
+openapi-generator = { id = "org.openapi.generator", version.ref = "openapi"}
+undercouch-download = { id = "de.undercouch.download", version.ref = "undercouch-download"}
+jbake-site = { id = "org.jbake.site", version.ref = "jbake"}
+gretty = { id = "org.gretty", version.ref = "gretty"}
+
+[libraries]
+groovy-xml = { module = "org.codehaus.groovy:groovy-xml", version.ref = "groovy" }
+asciidoctor = { module = "org.asciidoctor:asciidoctor-gradle-jvm", version.ref = "asciidoctor-jvm" }
+asciidoctor-pdf = { module = "org.asciidoctor:asciidoctor-gradle-jvm-pdf", version.ref = "asciidoctor-jvm" }
+asciidoctor-gems = { module = "org.asciidoctor:asciidoctor-gradle-jvm-gems", version.ref = "asciidoctor-jvm" }
+asciidoctor-slides = { module = "org.asciidoctor:asciidoctor-gradle-jvm-slides", version.ref = "asciidoctor-jvm" }
+jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
+html-sanity-check = { module = "org.aim42.htmlSanityCheck:org.aim42.htmlSanityCheck.gradle.plugin", version.ref = "htmlSanityCheck" }
+poi-ooxml =  { module = "org.apache.poi:poi-ooxml", version.ref = "apache-poi" }
+markdown-to-asciidoc =  { module = "nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc", version.ref = "markdown-to-asciidoc" }
+openapi-generator = { module = "org.openapitools:openapi-generator-gradle-plugin", version.ref = "openapi" }
+structurizr-dsl = { module = "com.structurizr:structurizr-dsl", version.ref = "structurizr-dsl" }
+structurizr-export = { module = "com.structurizr:structurizr-export", version.ref = "structurizr-export" }
+structurizr-graphviz = { module = "com.structurizr:structurizr-graphviz", version.ref = "structurizr-graphviz" }
+structurizr-d2-exporter = { module = "io.github.goto1134:structurizr-d2-exporter", version.ref = "structurizr-d2-exporter" }
+openai-gpt3-service = { module = "com.theokanning.openai-gpt3-java:service", version.ref = "openai-gpt3" }
+asciidoctorj-diagram = { module = "org.asciidoctor:asciidoctorj-diagram", version.ref = "asciidoctorj-diagram" }
+pebble = { module = "io.pebbletemplates:pebble", version.ref = "pebble" }
+
+
+# Test
+spock-core = { module = "org.spockframework:spock-core", version.ref = "spock" }
+spock-reports = { module = "com.athaydes:spock-reports", version.ref = "spock-reports" }
+junit = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+httpmime = { module = "org.apache.httpcomponents:httpmime", version.ref = "httpmime" }
+http-builder = { module = "org.codehaus.groovy.modules.http-builder:http-builder", version.ref = "http-builder" }
+byte-buddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byte-buddy" }

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -11,11 +11,12 @@ buildscript {
             url mavenRepository
         }
     }
+
     dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-jvm:4.0.0-alpha.1'
-        classpath 'org.asciidoctor:asciidoctor-gradle-jvm-pdf:4.0.0-alpha.1'
-        classpath 'org.asciidoctor:asciidoctor-gradle-jvm-gems:4.0.0-alpha.1'
-        classpath 'org.asciidoctor:asciidoctor-gradle-jvm-slides:4.0.0-alpha.1'
+        classpath libs.asciidoctor
+        classpath libs.asciidoctor.pdf
+        classpath libs.asciidoctor.gems
+        classpath libs.asciidoctor.slides
     }
 }
 

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -176,9 +176,26 @@ asciidoctorj {
 }
 //tag::AsciidoctorTask[]
 
+// start Gradle 8 workaround
+// TODO: Remove it after AsciidoctorJ 4.0.0 new release, workaround to fix NoClassDefFoundError on Gradle 7.6,
+// see https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/655#issuecomment-1374479836
+configurations {
+    asciidocExtensions
+}
+
+dependencies {
+    asciidocExtensions gradleApi()
+}
+// end Gradle 8 workaround
+
 // common settings for asciidoctor
 // this is needed for PDF generation with plantUML
 tasks.withType(AbstractAsciidoctorTask) { docTask ->
+
+    // start Gradle 8 workaround
+    // TODO: remove this after AsciidoctorJ is Gradle 8 compatible
+    configurations 'asciidocExtensions'
+    // end Gradle 8 workaround
 
     baseDirFollowsSourceFile()
 

--- a/scripts/asciidoc2confluence.groovy
+++ b/scripts/asciidoc2confluence.groovy
@@ -28,13 +28,6 @@
 */
 
 // some dependencies
-/**
-@Grapes(
-        [@Grab('org.jsoup:jsoup:1.8.2'),
-         @Grab('org.codehaus.groovy.modules.http-builder:http-builder:0.6' ),
-         @Grab('org.apache.httpcomponents:httpmime:4.5.1')]
-)
-**/
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import org.jsoup.nodes.Entities.EscapeMode

--- a/scripts/confluence2asciidoc.groovy
+++ b/scripts/confluence2asciidoc.groovy
@@ -1,12 +1,4 @@
 //WIP
-// some dependencies
-/**
-@Grapes(
-        [@Grab('org.jsoup:jsoup:1.8.2'),
-         @Grab('org.codehaus.groovy.modules.http-builder:http-builder:0.6' ),
-         @Grab('org.apache.httpcomponents:httpmime:4.5.1')]
-)
-**/
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import org.jsoup.nodes.Entities.EscapeMode

--- a/scripts/confluenceToAsciiDoc.groovy
+++ b/scripts/confluenceToAsciiDoc.groovy
@@ -1,8 +1,3 @@
-/**
-@Grapes(
-        [@Grab('org.jsoup:jsoup:1.14.3')]
-)
-**/
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import org.jsoup.nodes.Document
@@ -229,7 +224,7 @@ images/${folderStructure.join("/")}/${documentId}.png
                             element.before("""
     <div class="lucidchart-wrapper">
 ${lucidInfos.replaceAll("\n", "%%CRLF%%")}
-    $chart 
+    $chart
     https://lucid.app/lucidchart/${documentId}/edit[edit lucidchart]
     </div>
     """)

--- a/scripts/exportConfluence.gradle
+++ b/scripts/exportConfluence.gradle
@@ -10,11 +10,11 @@ buildscript {
     }
     dependencies {
         //for the exportJiraIssues Task
-        classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
+        classpath libs.http.builder
         //for the renderToConfluence Task
-        classpath 'org.apache.httpcomponents:httpmime:4.5.14'
-        classpath 'org.jsoup:jsoup:1.15.4'
-        classpath 'org.codehaus.groovy:groovy-xml:3.0.13'
+        classpath libs.httpmime
+        classpath libs.jsoup
+        classpath libs.groovy.xml
     }
 }
 

--- a/scripts/exportEAPJiraPrintHelper.groovy
+++ b/scripts/exportEAPJiraPrintHelper.groovy
@@ -1,4 +1,3 @@
-@Grab("org.codehaus.groovy.modules.http-builder:http-builder:0.7.2" )
 import groovyx.net.http.RESTClient
 import groovyx.net.http.HttpResponseException
 import groovyx.net.http.HTTPBuilder

--- a/scripts/exportExcel.gradle
+++ b/scripts/exportExcel.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         //for export Excel Task
-        classpath 'org.apache.poi:poi-ooxml:5.2.3'
+        classpath libs.poi.ooxml
     }
 }
 

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -10,8 +10,8 @@ buildscript {
     }
     dependencies {
         //for the exportJiraIssues Task
-        classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
-        classpath 'org.apache.poi:poi-ooxml:5.2.3'
+        classpath libs.http.builder
+        classpath libs.poi.ooxml
     }
 }
 

--- a/scripts/exportJiraSprintChangelog.gradle
+++ b/scripts/exportJiraSprintChangelog.gradle
@@ -10,8 +10,8 @@ buildscript {
     }
     dependencies {
         //for the exportJiraRelaseNotes Task
-        classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
-        classpath 'org.apache.poi:poi-ooxml:5.2.3'
+        classpath libs.http.builder
+        classpath libs.poi.ooxml
     }
 }
 

--- a/scripts/exportMarkdown.gradle
+++ b/scripts/exportMarkdown.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         //for the markdown conversion
-        classpath 'nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc:1.1'
+        classpath libs.markdown.to.asciidoc
     }
 }
 

--- a/scripts/exportOpenApi.gradle
+++ b/scripts/exportOpenApi.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.openapitools:openapi-generator-gradle-plugin:6.6.0"
+        classpath libs.openapi.generator
     }
 }
 apply plugin: 'org.openapi.generator'

--- a/scripts/exportStructurizr.gradle
+++ b/scripts/exportStructurizr.gradle
@@ -9,10 +9,10 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.structurizr:structurizr-dsl:1.29.1'
-        classpath 'com.structurizr:structurizr-export:1.14.0'
-        classpath 'io.github.goto1134:structurizr-d2-exporter:1.2.0'
-        classpath 'com.structurizr:structurizr-graphviz:2.0.0'
+        classpath libs.structurizr.dsl
+        classpath libs.structurizr.export
+        classpath libs.structurizr.d2.exporter
+        classpath libs.structurizr.graphviz
     }
 }
 

--- a/scripts/fixGlobalReferences.gradle
+++ b/scripts/fixGlobalReferences.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'org.jsoup:jsoup:1.15.4'
+        classpath libs.jsoup
     }
 }
 

--- a/scripts/generateContent.gradle
+++ b/scripts/generateContent.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.theokanning.openai-gpt3-java:service:0.12.0'
+        classpath libs.openai.gpt3.service
     }
 }
 

--- a/scripts/generateSite.gradle
+++ b/scripts/generateSite.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'org.asciidoctor:asciidoctorj-diagram:2.2.7'
+        classpath libs.asciidoctorj.diagram
     }
 }
 repositories {
@@ -25,8 +25,8 @@ repositories {
     }
 }
 dependencies {
-    jbake 'org.asciidoctor:asciidoctorj-diagram:2.2.7'
-    jbake 'io.pebbletemplates:pebble:3.2.0'
+    jbake libs.asciidoctorj.diagram
+    jbake libs.pebble
     config.jbake.plugins.each { plugin ->
         jbake plugin
     }

--- a/scripts/html2asciidoc.groovy
+++ b/scripts/html2asciidoc.groovy
@@ -1,6 +1,3 @@
-@Grapes(
-    [@Grab('org.jsoup:jsoup:1.8.2'),]
-)
 import org.jsoup.Jsoup
 import org.jsoup.select.NodeVisitor
 import org.jsoup.parser.Parser

--- a/scripts/htmlSanityCheck.gradle
+++ b/scripts/htmlSanityCheck.gradle
@@ -10,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath ('gradle.plugin.org.aim42:htmlSanityCheck:1.1.3')
+        classpath libs.html.sanity.check
     }
 }
 

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -10,10 +10,10 @@ buildscript {
     }
     dependencies {
         //for the exportJiraIssues Task
-        classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
+        classpath libs.http.builder
         //for the renderToConfluence Task
-        classpath 'org.apache.httpcomponents:httpmime:4.5.14'
-        classpath 'org.jsoup:jsoup:1.15.4'
+        classpath libs.httpmime
+        classpath libs.jsoup
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,3 +17,12 @@ include 'services:webservice'
 */
 
 rootProject.name = 'docToolchain'
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("libs.versions.toml"))
+        }
+    }
+}
+


### PR DESCRIPTION
# Upgrade to Gradle 8

This PR upgrades Gradle to latest 8.1.1 using a workaround based on https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/655 
This allows us to keep up to date with Gradle versions. 

Closes #1103 

**To be discussed**
Do we want to accept the workaround, in order to move forward, or do we want to wait for the official compatibility?

### All Submissions:

* [x] Did you update the `changelog.adoc`?
