### PR TITLE
Install instruction using sdkman

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -10,6 +10,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 === fixed
 
 === added
+* https://github.com/docToolchain/docToolchain/pull/1530[Add instruction for installing docToolchain using SDKMAN]
 
 === changed
 * https://github.com/docToolchain/docToolchain/pull/1511[exportEA: close application after export with ShutdownEA interface]

--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -260,7 +260,10 @@ If the docToolchain installation finished successfully, you are ready to <<first
 [[install-dtc-with-sdk]]
 == Install docToolchain with SDKMAN!
 
-TODO: description how to install docToolchain with https://sdkman.io/[SDKMAN!].
+[source, bash]
+----
+sdk install doctoolchain
+----
 
 
 [[first-command]]

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -98,5 +98,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/ashauer[Lutz Ashauer]
 - https://github.com/igoreq1010[Igor Gaiduk]
 - https://github.com/jgenssler-GiN[Jakob Genßler]
+- https://github.com/davidmpaz[David Paz]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
Add instruction for installing docToolchain using SDKMAN.

### All Submissions:

* [x] Did you update the `changelog.adoc`?
* [x] Does your PR affect the documentation?
* [x] If yes, did you update the documentation or create an issue for updating it?

The source of the documentation can be found in `/src/docs/`.

If you didn't find the time to update docs, please create an issue as reminder to do so.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Your first submission

* [x] Welcome to the list of contributors! If you have any questions, feel free to ask them by creating a new issue
* [x] Have you added your name to the list of [30_community.adoc](https://github.com/docToolchain/docToolchain/blob/ng/src/docs/10_about/30_community.adoc)?


inspiration: https://github.com/stevemao/github-issue-templates
