### PR TITLE
introduce wipeConfluenceSpaceTask

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -11,6 +11,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === added
 * https://github.com/docToolchain/docToolchain/issues/1327[#1327: Allow use of enhanced docker image]
+* new task `wipeConfluenceSpace` to delete all pages of a space
 
 === changed
 

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/ConfluenceService.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/ConfluenceService.groovy
@@ -1,5 +1,6 @@
 package org.docToolchain.atlassian.confluence
 
+import org.docToolchain.atlassian.confluence.clients.ConfluenceClient
 import org.docToolchain.configuration.ConfigService
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -45,5 +46,16 @@ class ConfluenceService {
             println "Keywords:" + keywords
         }
         return keywords
+    }
+
+    def wipeConfluenceSpace(ConfluenceClient confluenceClient) {
+        String spaceKey = configService.getConfigProperty('confluence.spaceKey')
+        def allPages = confluenceClient.fetchPagesBySpaceKey(spaceKey, 100)
+        println("Deleting ${allPages.size()} pages from space ${spaceKey}")
+        allPages.each { key, page ->
+            println("Deleting page: [${page.title}]")
+            confluenceClient.deletePage(page.id)
+        }
+        println("Successfully wiped ${spaceKey}")
     }
 }

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClient.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClient.groovy
@@ -94,6 +94,8 @@ abstract class ConfluenceClient {
 
     abstract fetchPageByPageId(String id)
 
+    abstract deletePage(String id)
+
     abstract updatePage(String pageId, String title, String confluenceSpaceKey, Object localPage, Integer pageVersion, String pageVersionComment, String parentId)
 
     abstract createPage(String title, String confluenceSpaceKey, Object localPage, String pageVersionComment, String parentId)

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV1.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV1.groovy
@@ -1,6 +1,7 @@
 package org.docToolchain.atlassian.confluence.clients
 
 import groovy.json.JsonBuilder
+import org.apache.hc.client5.http.classic.methods.HttpDelete
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.classic.methods.HttpPost
 import org.apache.hc.client5.http.classic.methods.HttpPut
@@ -156,6 +157,14 @@ class ConfluenceClientV1 extends ConfluenceClient {
             .build()
         HttpRequest get = new HttpGet(uri)
         return callApiAndFailIfNot20x(get)
+    }
+
+    @Override
+    def deletePage(String id) {
+        URI uri = new URIBuilder(API_V1_PATH + "/content/${id}")
+            .build()
+        HttpRequest delete = new HttpDelete(uri)
+        return callApiAndFailIfNot20x(delete)
     }
 
     @Override

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
@@ -1,6 +1,7 @@
 package org.docToolchain.atlassian.confluence.clients
 
 import groovy.json.JsonBuilder
+import org.apache.hc.client5.http.classic.methods.HttpDelete
 import org.apache.hc.client5.http.classic.methods.HttpGet
 import org.apache.hc.client5.http.classic.methods.HttpPost
 import org.apache.hc.client5.http.classic.methods.HttpPut
@@ -156,6 +157,14 @@ class ConfluenceClientV2 extends ConfluenceClient {
             .build()
         HttpRequest get = new HttpGet(uri)
         return callApiAndFailIfNot20x(get)
+    }
+
+    @Override
+    def deletePage(String id) {
+        URI uri = new URIBuilder(API_V2_PATH + "/pages/${id}")
+            .build()
+        HttpRequest delete = new HttpDelete(uri)
+        return callApiAndFailIfNot20x(delete)
     }
 
     @Override

--- a/core/src/main/groovy/org/docToolchain/tasks/AbstractConfluenceTask.groovy
+++ b/core/src/main/groovy/org/docToolchain/tasks/AbstractConfluenceTask.groovy
@@ -1,0 +1,22 @@
+package org.docToolchain.tasks
+
+import org.docToolchain.atlassian.confluence.clients.ConfluenceClient
+import org.docToolchain.atlassian.confluence.clients.ConfluenceClientV1
+import org.docToolchain.atlassian.confluence.clients.ConfluenceClientV2
+
+abstract class AbstractConfluenceTask extends DocToolchainTask {
+
+    ConfluenceClient confluenceClient
+
+    AbstractConfluenceTask(ConfigObject config) {
+        super(config)
+        Boolean useV1Api = configService.getConfigProperty('confluence.useV1Api')
+        if(useV1Api){
+            println("Using Confluence API V1")
+            this.confluenceClient = new ConfluenceClientV1(configService)
+        } else {
+            println("Using Confluence API V2")
+            this.confluenceClient = new ConfluenceClientV2(configService)
+        }
+    }
+}

--- a/core/src/main/groovy/org/docToolchain/tasks/VerifyConfluenceApiAccessTask.groovy
+++ b/core/src/main/groovy/org/docToolchain/tasks/VerifyConfluenceApiAccessTask.groovy
@@ -1,28 +1,13 @@
 package org.docToolchain.tasks
 
-
-import org.docToolchain.atlassian.confluence.clients.ConfluenceClient
-import org.docToolchain.atlassian.confluence.clients.ConfluenceClientV1
-import org.docToolchain.atlassian.confluence.clients.ConfluenceClientV2
-
 import java.util.logging.Logger
 
-class VerifyConfluenceApiAccessTask extends DocToolchainTask {
+class VerifyConfluenceApiAccessTask extends AbstractConfluenceTask {
 
     Logger LOGGER = Logger.getLogger(VerifyConfluenceApiAccessTask.class.getName())
 
-    ConfluenceClient confluenceClient
-
     VerifyConfluenceApiAccessTask(ConfigObject config) {
         super(config)
-        Boolean useV1Api = configService.getConfigProperty('confluence.useV1Api')
-        if(useV1Api){
-            println("Using Confluence API V1")
-            this.confluenceClient = new ConfluenceClientV1(configService)
-        } else {
-            println("Using Confluence API V2")
-            this.confluenceClient = new ConfluenceClientV2(configService)
-        }
     }
 
     @Override

--- a/core/src/main/groovy/org/docToolchain/tasks/WipeConfluenceSpaceTask.groovy
+++ b/core/src/main/groovy/org/docToolchain/tasks/WipeConfluenceSpaceTask.groovy
@@ -1,0 +1,20 @@
+package org.docToolchain.tasks
+
+import org.docToolchain.atlassian.confluence.ConfluenceService
+
+import java.util.logging.Logger
+
+class WipeConfluenceSpaceTask extends AbstractConfluenceTask {
+
+    Logger LOGGER = Logger.getLogger(WipeConfluenceSpaceTask.class.getName())
+
+    WipeConfluenceSpaceTask(ConfigObject config) {
+        super(config)
+    }
+
+    @Override
+    void execute() {
+        LOGGER.warning("Wiping Confluence space...")
+        new ConfluenceService(configService).wipeConfluenceSpace(confluenceClient)
+    }
+}

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -31,9 +31,9 @@ task verifyConfluenceApiAccess(
 }
 //end::verifyConfluenceApiAccess[]
 
-//tag::wipeConfluenceSpaceTask[]
-task wipeConfluenceSpaceTask(
-    description: 'verifies confluence API URL and credentials are set correctly',
+//tag::wipeConfluenceSpace[]
+task wipeConfluenceSpace(
+    description: 'deletes all pages in the configured confluence space',
     group: 'docToolchain'
 ) {
     doLast {
@@ -50,7 +50,7 @@ task wipeConfluenceSpaceTask(
 
     }
 }
-//end::wipeConfluenceSpaceTask[]
+//end::wipeConfluenceSpace[]
 
 //tag::publishToConfluence[]
 task publishToConfluence(

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -14,6 +14,7 @@ buildscript {
 }
 
 import org.docToolchain.tasks.VerifyConfluenceApiAccessTask
+import org.docToolchain.tasks.WipeConfluenceSpaceTask
 
 //tag::verifyConfluenceApiAccess[]
 task verifyConfluenceApiAccess(
@@ -29,6 +30,27 @@ task verifyConfluenceApiAccess(
     }
 }
 //end::verifyConfluenceApiAccess[]
+
+//tag::wipeConfluenceSpaceTask[]
+task wipeConfluenceSpaceTask(
+    description: 'verifies confluence API URL and credentials are set correctly',
+    group: 'docToolchain'
+) {
+    doLast {
+        ant.input(message: "${'Do you really want to delete all pages in ' + config.confluence.spaceKey}", validargs: 'y,n', addproperty: 'confirm')
+        if(ant.confirm.toBoolean()) {
+            //TODO default should be false, if the V1 has been removed in cloud
+            config.confluence.useV1Api = findProperty("confluence.useV1Api") != null ?
+                findProperty("confluence.useV1Api") : config.confluence.useV1Api != [:] ?
+                config.confluence.useV1Api :true
+            new WipeConfluenceSpaceTask(config).execute()
+        } else {
+            println("Aborting wipe confluence space, this task needs to be confirmed with 'y'")
+        }
+
+    }
+}
+//end::wipeConfluenceSpaceTask[]
 
 //tag::publishToConfluence[]
 task publishToConfluence(

--- a/src/docs/015_tasks/03_task_wipeConfluenceSpace.adoc
+++ b/src/docs/015_tasks/03_task_wipeConfluenceSpace.adoc
@@ -1,0 +1,44 @@
+:filename: 015_tasks/03_task_wipeConfluenceSpace.adoc
+include::_config.adoc[]
+
+[[task_previewsite]]
+= wipeConfluenceSpace
+
+include::../_feedback.adoc[]
+
+== About This Task
+
+[WARNING]
+====
+This task is destructive and can harm your environment
+====
+
+This task will wipe all content from your Confluence space, configured in your `docToolchainConfig.groovy`.
+It will not delete the space itself. The task makes it easy if you want to start from scratch with your documentation, or if you want to re-import your documentation from scratch after you did refactor your document structure and want to get rid of all the old pages.
+
+== Usage
+
+[source,bash]
+----
+./dtcw wipeConfluenceSpace -PconfluenceUser=foo.bar@example.corp -PconfluencePass=<REDACTED>
+----
+
+You will be asked to confirm the deletion of all pages in the space. Enter `y` to confirm.
+
+[source,bash]
+----
+...
+To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/8.1.1/userguide/gradle_daemon.html#sec:disabling_the_daemon.
+Daemon will be stopped at the end of the build
+
+> Task :wipeConfluenceSpace
+[ant:input] Do you really want to delete all pages in myDemoSpace (y, n)
+----
+
+== Source
+
+.publishToConfluence.gradle
+[source,groovy]
+----
+include::{projectRootDir}/scripts/publishToConfluence.gradle[tags=wipeConfluenceSpace]
+----


### PR DESCRIPTION
This introduces a new task called `wipeConfluenceSpace` which allows user to clean up their confluence space

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?