### PR TITLE
use fix core module release in docToolchain releases 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ### Gradle template
 .gradle
 build/
+libs/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,6 @@ buildscript {
                 details.because 'jcenter redirect'
                 System.out.println ">>>>>>>>> fix grolifant"
             }
-            //TODO is this really needed here?
-            if (details.requested.group == 'org.codehaus.groovy.modules.http-builder' && details.requested.name == 'http-builder' && details.requested.version == '0.7.2') {
-                details.useVersion '0.7.1'
-                details.because 'jcenter redirect'
-                System.out.println ">>>>>>>>> fix http-builder"
-            }
         }
     }
 }
@@ -57,7 +51,6 @@ dependencies {
             (libs.spock.core),
             gradleTestKit(),
             (libs.jsoup),
-            ("org.docToolchain:core")
     )
     testRuntimeOnly(libs.byte.buddy)
     compileClasspath((libs.http.client))
@@ -133,6 +126,9 @@ task autobuildSite(
 
 }
 task prepareDist() {
+    if (!file("libs/org/docToolchain/core-${project.properties.dtc_version}.jar").exists()) {
+        dependsOn gradle.includedBuild('core').task(':release-core')
+    }
     doLast {
         def distFolder = "dist/docToolchain-"+dtc_version
         println "generate distribution for "+dtc_version
@@ -156,11 +152,11 @@ task prepareDist() {
             into new File(buildDir,distFolder+"/resources")
         }
         copy{
-            from (new File("./core")) {
+            from (new File("./libs")) {
                 include "*"
                 include "**/*"
             }
-            into new File(buildDir,distFolder+"/core")
+            into new File(buildDir,distFolder+"/libs")
         }
         copy{
             from new File("./scripts")

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,11 @@ dependencies {
             gradleTestKit(),
             (libs.jsoup),
     )
+    if (file("libs/org/docToolchain/core-${project.properties.dtc_version}.jar").exists()) {
+        testImplementation(files("libs/org/docToolchain/core-${project.properties.dtc_version}.jar"))
+    } else {
+        testImplementation("org.docToolchain:core")
+    }
     testRuntimeOnly(libs.byte.buddy)
     compileClasspath((libs.http.client))
 }

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -11,6 +11,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 * [Noticket] Enforce x86 Java on macOS as long as jbake does not support arm64 processors
 * [Noticket] Avoid usage of an arbitrary `arch` binary/script on `+${PATH}+` instead of the desired `/usr/bin/arch` on macOS.
+* https://github.com/docToolchain/docToolchain/issues/1353[#1353: docker: Problem with 3.x images and dependencies?]
 
 === added
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'groovy'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 apply plugin:'groovy'
@@ -42,4 +43,16 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+tasks.register('release-core', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+    archiveFileName = "core-${dtc_version}.jar"
+    destinationDirectory = file("../libs/${project.group.toString().replace('.', '/')}")
+    manifest {
+        attributes(
+            'Implementation-Version': dtc_version
+        )
+    }
+    from sourceSets.main.output
+    configurations = [project.configurations.runtimeClasspath]
 }

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -13,11 +13,15 @@ buildscript {
     }
 
     dependencies {
-        classpath libs.asciidoctor
-        classpath libs.asciidoctor.pdf
-        classpath libs.asciidoctor.gems
-        classpath libs.asciidoctor.slides
-        classpath("org.docToolchain:core")
+        classpath (libs.asciidoctor)
+        classpath (libs.asciidoctor.pdf)
+        classpath (libs.asciidoctor.gems)
+        classpath(libs.asciidoctor.slides)
+        if (file("libs/org/docToolchain/core-${project.properties.dtc_version}.jar").exists()) {
+            classpath files("libs/org/docToolchain/core-${project.properties.dtc_version}.jar")
+        } else {
+            classpath("org.docToolchain:core")
+        }
     }
 }
 

--- a/scripts/exportJiraIssues.gradle
+++ b/scripts/exportJiraIssues.gradle
@@ -9,7 +9,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.docToolchain:core")
+        if (file("libs/org/docToolchain/core-${project.properties.dtc_version}.jar").exists()) {
+            classpath files("libs/org/docToolchain/core-${project.properties.dtc_version}.jar")
+        } else {
+            classpath("org.docToolchain:core")
+        }
     }
 }
 

--- a/scripts/exportJiraSprintChangelog.gradle
+++ b/scripts/exportJiraSprintChangelog.gradle
@@ -9,7 +9,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.docToolchain:core")
+        if (file("libs/org/docToolchain/core-${project.properties.dtc_version}.jar").exists()) {
+            classpath files("libs/org/docToolchain/core-${project.properties.dtc_version}.jar")
+        } else {
+            classpath("org.docToolchain:core")
+        }
     }
 }
 

--- a/scripts/publishToConfluence.gradle
+++ b/scripts/publishToConfluence.gradle
@@ -9,7 +9,11 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.docToolchain:core")
+        if (file("libs/org/docToolchain/core-${project.properties.dtc_version}.jar").exists()) {
+            classpath files("libs/org/docToolchain/core-${project.properties.dtc_version}.jar")
+        } else {
+            classpath("org.docToolchain:core")
+        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,5 +26,7 @@ dependencyResolutionManagement {
     }
 }
 
-includeBuild('core')
+if (!file("libs/org/docToolchain/core-${properties.dtc_version}.jar").exists()) {
+    includeBuild("core")
+}
 


### PR DESCRIPTION
core module will be prebuild as fatJar when executing createDist to ensure Core module does not get recognized by Gradle in the release version of docToolchain

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?