### PR TITLE
Cherry-pick: Install instruction using sdkman (#1530)

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -11,6 +11,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 * https://github.com/docToolchain/docToolchain/issues/1526[dtcw.ps1: fix setting mainConfigFile via CLI argument]
 
 === added
+* https://github.com/docToolchain/docToolchain/pull/1530[Add instruction for installing docToolchain using SDKMAN]
 
 === changed
 * https://github.com/docToolchain/docToolchain/pull/1511[exportEA: close application after export with ShutdownEA interface]

--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -260,7 +260,10 @@ If the docToolchain installation finished successfully, you are ready to <<first
 [[install-dtc-with-sdk]]
 == Install docToolchain with SDKMAN!
 
-TODO: description how to install docToolchain with https://sdkman.io/[SDKMAN!].
+[source, bash]
+----
+sdk install doctoolchain
+----
 
 
 [[first-command]]

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -98,5 +98,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/ashauer[Lutz Ashauer]
 - https://github.com/igoreq1010[Igor Gaiduk]
 - https://github.com/jgenssler-GiN[Jakob Genßler]
+- https://github.com/davidmpaz[David Paz]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
## Summary
Cherry-picks the SDKMAN installation documentation improvements from #1530 into main-4.x branch.

## Changes
- Improved installation instructions using SDKMAN
- Same changes as already merged in `ng` branch

## Related
- Original PR: #1530 (already merged in `ng`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)