### PR TITLE
Fix issue #1193 with String constructor on converting to utf-8

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -9,6 +9,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === fixes
 
+* https://github.com/docToolchain/docToolchain/issues/1193[#1193: exportEA fails since v2.0.5 with an exception]
 * https://github.com/docToolchain/docToolchain/issues/395[#395 asciidoctor-diagram: ERROR: Failed to generate image: PlantUML image generation failed]
 * https://github.com/docToolchain/docToolchain/issues/455[#455 Force execution to stop with failure on missing image reference]
 * https://github.com/docToolchain/docToolchain/issues/621[#621: dtcw - sdkman installation check returns wrong result]

--- a/scripts/exportEA.gradle
+++ b/scripts/exportEA.gradle
@@ -100,13 +100,13 @@ task streamingExecute(
             }
             def p
             try {
-                String commandUTF8 = new String(command.value, 'utf-8');
+                String commandUTF8 = new String(command.toString().getBytes(), 'utf-8');
                 p = "cmd.exe /c ${commandUTF8}".execute()
             } catch (Exception e) {
                 throw new Exception ("""
 sorry, this task currently needs needs windows as operation system
 if you started this task from WSL, please switch to powershell
-""")
+""" + e.getMessage())
 
             }
             def result = [std: '', err: '']
@@ -161,7 +161,7 @@ This is to make sure that they can be used from environments other than windows.
 
 # Warning!
 
-**The contents of this folder will be overwritten with each re-export!**
+**The contents of this folder	will be overwritten with each re-export!**
 
 use `gradle exportEA` to re-export files
 """


### PR DESCRIPTION
As described in #1193 the task exportEA fails with an exception in line 106 on latest version v2.2.1. The failing function was 'task streamingExecute'.
The message shown is not the right reason as the execution is made on Windows. The real reason for the issue is the String constructor. By using the toString().getBytes() function a byte array is created that is valid for the String constructor. It also works in case the command object is already of type String.

The fix implemented by this pull request is working with latest commit on branch 'ng', with tag v2.2.1 and older ones.