### PR TITLE
fixed curl command in manual

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -15,6 +15,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * https://github.com/docToolchain/docToolchain/issues/1192[#1192: exportExcel: unnecessary Rowspans break rendering of table]
 * https://github.com/docToolchain/docToolchain/issues/1221[#1221: generateSite: beforeToc functionality broken]
 * https://github.com/docToolchain/docToolchain/issues/1218[#1218: plantuml encoding issues]
+* fixed curl command in manual
 
 === added
 

--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -49,7 +49,7 @@ Now, download `dtcw` into your project directory and make the script executable 
 [source, bash]
 ----
 cd <your project>
-curl -Lo dtcw doctoolchain.org/dtcw
+curl -Lo dtcw https://doctoolchain.org/dtcw
 chmod +x dtcw
 ----
 

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -90,5 +90,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/sparsick[Sandra Parsick]
 - https://github.com/johthor[Johannes Thorn]
 - https://github.com/srotman[Stefan Rotman]
+- https://github.com/klatka[Kevin Latka]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
Without I get `curl: (7) Failed to connect to doctoolchain.org port 80 after 2315 ms: Couldn't connect to server`

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [x] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [x] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
