### PR TITLE
remove Java 21 from build

### DIFF
--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # TODO: Will it really run on one of these? , windows-latest, macOS-latest]
-        java: [11, 14, 17, 21]
+        java: [11, 14, 17]
         jdk: [adopt]
         # , temurin]
       fail-fast: false


### PR DESCRIPTION
We cannot support Java 21 as of now. See #1419 