### PR TITLE
Fix Confluence APIv2 Cursor Logic

### DIFF
--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
@@ -120,12 +120,12 @@ class ConfluenceClientV2 extends ConfluenceClient {
             URIBuilder uriBuilder = new URIBuilder(API_V2_PATH + "/pages/${pageId}/children")
                 .addParameter('depth', 'all')
                 .addParameter('limit', pageLimit.toString())
-            if(cursor){
+            if (cursor){
                 uriBuilder.addParameter('cursor', cursor)
             }
             URI uri = uriBuilder.build()
             HttpRequest get = new HttpGet(uri)
-            def response =  callApiAndFailIfNot20x(get)
+            def response = callApiAndFailIfNot20x(get)
             def results = response.results ?: []
             results.inject(allPages) { Map acc, Map match ->
                 //unique page names in confluence, so we can get away with indexing by title
@@ -137,13 +137,14 @@ class ConfluenceClientV2 extends ConfluenceClient {
                 ]
                 acc
             }
+            def hasNext = response.containsKey('_links') && response._links.containsKey('next')
             if (results.empty && ids.isEmpty()) {
-                if(pageIds.isEmpty()) {
+                if (pageIds.isEmpty()) {
                     morePages = false
                 } else {
                     pageId = pageIds.remove(0)
                 }
-            } else if (!results.empty && !response._links.isEmpty()) {
+            } else if (!results.empty && hasNext) {
                 cursor = response._links.next.split("cursor=")[1]
             } else {
                 cursor = null

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
@@ -84,14 +84,15 @@ class ConfluenceClientV2 extends ConfluenceClient {
             URIBuilder uriBuilder = new URIBuilder(API_V2_PATH + "/spaces/${spaceId}/pages")
                 .addParameter('depth', 'all')
                 .addParameter('limit', pageLimit.toString())
-            if(cursor){
+            if (cursor){
                 uriBuilder.addParameter('cursor', cursor)
             }
             URI uri = uriBuilder.build()
             HttpRequest get = new HttpGet(uri)
             def response =  callApiAndFailIfNot20x(get)
             def results = response.results ?: []
-            if (results.empty || response._links.isEmpty()) {
+            def hasNext = response.containsKey('_links') && response._links.containsKey('next')
+            if (results.empty || !hasNext) {
                 morePages = false
             } else {
                 cursor = response._links.next.split("cursor=")[1]

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -94,5 +94,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/MichaelRossner[Michael Roßner]
 - https://github.com/jstueckrath[Jan Stückrath]
 - https://github.com/timo-abele[Timo Abele]
+- https://gitlab.com/bonzanip[Patrizio Bonzani]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
The Confluence API v2 always returns a `_links` object containing the base path. This PR adds defensive code checking for existence of the `next` key in the `_links` map.