### PR TITLE
fixed an issue with ConfluenceClientV2 pagination traversal / cursor extraction

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -10,6 +10,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 === fixed
 
 * https://github.com/docToolchain/docToolchain/issues/1447[publishToConfluence: Internal links broken with v3.4.1]
+* fixed an issue with ConfluenceClientV2 pagination traversal / cursor extraction
 
 === added
 

--- a/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/confluence/clients/ConfluenceClientV2.groovy
@@ -95,7 +95,8 @@ class ConfluenceClientV2 extends ConfluenceClient {
             if (results.empty || !hasNext) {
                 morePages = false
             } else {
-                cursor = response._links.next.split("cursor=")[1]
+                def nextUri = new URIBuilder(response._links.next)
+                cursor = nextUri.getQueryParams().find { it.name == 'cursor' }.value
             }
             results.inject(allPages) { Map acc, Map match ->
                 //unique page names in confluence, so we can get away with indexing by title
@@ -146,7 +147,8 @@ class ConfluenceClientV2 extends ConfluenceClient {
                     pageId = pageIds.remove(0)
                 }
             } else if (!results.empty && hasNext) {
-                cursor = response._links.next.split("cursor=")[1]
+                def nextUri = new URIBuilder(response._links.next)
+                cursor = nextUri.getQueryParams().find { it.name == 'cursor' }.value
             } else {
                 cursor = null
                 pageId = ids.remove(0)


### PR DESCRIPTION
### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

NOTE:

The current cursor page traversal implementation in `ConfluenceClientV2` relies upon the `cursor` query field in the returned URI to always be at the end. However we have experienced sessions, where this is not the case (from debug session on `publishToConfluence`:

```
2024-11-15T11:33:28.750+0000 [DEBUG] [org.apache.hc.client5.http.wire] http-outgoing-22 << "Link: </wiki/api/v2/spaces/XXXXX/pages?cursor=eyJpZCI6IjMwMjczNyIsImNvbnRlbnRPcmRlciI6ImlkIiwiY29udGVudE9yZGVyVmFsdWUiOjMwMjczN30=&depth=all&limit=100>; rel="next", <https://XXXXX.atlassian.net/wiki>; rel="base"[\r][\n]"
...
2024-11-15T11:33:29.002+0000 [DEBUG] [org.apache.hc.client5.http.impl.classic.MainClientExec] ex-0000000024 executing GET /wiki/api/v2/spaces/XXXXX/pages?depth=all&limit=100&cursor=eyJpZCI6IjMwMjczNyIsImNvbnRlbnRPcmRlciI6ImlkIiwiY29udGVudE9yZGVyVmFsdWUiOjMwMjczN30%3D%26depth%3Dall%26limit%3D100 HTTP/1.1
```

The cursor was incorrectly extracted and parts of the query parameters were added to the cursor by escaping the special chars.

This PR proposes one way to fix this, happy to also use a different method if you think some other method is better.