### PR TITLE
ignore any test dependency in production

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ task downloadDependencies {
             }
         }
 
-        configurations.findAll{it.canBeResolved}.each{
+        configurations.findAll{it.canBeResolved && !it.name.startsWith("test")}.each{
             println "-> "+it.name
             it.resolve()
         }


### PR DESCRIPTION
This PR just ensures that when we download runtime dependencies no longer test dependencies are included. 
