### PR TITLE
Add LLM.md reference to README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,6 @@
 image:https://api.travis-ci.com/doctoolchain/doctoolchain.svg?branch=ng[link={url-ci-travis}]
 
 
-
 [NOTE]
 ====
 Corona/Covid19 is taking its toll.
@@ -42,6 +41,10 @@ image::https://doctoolchain.github.io/docToolchain/v2.0.x/images/ea/Manual/Overv
 
 //TODO: this is the v1.3.x report:
 https://doctoolchain.github.io/docToolchain/v1.3.x/htmlchecks/[htmlSanityCheck Test Results]
+
+=== For Large Language Models (LLMs) and AI Assistants
+
+If you're using an AI assistant like ChatGPT or Claude to help with docToolchain, please direct it to read our link:LLM.md[LLM.md] file first. This file contains accurate, up-to-date information about docToolchain's installation and usage, which helps AI assistants provide better guidance.
 
 === Contributors
 


### PR DESCRIPTION
## Overview

This PR adds a reference to the LLM.md file in the README.adoc. This addition helps users direct AI assistants to the most accurate and up-to-date information about docToolchain.

## Changes

- Added a new section titled "For Large Language Models (LLMs) and AI Assistants" in the README
- Added a link to the LLM.md file with a brief explanation of its purpose

## Why This Matters

Many users now turn to AI assistants like ChatGPT, Claude, Bard, etc. for help with technical tools. By adding this explicit reference in the README, we increase the likelihood that these AI systems will provide accurate, current information about docToolchain installation and usage.

This PR replaces PR #1495 and references the LLM.md file that was already merged through PR #1494.