### PR TITLE
fix image parameter on powershell script

### DIFF
--- a/dtcw.ps1
+++ b/dtcw.ps1
@@ -103,7 +103,7 @@ function main($_args) {
     }
     else {
         $docker_image_name = "doctoolchain/doctoolchain"
-        if ( $_args[0] -eq "install" ) {
+        if ( $_args[0] -eq "image" ) {
             # shift 1
             $null, $_args = $_args
             $docker_image_name = $_args[0]


### PR DESCRIPTION
In the documentation it states that one can use `dtcw.ps1 docker image {customImageName}` to use a custom image. This currently does not work as the image command is not recognised but provided to the doctoolchain which fails due to not finding the image command.

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [ ] Does your PR affect the documentation?
* [ ] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [ ] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [ ] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
