### PR TITLE
Update HTML Sanity Check to 2.0.0-rc0 and fix bugs found by it

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -16,6 +16,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === changed
 
+* Use https://github.com/aim42/htmlSanityCheck/releases/tag/2.0.0-rc0[Release 2.0.0-rc0] of HTML Sanity Checker
 * https://github.com/docToolchain/docToolchain/issues/1411[removed legacy `jiraRoot` config property]
 
 == 3.4.0 - 2024-07-18

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -9,6 +9,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === fixed
 
+* Missing alt attributes in site templates (found by HTML Sanity Checker 2.0.0-rc0, see below).
 * https://github.com/docToolchain/docToolchain/issues/1411[Jira links substitution is not working]
 * https://github.com/docToolchain/docToolchain/issues/1421[publishToConfluence fails with "No such property: attachmentPrefix for class: org.docToolchain.tasks.Asciidoc2ConfluenceTask"]
 

--- a/changelog.adoc
+++ b/changelog.adoc
@@ -15,6 +15,8 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === added
 
+* Add an environment variable `DTC_SHELL_DEBUG` (which could be set to `-x` or `-xv`) to let `dtcw` run the DTC script in a more verbose way.
+
 === changed
 
 * Use https://github.com/aim42/htmlSanityCheck/releases/tag/2.0.0-rc0[Release 2.0.0-rc0] of HTML Sanity Checker
@@ -30,7 +32,6 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * Collapsible left menu (see https://doctoolchain.org/docToolchain/v2.0.x/030_news/index.html for an example)
 * https://github.com/docToolchain/docToolchain/pull/1389[exportEA: Add additional option to set the image format]
 * https://github.com/docToolchain/docToolchain/pull/1391[#1391: Update collectIncludes.gradle]
-*
 
 === changed
 

--- a/dtcw
+++ b/dtcw
@@ -129,7 +129,9 @@ main() {
     fi
 
     # echo "Command to invoke: ${command}"
-    exec ${emu} ${bash} -c "${command}"
+    # shellcheck disable=SC2086
+    # as we hope to know what we are doing here ;-)
+    exec ${emu} ${bash} ${DTC_SHELL_DEBUG:-} -c "${command}"
 }
 
 assert_argument_exists() {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 groovy = "3.0.13"
 # Plugins
-htmlSanityCheck = "1.1.6"
+htmlSanityCheck = "2.0.0-rc0"
 versions = "0.46.0"
 openapi = "6.6.0"
 undercouch-download = "5.4.0"

--- a/src/docs/015_tasks/03_task_htmlSanityCheck.adoc
+++ b/src/docs/015_tasks/03_task_htmlSanityCheck.adoc
@@ -10,7 +10,7 @@ include::../_feedback.adoc[]
 This task invokes the https://github.com/aim42/htmlSanityCheck[htmlSanityCheck] gradle plugin.
 It is a standalone (batch- and command-line) HTML sanity checker whose role is to detect missing images, dead links and duplicated bookmarks.
 In docToolchain, the htmlSanityCheck task ensures that generated HTML contains no missing links or other problems.
-It is the last default task, and creates a report in `build/report/htmlchecks/index.html` (see example below).
+It is the last default task, and creates a report in `build/reports/htmlchecks/index.html` (see example below).
 
 .sample report
 image::manual/htmlSanityCheck.png[align="center"]

--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -1,7 +1,7 @@
 <div class="row flex-xl-nowrap">
     <main class="col-12 col-md-12 col-xl-12 pl-md-12" role="main">
         <div class="bg-light p-5 rounded jumbotron">
-            <img src="images/doctoolchain-logo-blue.png" style="float: left" />
+            <img src="images/doctoolchain-logo-blue.png" alt="docToolchain" style="float: left" />
             <h1>docToolchain</h1>
             <p class="lead">
                 Create awesome docs the easy way!

--- a/src/site/templates/menu.gsp
+++ b/src/site/templates/menu.gsp
@@ -12,7 +12,7 @@
 %>
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark flex-column flex-md-row td-navbar">
     <a class="navbar-brand" href="${content.rootpath}index.html">
-        <span class="navbar-logo"><img src="${content.rootpath}images/doctoolchain-logo-blue.png" width="32px" /></span><span
+        <span class="navbar-logo"><img src="${content.rootpath}images/doctoolchain-logo-blue.png" alt="docToolchain" width="32px" /></span><span
             class="font-weight-bold">${config.site_title}</span>
     </a>
     <div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">


### PR DESCRIPTION
### All Submissions:

* [x] Did you update the `changelog.adoc`?

@PacoVK or @rdmueller I'd be happy if you could soonish release a 3.4.1 (as this is mostly a bugfix release) which would help to build HSC itself in a clean way. 

Background: HSC makes use of the JBake templates delivered with DTC. If they contain errors, HSC cannot be built in a clean way.