### PR TITLE
fix loading of custom ruby extensions

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -12,6 +12,8 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * [Noticket] Enforce x86 Java on macOS as long as jbake does not support arm64 processors
 * [Noticket] Avoid usage of an arbitrary `arch` binary/script on `+${PATH}+` instead of the desired `/usr/bin/arch` on macOS.
 * https://github.com/docToolchain/docToolchain/issues/1353[#1353: docker: Problem with 3.x images and dependencies?]
+* https://github.com/docToolchain/docToolchain/issues/1239[#1239: Execute a custom asciidoctor converter for generateHTML]
+* https://github.com/docToolchain/docToolchain/issues/1290[#1290: Custom ruby extension for PDF generation]
 
 === added
 

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -116,6 +116,26 @@ config.flatten().each {key, value ->
     }
 }
 
+// this is a hard dependency for the asciidoctor-gradle-plugin based generateDeck task
+config.inputFiles.each {
+    if(it.formats.contains('revealjs')){
+        repositories {
+            ruby {
+                gems()
+            }
+        }
+    }
+}
+
+// TODO this could help to allow ruby gems from remote
+if (config.rubyExtensions && config.rubyExtensions.any { !it.endsWith('.rb') }) {
+    repositories {
+        ruby {
+            gems()
+        }
+    }
+}
+
 ext {
     srcDir  = "${docDir}/${inputPath}"
     if (config.outputPath.startsWith('/') || config.outputPath.matches('^[A-Za-z]:.*$')) {
@@ -238,7 +258,6 @@ tasks.withType(AbstractAsciidoctorTask) { docTask ->
     //TODO: write docs for this
     if (config.rubyExtensions) {
         config.rubyExtensions.each { extension ->
-            println("extension: $extension")
             if(extension.endsWith('.rb')) {
                 def root= new File(projectDir.canonicalPath)
                 def full = new File(new File(docDir,extension).canonicalPath)

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -37,12 +37,6 @@ apply plugin: org.asciidoctor.gradle.jvm.pdf.AsciidoctorJPdfPlugin
 apply plugin: org.asciidoctor.gradle.jvm.gems.AsciidoctorGemSupportPlugin
 apply plugin: org.asciidoctor.gradle.jvm.slides.AsciidoctorRevealJSPlugin
 
-repositories {
-    ruby {
-        gems()
-    }
-}
-
 revealjs {
     version = '4.1.0'
 
@@ -241,14 +235,19 @@ tasks.withType(AbstractAsciidoctorTask) { docTask ->
     // good to see what the build is doing...
     logDocuments = true
 
-    //TODO: write docs
+    //TODO: write docs for this
     if (config.rubyExtensions) {
         config.rubyExtensions.each { extension ->
-            def root= new File(projectDir.canonicalPath)
-            def full= new File(new File(docDir,extension).canonicalPath)
-            def relPath = root.toPath().relativize( full.toPath() ).toFile()
-            requires += [relPath.toString()]
-            logger.info ("added required ruby extension '$full'")
+            println("extension: $extension")
+            if(extension.endsWith('.rb')) {
+                def root= new File(projectDir.canonicalPath)
+                def full = new File(new File(docDir,extension).canonicalPath)
+                def relPath = root.toPath().relativize( full.toPath() ).toFile()
+                asciidoctorj.requires += [relPath.toString()]
+                println ("added required ruby extension '$full'")
+            } else {
+                throw new IllegalArgumentException("Ruby extension '$extension' must end with '.rb'. Only local extensions are supported, yet.")
+            }
         }
     }
     // fix for #1150

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -117,18 +117,20 @@ config.flatten().each {key, value ->
 }
 
 // this is a hard dependency for the asciidoctor-gradle-plugin based generateDeck task
-config.inputFiles.each {
-    if(it.formats.contains('revealjs')){
-        repositories {
-            ruby {
-                gems()
+task prepareRubyGems {
+    doFirst {
+            project.repositories {
+                ruby {
+                    gems()
+                }
             }
-        }
     }
 }
+asciidoctorGemsPrepare.dependsOn prepareRubyGems
 
 // TODO this could help to allow ruby gems from remote
 if (config.rubyExtensions && config.rubyExtensions.any { !it.endsWith('.rb') }) {
+    //TODO make dependsOn prepareRubyGems for asciidoctor tasks
     repositories {
         ruby {
             gems()

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -117,21 +117,13 @@ config.flatten().each {key, value ->
 }
 
 // this is a hard dependency for the asciidoctor-gradle-plugin based generateDeck task
-task prepareRubyGems {
-    doFirst {
-            project.repositories {
-                ruby {
-                    gems()
-                }
-            }
-    }
-}
-asciidoctorGemsPrepare.dependsOn prepareRubyGems
-
-// TODO this could help to allow ruby gems from remote
-if (config.rubyExtensions && config.rubyExtensions.any { !it.endsWith('.rb') }) {
-    //TODO make dependsOn prepareRubyGems for asciidoctor tasks
-    repositories {
+def tasksToExecute = project.gradle.startParameter.taskNames
+if (tasksToExecute.contains('asciidoctorGemsPrepare') ||
+    tasksToExecute.contains('generateDeck') ||
+    // TODO this could help to allow ruby gems from remote, but it is not working yet
+    config.rubyExtensions && config.rubyExtensions.any { !it.endsWith('.rb')}
+) {
+    project.repositories {
         ruby {
             gems()
         }

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -11,6 +11,13 @@ outputPath = 'build'
 
 inputPath = 'src/docs';
 
+// if you need to register custom Asciidoctor extensions, this is the right place
+// configure the name and path to your extension, relative to the root of your project
+// (relative to dtcw). For example: 'src/ruby/asciidoctor-lists.rb'.
+// this is the same as the `requires`-list of the asciidoctor gradle plugin. The extensions will be
+// registered for generateDeck, generateHtml, generatePdf and generateDocbook tasks, only.
+// rubyExtensions = []
+
 // the pdfThemeDir config in this file is outdated.
 // please check http://doctoolchain.org/docToolchain/v2.0.x/020_tutorial/030_generateHTML.html#_pdf_style for further details
 // pdfThemeDir = './src/docs/pdfTheme'
@@ -163,13 +170,6 @@ Needs `python3` and `docutils` installed.
         headers.title += " - from CustomConvention"
     """.stripIndent()
     **/
-
-    // if you need to register custom Asciidoctor extensions, this is the right place
-    // configure the name and path to your extension, relative to the root of your project
-    // (relative to dtcw). For example: 'src/ruby/asciidoctor-lists.rb'.
-    // this is the same as the `requires`-list of the asciidoctor gradle plugin
-
-    // rubyExtensions = []
 }
 
 //*****************************************************************************************


### PR DESCRIPTION
This will fix  #1290 #1239 and also complete the performance issue described in #1353 

This PR moves the setting `rubyExtensions` to the top level and makes it no longer an option within the `microsites` config. The reason is that it does not relate to `microsite`tasks since they depend on JBake and JBake currently does not support custom Ruby extensions.

A follow up to this task is #1363 where we should document the config option

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?