### PR TITLE
Fixes using a wrong arch(itecture) on macOS (Darwin)

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -9,6 +9,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === fixes
 
+* [Noticket] Enforce x86 Java on macOS as long as jbake does not support arm64 processors
 * [Noticket] Avoid usage of an arbitrary `arch` binary/script on `+${PATH}+` instead of the desired `/usr/bin/arch` on macOS.
 
 === added

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -9,6 +9,8 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === fixes
 
+* [Noticket] Avoid usage of an arbitrary `arch` binary/script on `+${PATH}+` instead of the desired `/usr/bin/arch` on macOS.
+
 === added
 
 === changed

--- a/dtcw
+++ b/dtcw
@@ -541,7 +541,9 @@ local_install_java() {
     fi
     case "${os}" in
         Linux) os=linux ;;
-        Darwin) os=mac ;;
+        Darwin) os=mac
+            # Enforce usage of Intel Java as long as jbake does not work on Apple Silicon
+            arch=x64 ;;
         Cygwin) os=linux ;;
     esac
     mkdir -p "${DTC_JAVA_HOME}"

--- a/dtcw
+++ b/dtcw
@@ -121,7 +121,7 @@ main() {
     emu=""
     if [ "${os}" = "Darwin" ] && [ "${arch}" = "arm64" ]; then
       echo "Apple silicon detected, using x86_64 mode and os native bash"
-      emu="arch -x86_64"
+      emu="/usr/bin/arch -x86_64"
       bash="/bin/bash"
     fi
 


### PR DESCRIPTION
Fixes using a wrong `arch` on macOS (Darwin) + Enforce x86 Java as long as JBake does not support arm64 processors

- If you happen to have another `arch` binary or script on `${PATH}` this was used instead of /usr/bin/arch by DTCW - with disturbing results. 
The patch ensures the right executable is used to perform docToolchain on macOS.
- DTCW uses x86_64 arch binaries (e.g., bash) on macOS with arm64 processor. 
Consequently, it must also enforce installation of x86 Java for local usage.

### All Submissions:

* [x] Did you update the `changelog.adoc`?
