### PR TITLE
Fix warning of spellcheck

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -119,7 +119,7 @@ main() {
     fi
 
     # echo "Command to invoke: ${command}"
-    exec ${emu} ${bash} -c "${command}"
+    exec "${emu}" "${bash}" -c "${command}"
 }
 
 assert_argument_exists() {


### PR DESCRIPTION
add "" around arguments to fix warning

https://github.com/koalaman/shellcheck
* "SC2086: Double quote to prevent globbing and word splitting."

### All Submissions:

* [n] Did you update the `changelog.adoc`?
* [n] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?