### PR TITLE
fixing execution of rubyExtension with relative path

### DIFF
--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -286,7 +286,17 @@ tasks.withType(AbstractAsciidoctorTask) { docTask ->
             if(extension.endsWith('.rb')) {
                 def root= new File(projectDir.canonicalPath)
                 def full = new File(new File(docDir,extension).canonicalPath)
-                def relPath = root.toPath().relativize( full.toPath() ).toFile()
+                def rootPath = root.toPath()
+                def fullPath = full.toPath()
+
+                def relPath
+                if (rootPath.root == fullPath.root) {
+                    relPath = rootPath.relativize(fullPath).toFile()
+                } else {
+                    // Use the full path as relative path is not possible
+                    relPath = fullPath.toFile()
+                }
+
                 asciidoctorj.requires += [relPath.toString()]
                 println ("added required ruby extension '$full'")
             } else {


### PR DESCRIPTION
Summary

This update enables the use of relative paths in the Ruby extension when the rootPath and fullPath share the same root. A relative path is used if they share the same root; otherwise, the full path is retained.

This improves path handling by using relative paths when possible.