### PR TITLE
Add new optional parameter for docker images

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -10,6 +10,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 === fixes
 
 === added
+* https://github.com/docToolchain/docToolchain/issues/1327[#1327: Allow use of enhanced docker image]
 
 === changed
 

--- a/dtcw
+++ b/dtcw
@@ -41,7 +41,7 @@ GITHUB_PROJECT_URL=https://github.com/docToolchain/docToolchain
 GITHUB_PROJECT_URL_SSH=git@github.com:docToolchain/docToolchain
 
 # Bump this version up if something is changed in the wrapper script
-DTCW_VERSION=0.50
+DTCW_VERSION=0.51
 # Template replaced by the GitHub value upon releasing dtcw
 DTCW_GIT_HASH=##DTCW_GIT_HASH##
 
@@ -88,15 +88,24 @@ main() {
 
     # No install command, so forward call to docToolchain but first we check if
     # everything is there.
+    docker_image_name=""
     if [[ ${environment} != docker ]]; then
         assert_doctoolchain_installed "${environment}" "${DTC_VERSION}"
         assert_java_version_supported
 
         # TODO: what if 'doctoolchain' found by $PATH does not match the one from the local environment?
         # The version provided by $DTC_VERSION could be a different one.
+    else
+        docker_image_name="doctoolchain/doctoolchain"
+        if [ "${1}" = "image" ]; then
+            docker_image_name="${2-}"
+            shift 2
+            assert_argument_exists "$@"
+        fi
+        echo "Using docker image: ${docker_image_name}"
     fi
 
-    command=$(build_command "${environment}" "${DTC_VERSION}" "$@")
+    command=$(build_command "${environment}" "${DTC_VERSION}" "${docker_image_name}" "$@")
 
     [[ "${DTC_HEADLESS}" = true ]] && echo "Using headless mode since there is no (terminal) interaction possible"
 
@@ -585,7 +594,8 @@ how_to_install_doctoolchain() {
 build_command() {
     local env=${1}
     local version=${2}
-    shift 2
+    local docker_image=${3}
+    shift 3
     local cmd
     if [ "${env}" = docker ]; then
         # TODO: DTC_PROJECT_BRANCH is  not passed into the docker environment
@@ -597,7 +607,7 @@ build_command() {
 
         docker_args="run --rm -i --platform linux/amd64 -u $(id -u):$(id -g) --name ${container_name} \
             -e DTC_HEADLESS=true -e DTC_SITETHEME -e DTC_PROJECT_BRANCH=${DTC_PROJECT_BRANCH} \
-            --entrypoint /bin/bash -v '${pwd}:/project' doctoolchain/doctoolchain:v${version}"
+            --entrypoint /bin/bash -v '${pwd}:/project' ${docker_image}:v${version}"
 
         cmd="docker ${docker_args} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
     else

--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -120,6 +120,39 @@ If the container engine is installed you can <<first-command>>.
 The docToolchain wrapper script in your project directory will detect the
 container engine and pull the docToolchain image on the first invocation.
 
+Some might need to create their own docker image to add additional tooling or configurations, e.g. proxy settings.
+In this case you can pass the image name via parameter `image` directly after `docker`:
+
+.Linux/Mac with bash
+[role='primary']
+---
+[source, bash]
+----
+./dtcw docker image <image_name> generateHTML
+----
+
+---
+
+.Windows with Powershell
+[role='secondary']
+---
+[source, powershell]
+----
+.\dtcw.ps1 docker image <image_name> generateHTML
+----
+
+---
+
+.Windows with cmd.exe
+[role='secondary']
+---
+
+
+[source, cmd]
+----
+.\dtcw.bat docker image <image_name> generateHTML
+----
+
 [[install-dtc-with-dtcw]]
 == Install docToolchain with `dtcw`
 

--- a/src/docs/020_tutorial/010_Install.adoc
+++ b/src/docs/020_tutorial/010_Install.adoc
@@ -21,7 +21,7 @@ include::../010_manual/20_install.adoc[tags=install]
 
 ==== `dtcw` doesn't run
 
-You might get an error similiar to this one:
+You might get an error similar to this one:
 
 [source]
 ----
@@ -36,7 +36,7 @@ Please try to redownload the wrapper.
 
 ==== docker throws and error with `dtcw`
 
-On windows you might get the following error 
+On windows you might get the following error
 [source]
 ----
 Error response from daemon: user declined directory sharing C:\Users\path_to_my_folder
@@ -55,9 +55,9 @@ You may see that docToolchain starts but crashes with a stacktrace that starts l
 Could not compile settings file '/Users/falk/.doctoolchain/docToolchain-2.0.0/settings.gradle'.
 > startup failed:
   General error during semantic analysis: Unsupported class file major version 61
-  
+
   java.lang.IllegalArgumentException: Unsupported class file major version 61
-----  
+----
 
 In this case, you've got an incompatible version of Java.
 `dtcw` tries to check the Java version up front by running  `java --version`, but Gradle sometimes picks up a different version.


### PR DESCRIPTION
If additional tools - for additional tasks - need to be installed in a docker image, it is required to allow users to select a different docker image than
docToolchain/docToolchain.

An additional optional parameter for "docker" environment is added:

"dtcw docker image <image_name> <task>"

### All Submissions:

* [y] Did you update the `changelog.adoc`?
* [y] Does your PR affect the documentation?
* [y] If yes, did you update the documentation or create an issue for updating it?