### PR TITLE
Improve basic rest client

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -57,6 +57,7 @@ unit_tests () {
   echo "#        Unit testing                      #"
   echo "#                                          #"
   echo "############################################"
+  ./gradlew core:test --info
   ./gradlew test --info
 }
 

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -15,6 +15,8 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === changed
 
+* [Core] Http calls from docToolchain are now identified by a user agent string of format `docToolchain_v<DTCW_VERSION>`.
+
 == 3.2.1 - 2024-01-10
 
 === fixes

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,6 +8,20 @@ repositories {
     mavenCentral()
 }
 
+// Workaround to keep project.version in sync with gradle.properties but the modules isolated as hell
+def props = new Properties()
+file("../gradle.properties").withInputStream { props.load(it) }
+def dtc_version = props.getProperty('dtc_version')
+// end of workaround
+
+jar {
+    manifest {
+        attributes(
+            'Implementation-Version': dtc_version
+        )
+    }
+}
+
 group = "org.docToolchain"
 
 dependencies {

--- a/core/src/main/groovy/org/docToolchain/http/BasicRestClient.groovy
+++ b/core/src/main/groovy/org/docToolchain/http/BasicRestClient.groovy
@@ -16,7 +16,7 @@ abstract class BasicRestClient {
     BasicRestClient() {
         this.httpClientBuilder = HttpClientBuilder.create()
         httpClientBuilder.addRequestInterceptorFirst { request, entityDetails, context ->
-            request.setHeader('User-Agent', "docToolchain_v${getClass().getPackage().getImplementationVersion()}")
+            request.setHeader(HttpHeaders.USER_AGENT, "docToolchain_v${getClass().getPackage().getImplementationVersion()}")
             Header hostHeader = request.getHeader(HttpHeaders.HOST)
             if (hostHeader == null) {
                 String host = new URIBuilder(request.getUri().toString()).getHost()

--- a/core/src/main/groovy/org/docToolchain/http/BasicRestClient.groovy
+++ b/core/src/main/groovy/org/docToolchain/http/BasicRestClient.groovy
@@ -3,8 +3,11 @@ package org.docToolchain.http
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder
 import org.apache.hc.core5.http.ClassicHttpRequest
+import org.apache.hc.core5.http.Header
+import org.apache.hc.core5.http.HttpHeaders
 import org.apache.hc.core5.http.HttpHost
 import org.apache.hc.core5.http.io.HttpClientResponseHandler
+import org.apache.hc.core5.net.URIBuilder
 
 abstract class BasicRestClient {
 
@@ -12,6 +15,15 @@ abstract class BasicRestClient {
 
     BasicRestClient() {
         this.httpClientBuilder = HttpClientBuilder.create()
+        httpClientBuilder.addRequestInterceptorFirst { request, entityDetails, context ->
+            request.setHeader('User-Agent', "docToolchain_v${getClass().getPackage().getImplementationVersion()}")
+            Header hostHeader = request.getHeader(HttpHeaders.HOST)
+            if (hostHeader == null) {
+                String host = new URIBuilder(request.getUri().toString()).getHost()
+                // Set the Host header to the host of the request URI, if not already set explicitly
+                request.setHeader(HttpHeaders.HOST, host)
+            }
+        }
     }
 
     def doRequest(HttpHost targetHost, ClassicHttpRequest httpRequest, HttpClientResponseHandler<String> responseHandler) {

--- a/core/src/main/groovy/org/docToolchain/scripts/asciidoc2confluence.groovy
+++ b/core/src/main/groovy/org/docToolchain/scripts/asciidoc2confluence.groovy
@@ -835,9 +835,9 @@ config.confluence.input.each { input ->
         def (pages, anchors, pageAnchors) = getPages(dom, parentId, confluenceSubpagesForSections)
         pushPages pages, anchors, pageAnchors, keywords
         if (parentId) {
-            println "published to ${config.confluence.api - "rest/api/"}spaces/${confluenceSpaceKey}/pages/${parentId}"
+            println "published to ${config.confluence.api - "rest/api/"}/spaces/${confluenceSpaceKey}/pages/${parentId}"
         } else {
-            println "published to ${config.confluence.api - "rest/api/"}spaces/${confluenceSpaceKey}"
+            println "published to ${config.confluence.api - "rest/api/"}/spaces/${confluenceSpaceKey}"
         }
     }
 }

--- a/core/src/test/groovy/org/docToolchain/atlassian/jira/JiraServiceSpec.groovy
+++ b/core/src/test/groovy/org/docToolchain/atlassian/jira/JiraServiceSpec.groovy
@@ -47,6 +47,10 @@ class JiraServiceSpec extends Specification {
         return config
     }
 
+    def setupSpec() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    }
+
     def "test exportJiraSprintChangelog"() {
         setup: "a JiraService instance in a clean environment"
             new File("${TARGET_DIR}/${RESULT_DIR_CHANGELOG}").deleteDir()

--- a/core/src/test/groovy/org/docToolchain/atlassian/jira/utils/DateUtilSpec.groovy
+++ b/core/src/test/groovy/org/docToolchain/atlassian/jira/utils/DateUtilSpec.groovy
@@ -4,17 +4,21 @@ import spock.lang.Specification
 
 class DateUtilSpec extends Specification {
 
+    def setupSpec() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+    }
+
     def "test format with default format"() {
         when: "formatting a date"
             String formattedDate = DateUtil.format("2019-01-01T12:00:00.000+0000")
         then: "the date is formatted correctly"
-            formattedDate == "01.01.2019 13:00:00 MEZ"
+            formattedDate == "01.01.2019 12:00:00 UTC"
     }
 
     def "test format with custom format"() {
         when: "formatting a date"
             String formattedDate = DateUtil.format("2019-01-01T12:00:00.000+0000", "yyyy-MM-dd'T'HH:mm:ss.SSSZ", "MM.yyyy HH:mm:ss z")
         then: "the date is formatted correctly"
-            formattedDate == "01.2019 13:00:00 MEZ"
+            formattedDate == "01.2019 12:00:00 UTC"
     }
 }

--- a/core/src/test/groovy/org/docToolchain/scripts/asciidoc2confluenceSpec.groovy
+++ b/core/src/test/groovy/org/docToolchain/scripts/asciidoc2confluenceSpec.groovy
@@ -2,10 +2,7 @@ package org.docToolchain.scripts
 
 import org.docToolchain.util.TestUtils
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import org.jsoup.parser.Parser
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class asciidoc2confluenceSpec extends Specification {
 
@@ -25,38 +22,6 @@ class asciidoc2confluenceSpec extends Specification {
         return new GroovyShell(new Binding([
             config: config
         ]))
-    }
-
-    void 'test default language'() {
-        setup: 'load org.docToolchain.scripts.asciidoc2confluence'
-        GroovyShell shell = setupShell()
-        def script = shell.parse(ASCIIDOC2CONFLUENCE_SCRIPT)
-        when: 'run rewriteCodeblocks'
-        Document dom = Jsoup.parse('<pre><code>none</code></pre>', 'utf-8', Parser.xmlParser())
-        script.rewriteCodeblocks dom.getAllElements(), '<cdata-placeholder>', '</cdata-placeholder>'
-
-        then: 'the language is text'
-        dom.select('ac|structured-macro > ac|parameter').text() == 'text'
-    }
-
-    @Unroll
-    void 'test converted language'() {
-        setup: 'load org.docToolchain.scripts.asciidoc2confluence'
-        GroovyShell shell = setupShell()
-        def script = shell.parse(ASCIIDOC2CONFLUENCE_SCRIPT)
-
-        when: 'run rewriteCodeblocks'
-        Document dom = Jsoup.parse("<pre><code data-lang=\"${input}\">language</code></pre>", 'utf-8', Parser.xmlParser())
-        script.rewriteCodeblocks dom.getAllElements(), '<cdata-placeholder>', '</cdata-placeholder>'
-
-        then: 'the language is converted'
-        dom.select('ac|structured-macro > ac|parameter').text() == output
-
-        where:
-        input || output
-        'terraform' || 'text' // fallback
-        'yaml' || 'yml' // mapping
-        'xml' || 'xml' // identity
     }
 
     void 'test body is parsed properly'() {

--- a/core/src/test/resources/jira/expectedFiles/CurrentSprint.adoc
+++ b/core/src/test/resources/jira/expectedFiles/CurrentSprint.adoc
@@ -2,6 +2,6 @@
 |=== 
 |Key |Priority |Created |Resolutiondate |Summary |Assignee |Status |Issuetype |Story Points 
 
-| https://jira.atlassian.com/browse/ED-1[ED-1] | Medium | 16.11.2022 00:15:20 MEZ | 16.11.2022 00:16:20 MEZ | summary | not assigned| To Do | Story | -
+| https://jira.atlassian.com/browse/ED-1[ED-1] | Medium | 15.11.2022 23:15:20 UTC | 15.11.2022 23:16:20 UTC | summary | not assigned| To Do | Story | -
 
 |=== 


### PR DESCRIPTION
As an outcome of the discussion in #1335 there are further improvements to the rest client, namely:
* Ensure the `Host` header does not contain port definitions
* Set custom `User-Agent` to ease network traffic inspections, the User-Agent will be in format `docToolchain-v<dtcw_version>`

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?