### PR TITLE
Fix publishToConfluence tasks 

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -9,6 +9,8 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === fixes
 
+* https://github.com/docToolchain/docToolchain/issues/1330[#1330: Publish to confluence gives response 400 on version 3.2.0]
+
 === added
 * https://github.com/docToolchain/docToolchain/issues/1327[#1327: Allow use of enhanced docker image]
 

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClient.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClient.groovy
@@ -6,6 +6,7 @@ import org.apache.hc.client5.http.entity.mime.InputStreamBody
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder
 import org.apache.hc.client5.http.entity.mime.StringBody
 import org.apache.hc.core5.http.ClassicHttpRequest
+import org.apache.hc.core5.http.ContentType
 import org.apache.hc.core5.http.HttpEntity
 import org.apache.hc.core5.net.URIBuilder
 import org.docToolchain.configuration.ConfigService

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV1.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV1.groovy
@@ -4,11 +4,14 @@ import groovy.json.JsonBuilder
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.classic.methods.HttpPost
 import org.apache.hc.client5.http.classic.methods.HttpPut
+import org.apache.hc.core5.http.ContentType
 import org.apache.hc.core5.http.HttpRequest
 import org.apache.hc.core5.http.io.entity.StringEntity
 import org.apache.hc.core5.http.message.BasicNameValuePair
 import org.apache.hc.core5.net.URIBuilder
 import org.docToolchain.configuration.ConfigService
