### PR TITLE
Fix #1524 #1528: Code blocks break in Confluence with subpagesForSections > 1

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -10,6 +10,9 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 === fixed
 * https://github.com/docToolchain/docToolchain/issues/1526[dtcw.ps1: fix setting mainConfigFile via CLI argument]
 
+* https://github.com/docToolchain/docToolchain/issues/1524[Source blocks not rendered correctly when subpagesForSections greater than 1]
+* https://github.com/docToolchain/docToolchain/issues/1488[doctoolchain version 3.4.2 breaks code blocks in publishToConfluence task]
+
 === added
 * https://github.com/docToolchain/docToolchain/pull/1530[Add instruction for installing docToolchain using SDKMAN]
 

--- a/core/src/main/groovy/org/docToolchain/tasks/Asciidoc2ConfluenceTask.groovy
+++ b/core/src/main/groovy/org/docToolchain/tasks/Asciidoc2ConfluenceTask.groovy
@@ -662,11 +662,12 @@ class Asciidoc2ConfluenceTask extends DocToolchainTask {
         element.select("div.sect${level}").each { sect ->
             def title = sect.select("h${level + 1}").text()
             pageAnchors.putAll(recordPageAnchor(sect.select("h${level + 1}")))
-            Elements pageBody
+            Element pageBody
             if (level == 1) {
-                pageBody = sect.select('div.sectionbody')
+                pageBody = sect.selectFirst('div.sectionbody')?.clone()
             } else {
-                pageBody = new Elements(sect)
+                // Work on a clone to avoid mutating the original DOM and to preserve whitespace/newlines
+                pageBody = sect.clone()
                 pageBody.select("h${level + 1}").remove()
             }
             def currentPage = [
@@ -682,7 +683,8 @@ class Asciidoc2ConfluenceTask extends DocToolchainTask {
             } else {
                 pageBody.select("div.sect${level + 1}").unwrap()
             }
-            promoteHeaders sect, level + 2, level + 1
+            // Promote headers within the page content (clone), not the original section
+            promoteHeaders pageBody, level + 2, level + 1
             pages << currentPage
             anchors.putAll(parseAnchors(currentPage))
         }
@@ -721,11 +723,11 @@ class Asciidoc2ConfluenceTask extends DocToolchainTask {
                 pages << preamble
                 parentId = null
                 anchors.putAll(parseAnchors(preamble))
-                
+
                 // Direkte Manipulation der children-Liste
                 preamble.children.addAll(getPagesRecursive(dom, parentId, anchors, pageAnchors, 1, maxLevel))
             }
-            
+
             // Falls keine Präambel gefunden wurde, füge Seiten direkt zu pages hinzu
             if (pages.isEmpty()) {
                 pages.addAll(getPagesRecursive(dom, parentId, anchors, pageAnchors, 1, maxLevel))

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -98,6 +98,7 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/ashauer[Lutz Ashauer]
 - https://github.com/igoreq1010[Igor Gaiduk]
 - https://github.com/jgenssler-GiN[Jakob Genßler]
+- https://github.com/tkleiber[Torsten Kleiber]
 - https://github.com/davidmpaz[David Paz]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
## Summary
Fixes critical bug where code blocks break in publishToConfluence task when `subpagesForSections > 1`.

## Original Issue
- Fixes #1524
- Fixes #1528
- Related to PR #1532 (rebased version)

## Changes
- Work with cloned DOM elements instead of mutating the original DOM
- Prevents code block corruption during header promotion
- Changes `Elements pageBody` to `Element pageBody` with proper cloning

## Technical Details
**Before:** Headers were promoted in the original section element, which corrupted code blocks
**After:** Headers are promoted in a cloned element, preserving the original DOM structure

## Credits
Original fix by @tkleiber - this PR is a rebased version to resolve merge conflicts.

## Test Plan
- [x] All existing tests pass
- [x] Tested with subpagesForSections = 0, 1, 2
- [x] Code blocks render correctly in Confluence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Torsten Kleiber <torsten.kleiber@web.de>