### PR TITLE
exportEA: Add additional option to set the image format

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -189,6 +189,7 @@ confluence.with {
 // -  glossaryTypes: if set and glossary is exported, used to filter for certain types.
 //    Not set or empty list will cause no filtered glossary.
 // -  diagramAttributes: if set, the diagram attributes are exported and formatted as specified
+// -  imageFormat: if set, the image format is used for the export of diagrams. Default is '.png'.
 
 exportEA.with {
 // OPTIONAL: Set the connection to a certain project or comment it out to use all project files inside the src folder or its child folder.
@@ -209,6 +210,8 @@ exportEA.with {
 // OPTIONAL: Additional files will be exported containing diagram attributes in the given asciidoc format
 // diagramAttributes = "Modified: %DIAGRAM_AUTHOR%, %DIAGRAM_MODIFIED%, %DIAGRAM_NAME%,
 // %DIAGRAM_GUID%, %DIAGRAM_CREATED%, %DIAGRAM_NOTES%, %DIAGRAM_DIAGRAM_TYPE%, %DIAGRAM_VERSION%"
+// OPTIONAL: format of the exported diagrams. Defaults to '.png' if the parameter is not provided.
+// imageFormat = ".svg"
 }
 //end::exportEAConfig[]
 

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -10,6 +10,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 === fixed
 
 === added
+* https://github.com/docToolchain/docToolchain/pull/1389[exportEA: Add additional option to set the image format]
 
 === changed
 

--- a/scripts/exportEA.gradle
+++ b/scripts/exportEA.gradle
@@ -191,8 +191,16 @@ use `gradle exportEA` to re-export files
         else {
             searchPath = new File(docDir, 'src').getAbsolutePath()
         }
+        if (config.exportEA.imageFormat.isEmpty()) {
+            imageFormat = ".png"
+        } else if(!config.exportEA.imageFormat.startsWith(".")) {
+            imageFormat = "." + config.exportEA.imageFormat
+        } else {
+            imageFormat = config.exportEA.imageFormat
+        }
         scriptParameterString = scriptParameterString + " -d \"$exportPath\""
         scriptParameterString = scriptParameterString + " -s \"$searchPath\""
+        scriptParameterString = scriptParameterString + " -f \"$imageFormat\""
         logger.info("docToolchain > exportEA: exportPath: " + exportPath)
 
         //remove old glossary files/folder if exist

--- a/scripts/exportEAP.vbs
+++ b/scripts/exportEAP.vbs
@@ -58,7 +58,7 @@
             name = currentElement.Name
             name = Replace(name,vbCr,"")
             name = Replace(name,vbLf,"")
-        
+
             strCombinedNotes = "_all_notes.ad"
             set objCombinedNotesFile = objFSO.OpenTextFile(path&prefix&post&"/"&strCombinedNotes,ForAppending, True)
 
@@ -190,7 +190,7 @@
         diagramName = Replace(diagramName,vbCr,"")
         diagramName = Replace(diagramName,vbLf,"")
         diagramName = NormalizeName(diagramName)
-        filename = objFSO.BuildPath(path, diagramName & ".png")
+        filename = objFSO.BuildPath(path, diagramName & imageFormat)
 
         exportDiagram = True
         If objFSO.FileExists(filename) Then
@@ -406,6 +406,7 @@
   Private exportDestination
   Private searchPath
   Private glossaryFilePath
+  Private imageFormat
   Private diagramAttributes
   Private additionalOptions
 
@@ -428,10 +429,14 @@
         searchPath = objArguments(argCount+1)
       Case "-g"
         glossaryFilePath = objArguments(argCount+1)
+      Case "-f"
+        imageFormat = objArguments(argCount+1)
       Case "-da"
         diagramAttributes = objArguments(argCount+1)
       Case "-ao"
         additionalOptions = objArguments(argCount+1)
+      Case Else
+        WScript.echo "unknown argument: " & objArguments(argCount)
     End Select
     argCount = argCount + 2
   WEnd

--- a/src/docs/015_tasks/03_task_exportEA.adoc
+++ b/src/docs/015_tasks/03_task_exportEA.adoc
@@ -86,6 +86,12 @@ You can add the string %NEWLINE% where a line break will be added.
 The resulting text is stored next to the diagram image using the same path and file name, but a different file extension (.ad). This can be included in the document if required.
 If diagramAttributes is not set or an empty string, no file is written.
 
+==== imageFormat
+If set, the set image format is used to export the diagrams.
+Default is set to ".png".
+
+Please check your Enterprise Architect version which formats are supported.
+
 ==== additionalOptions
 This parameter is used to define the specific behavior of the export. Currently, these options are supported:
 


### PR DESCRIPTION
A new option imageFormat/"-f" is added to exportEA to set the image format of the exported diagrams.

EA selects the format based on the file extention.

### All Submissions:

* [y] Did you update the `changelog.adoc`?
* [y] Does your PR affect the documentation?
* [y] If yes, did you update the documentation or create an issue for updating it?