### PR TITLE
Fix TOC generation in convertToDocx

### DIFF
--- a/Config.groovy
+++ b/Config.groovy
@@ -408,3 +408,8 @@ openAI.with {
     //temperature = '0.3'
 }
 //end::openAIConfig[]
+
+// Configuration for pandoc options
+pandocOptions = [
+    '--toc'
+]

--- a/scripts/pandoc.gradle
+++ b/scripts/pandoc.gradle
@@ -45,16 +45,20 @@ task convertToDocx (
         workingDir "$targetDir/docbook"
         executable = "pandoc"
 
+        def pandocOptions = config.pandocOptions ?: []
+
         if(referenceDocFile?.trim()) {
             args = ["-r","docbook",
                     "-t","docx",
                     "-o","../docx/$targetFile",
+                    *pandocOptions,
                     "--reference-doc=${docDir}/${referenceDocFile}",
                     sourceFile]
         } else {
             args = ["-r","docbook",
                     "-t","docx",
                     "-o","./../docx/$targetFile",
+                    *pandocOptions,
                     sourceFile]
         }
     }


### PR DESCRIPTION
Related to #1400

Add support for generating Table of Contents (TOC) in `convertToDocx` task using `pandoc` options.

* **Config.groovy**
  - Add a new configuration option `pandocOptions` to allow overriding pandoc options.
  - Include the `--toc` option in the `pandocOptions` list.

* **scripts/pandoc.gradle**
  - Update the `convertToDocx` task to include the `pandocOptions` from `Config.groovy`.
  - Add the `--toc` option to the `args` list in the `convertToDocx` task.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/docToolchain/docToolchain/issues/1400?shareId=98db7278-85b3-4c79-a0c8-e0fa60256f1c).