### PR TITLE
Typo on 010_manual/20_install.html

### DIFF
--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -21,7 +21,7 @@ The use of this setup has the following advantages:
 - Ensures that everyone in the project uses the same docToolchain version.
 - Keeps all docToolchain technology out of your project repository.
 - Facilitates the installation of the docToolchain if not installed.
-- Makes it easier to upgrade to never versions of docToolchain.
+- Makes it easier to upgrade to newer versions of docToolchain.
 
 == Install `dtcw` in your project directory
 


### PR DESCRIPTION
### All Submissions:

* [ ] Did you update the `changelog.adoc`?

Overkill for a 1 character error ?

* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

Fix a typo error on \src\docs\010_manual\20_install.adoc