### PR TITLE
include core module in dist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,13 @@ task prepareDist() {
             into new File(buildDir,distFolder+"/resources")
         }
         copy{
+            from (new File("./core")) {
+                include "*"
+                include "**/*"
+            }
+            into new File(buildDir,distFolder+"/core")
+        }
+        copy{
             from new File("./scripts")
             into new File(buildDir,distFolder+"/scripts")
         }


### PR DESCRIPTION
During release of docToolchain a zip file is generated. This is used for local installs, but the new core module was missing. 

