### PR TITLE
exportEA; Replace ":" in diagram names

### DIFF
--- a/scripts/exportEAP.vbs
+++ b/scripts/exportEAP.vbs
@@ -30,7 +30,7 @@
     ' Regular expression can easily be extended with further characters to be replaced.
     Function NormalizeName(theName)
        dim re : Set re = new regexp
-       re.Pattern = "[\\/\[\]\s]"
+       re.Pattern = "[\\/\[\]\s:]"
        re.Global = True
        NormalizeName = re.Replace(theName, "_")
     End Function


### PR DESCRIPTION
Also replace ":" in names of diagrams.

":" is not allowed for Windows - but is now frequently used e.g. for "ara::com" (Adaptive AUTOSAR) diagrams.

### All Submissions:

* [n] Did you update the `changelog.adoc`?
* [n] Does your PR affect the documentation?
* [n] If yes, did you update the documentation or create an issue for updating it?