+
+import java.nio.charset.StandardCharsets
 
 
 class ConfluenceClientV1 extends ConfluenceClient {
@@ -26,7 +29,7 @@ class ConfluenceClientV1 extends ConfluenceClient {
     @Override
     def addLabel(pageId, label) {
         HttpRequest post = new HttpPost(API_V1_PATH + '/content/' + pageId + "/label")
-        post.setHeader('Content-Type', 'application/json')
+        post.setHeader('Content-Type', ContentType.APPLICATION_JSON)
         // TODO test if this works
         post.setEntity(new StringEntity(new JsonBuilder([label]).toPrettyString()))
         return callApiAndFailIfNot20x(post)
@@ -178,8 +181,8 @@ class ConfluenceClientV1 extends ConfluenceClient {
         requestBody.id      = pageId
         requestBody.version = [number: pageVersion, message: pageVersionComment ?: '']
         HttpPut put = new HttpPut(API_V1_PATH + '/content/' + pageId)
-        put.setHeader('Content-Type', 'application/json')
-        put.setEntity(new StringEntity(new JsonBuilder(requestBody).toPrettyString()))
+        put.setHeader('Content-Type', ContentType.APPLICATION_JSON)
+        put.setEntity(new StringEntity(new JsonBuilder(requestBody).toPrettyString(), StandardCharsets.UTF_8))
         return callApiAndFailIfNot20x(put)
     }
 
@@ -188,8 +191,8 @@ class ConfluenceClientV1 extends ConfluenceClient {
         def requestBody = getDefaultModifyPageRequestBody(title, confluenceSpaceKey, localPage, parentId)
         requestBody.version = [message: pageVersionComment ?: '']
         HttpPost post = new HttpPost(API_V1_PATH + '/content')
-        post.setHeader('Content-Type', 'application/json')
-        post.setEntity(new StringEntity(new JsonBuilder(requestBody).toPrettyString()))
+        post.setHeader('Content-Type', ContentType.APPLICATION_JSON)
+        post.setEntity(new StringEntity(new JsonBuilder(requestBody).toPrettyString(), StandardCharsets.UTF_8))
         return callApiAndFailIfNot20x(post)
     }
 

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
@@ -4,10 +4,13 @@ import groovy.json.JsonBuilder
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.classic.methods.HttpPost
 import org.apache.hc.client5.http.classic.methods.HttpPut
+import org.apache.hc.core5.http.ContentType
 import org.apache.hc.core5.http.HttpRequest
 import org.apache.hc.core5.http.io.entity.StringEntity
 import org.apache.hc.core5.net.URIBuilder
 import org.docToolchain.configuration.ConfigService
+
+import java.nio.charset.StandardCharsets
 
 class ConfluenceClientV2 extends ConfluenceClient {
 
@@ -38,7 +41,7 @@ class ConfluenceClientV2 extends ConfluenceClient {
     @Override
     def addLabel(Object pageId, Object label) {
         HttpRequest post = new HttpPost(API_V1_PATH + '/content/' + pageId + "/label")
-        post.setHeader('Content-Type', 'application/json')
+        post.setHeader('Content-Type', ContentType.APPLICATION_JSON)
         // TODO test if this works
         post.setEntity(new StringEntity(new JsonBuilder([label]).toPrettyString()))
         return callApiAndFailIfNot20x(post)
@@ -187,8 +190,8 @@ class ConfluenceClientV2 extends ConfluenceClient {
             ]
         ]
         HttpPut put = new HttpPut(API_V2_PATH + '/pages/' + pageId)
-        put.setHeader('Content-Type', 'application/json')
-        put.setEntity(new StringEntity(new JsonBuilder(requestBody).toPrettyString()))
+        put.setHeader('Content-Type', ContentType.APPLICATION_JSON)
+        put.setEntity(new StringEntity(new JsonBuilder(requestBody).toPrettyString(), StandardCharsets.UTF_8))
         return callApiAndFailIfNot20x(put)
     }
 
@@ -209,8 +212,8 @@ class ConfluenceClientV2 extends ConfluenceClient {
             ]
         ]
         HttpPost post = new HttpPost(API_V2_PATH + '/pages')
-        post.setHeader('Content-Type', 'application/json')
-        post.setEntity(new StringEntity(new JsonBuilder(requestBody).toPrettyString()))
+        post.setHeader('Content-Type', ContentType.APPLICATION_JSON)
+        post.setEntity(new StringEntity(new JsonBuilder(requestBody).toPrettyString(), StandardCharsets.UTF_8))
         return callApiAndFailIfNot20x(post)
     }
 }

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/RestClient.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/RestClient.groovy
@@ -55,7 +55,6 @@ class RestClient extends BasicRestClient {
     private constructDefaultHeaders(){
         HashSet<Header> headers = new HashSet<>([
             new BasicHeader('X-Atlassian-Token', 'no-check'),
-            new BasicHeader('Content-Type', 'application/json;charset=utf-8')
         ])
         if(configService.getConfigProperty('confluence.bearerToken')){
             headers.add(new BasicHeader('Authorization', 'Bearer ' + configService.getConfigProperty('confluence.bearerToken')))

--- a/core/src/main/groovy/org/docToolchain/atlassian/transformer/CdataTransformer.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/transformer/CdataTransformer.groovy
@@ -22,7 +22,8 @@ class CdataTransformer {
             start = html.indexOf(ConfluenceTags.CDATA_PLACEHOLDER_START, start + 1)
         }
         return new Document("")
-            .outputSettings(new Document.OutputSettings().prettyPrint(false))
+            .outputSettings(new Document.OutputSettings().prettyPrint(false)
+            .syntax(Document.OutputSettings.Syntax.xml))
             .html(html)
     }
 }

--- a/core/src/main/groovy/org/docToolchain/scripts/asciidoc2confluence.groovy
+++ b/core/src/main/groovy/org/docToolchain/scripts/asciidoc2confluence.groovy
@@ -514,7 +514,9 @@ def parseBody(body, anchors, pageAnchors) {
     if(body instanceof Element){
         bodyString = body.html()
     }
-    Element saneHtml = new Document("").outputSettings(new Document.OutputSettings().prettyPrint(false)).html(bodyString)
+    Element saneHtml = new Document("")
+        .outputSettings(new Document.OutputSettings().syntax(Document.OutputSettings.Syntax.xml).prettyPrint(false))
+        .html(bodyString)
     def pageString = new HtmlTransformer().transformToConfluenceFormat(saneHtml)
 
     return Map.of(


### PR DESCRIPTION
set header correctly and parse the content as XML to be able to handle malformed html excerpts

closes #1330 and #1332 

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?