### PR TITLE
Cherry-pick: Kroki docs (#1505) and Confluence bugfix (#1545) to main-4.x

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -10,6 +10,9 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 === fixed
 * https://github.com/docToolchain/docToolchain/issues/1526[dtcw.ps1: fix setting mainConfigFile via CLI argument]
 
+* https://github.com/docToolchain/docToolchain/issues/1524[Source blocks not rendered correctly when subpagesForSections greater than 1]
+* https://github.com/docToolchain/docToolchain/issues/1488[doctoolchain version 3.4.2 breaks code blocks in publishToConfluence task]
+
 === added
 * https://github.com/docToolchain/docToolchain/pull/1530[Add instruction for installing docToolchain using SDKMAN]
 

--- a/core/src/main/groovy/org/docToolchain/tasks/Asciidoc2ConfluenceTask.groovy
+++ b/core/src/main/groovy/org/docToolchain/tasks/Asciidoc2ConfluenceTask.groovy
@@ -662,11 +662,12 @@ class Asciidoc2ConfluenceTask extends DocToolchainTask {
         element.select("div.sect${level}").each { sect ->
             def title = sect.select("h${level + 1}").text()
             pageAnchors.putAll(recordPageAnchor(sect.select("h${level + 1}")))
-            Elements pageBody
+            Element pageBody
             if (level == 1) {
-                pageBody = sect.select('div.sectionbody')
+                pageBody = sect.selectFirst('div.sectionbody')?.clone()
             } else {
-                pageBody = new Elements(sect)
+                // Work on a clone to avoid mutating the original DOM and to preserve whitespace/newlines
+                pageBody = sect.clone()
                 pageBody.select("h${level + 1}").remove()
             }
             def currentPage = [
@@ -682,7 +683,8 @@ class Asciidoc2ConfluenceTask extends DocToolchainTask {
             } else {
                 pageBody.select("div.sect${level + 1}").unwrap()
             }
-            promoteHeaders sect, level + 2, level + 1
+            // Promote headers within the page content (clone), not the original section
+            promoteHeaders pageBody, level + 2, level + 1
             pages << currentPage
             anchors.putAll(parseAnchors(currentPage))
         }
@@ -721,11 +723,11 @@ class Asciidoc2ConfluenceTask extends DocToolchainTask {
                 pages << preamble
                 parentId = null
                 anchors.putAll(parseAnchors(preamble))
-                
+
                 // Direkte Manipulation der children-Liste
                 preamble.children.addAll(getPagesRecursive(dom, parentId, anchors, pageAnchors, 1, maxLevel))
             }
-            
+
             // Falls keine Präambel gefunden wurde, füge Seiten direkt zu pages hinzu
             if (pages.isEmpty()) {
                 pages.addAll(getPagesRecursive(dom, parentId, anchors, pageAnchors, 1, maxLevel))

--- a/src/docs/020_tutorial/170_kroki-configuration.adoc
+++ b/src/docs/020_tutorial/170_kroki-configuration.adoc
@@ -1,7 +1,7 @@
-ifndef::imagesdir[:imagesdir: ../../images]
-:diagram-server-url: https://kroki.io/
-:diagram-server-type: kroki_io
-:kroki-server-url: https://kroki.io/
+:jbake-title: Kroki Configuration Guide
+:jbake-order: 170
+
+include::_config.adoc[]
 
 == Kroki Configuration Guide
 
@@ -11,11 +11,14 @@ This guide provides comprehensive instructions for configuring Kroki with docToo
 
 Kroki is a service that converts text-based diagrams (PlantUML, Mermaid, GraphViz, etc.) into images without requiring local tool installations. However, configuring Kroki in docToolchain can be confusing due to historical evolution of diagram extensions.
 
+IMPORTANT: **docToolchain uses the `asciidoctor-diagram` extension version 2.3.1** with Kroki delegation capabilities. This means you should use the `:diagram-server-*` attributes for proper functionality.
+
+
 === The Two Extensions
 
 There are two different AsciiDoc extensions that support Kroki:
 
-==== asciidoctor-diagram: The All-Rounder
+==== asciidoctor-diagram: The All-Rounder (Used by docToolchain)
 
 The original `asciidoctor-diagram` extension existed before Kroki and supported local tools. In version 2.1.0, Kroki support was added:
 
@@ -25,7 +28,7 @@ The original `asciidoctor-diagram` extension existed before Kroki and supported 
 :diagram-server-type: kroki_io
 ----
 
-This extension can use both local tools AND delegate to Kroki servers.
+This extension can use both local tools AND delegate to Kroki servers. **This is what docToolchain uses.**
 
 ==== asciidoctor-kroki: The Specialist
 
@@ -36,13 +39,22 @@ The specialized `asciidoctor-kroki` extension was built exclusively for Kroki:
 :kroki-server-url: https://kroki.io/
 ----
 
-This extension is optimized specifically for Kroki integration.
+This extension is optimized specifically for Kroki integration, but is **not used by docToolchain**.
 
-=== Recommended Configuration
+=== Required Configuration for docToolchain
 
-==== Defensive Configuration Strategy
+Since docToolchain uses `asciidoctor-diagram`, you **must** use these attributes:
 
-To ensure compatibility with both extensions, use all attributes:
+[source,asciidoc]
+----
+// Required for docToolchain (uses asciidoctor-diagram)
+:diagram-server-url: https://kroki.io/
+:diagram-server-type: kroki_io
+----
+
+=== Defensive Configuration Strategy (Recommended)
+
+To ensure compatibility with both extensions and future changes, use all attributes:
 
 [source,asciidoc]
 ----
@@ -57,9 +69,11 @@ To ensure compatibility with both extensions, use all attributes:
 [source,groovy]
 ----
 asciidoctorAttributes = [
-    // Defensive Kroki configuration
+    // Required for docToolchain (asciidoctor-diagram)
     'diagram-server-url': 'https://kroki.io/',
     'diagram-server-type': 'kroki_io',
+
+    // Optional defensive configuration
     'kroki-server-url': 'https://kroki.io/',
     
     // Other attributes...
@@ -158,8 +172,8 @@ a|[source,asciidoc]
 ....
 graph TD
     A[AsciiDoc Document] --> B{Extension Type?}
-    B -->\|asciidoctor-diagram\| C[diagram-server-url]
-    B -->\|asciidoctor-kroki\| D[kroki-server-url]
+    B -->|asciidoctor-diagram| C[diagram-server-url]
+    B -->|asciidoctor-kroki| D[kroki-server-url]
     C --> E[Kroki Server]
     D --> E
     E --> F[Rendered Diagram]
@@ -170,8 +184,8 @@ a|[mermaid]
 ....
 graph TD
     A[AsciiDoc Document] --> B{Extension Type?}
-    B -->\|asciidoctor-diagram\| C[diagram-server-url]
-    B -->\|asciidoctor-kroki\| D[kroki-server-url]
+    B -->|asciidoctor-diagram| C[diagram-server-url]
+    B -->|asciidoctor-kroki| D[kroki-server-url]
     C --> E[Kroki Server]
     D --> E
     E --> F[Rendered Diagram]
@@ -246,7 +260,7 @@ For a complete list, visit https://kroki.io/#support[kroki.io].
    ----
 
 2. **Verify attribute configuration**:
-   - Ensure all three attributes are set for maximum compatibility
+   - Ensure at minimum the `:diagram-server-url:` and `:diagram-server-type:` attributes are set
    - Check for typos in attribute names
 
 3. **Test with simple diagram**:
@@ -306,18 +320,6 @@ docker run -d --name kroki-mermaid yuzutech/kroki-mermaid
 docker run -d --name kroki-bpmn yuzutech/kroki-bpmn
 ----
 
-==== Performance Optimization
-
-For high-volume documentation:
-
-[source,groovy]
-----
-asciidoctorAttributes = [
-    'kroki-fetch-diagram': 'true',  // Cache diagrams locally
-    'kroki-default-format': 'svg',  // Use SVG for better quality
-]
-----
-
 === Security Considerations
 
 ==== Network Security
@@ -337,7 +339,7 @@ asciidoctorAttributes = [
 This approach offers several benefits:
 
 ✅ **Future-proof**: Works with extension updates +
-✅ **Flexible**: docToolchain can switch between extensions +
+✅ **Flexible**: if docToolchain ever switches between extensions, this setup will still work +
 ✅ **Robust**: No breaking changes with upgrades +
 ✅ **Team-friendly**: Team members don't need to know implementation details
 

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -98,6 +98,7 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/ashauer[Lutz Ashauer]
 - https://github.com/igoreq1010[Igor Gaiduk]
 - https://github.com/jgenssler-GiN[Jakob Genßler]
+- https://github.com/tkleiber[Torsten Kleiber]
 - https://github.com/davidmpaz[David Paz]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
## Summary
Cherry-picks two important merged PRs from `ng` to `main-4.x` for the 4.0 release.

## Changes

### 1. Kroki Configuration Documentation (#1505)
- Clarifies that docToolchain uses `asciidoctor-diagram` (not `asciidoctor-kroki`)
- Adds comprehensive Kroki configuration guide
- Addresses code review feedback
- Commit: `94bb817c`

### 2. Confluence Code Blocks Fix (#1545)
- **Critical bugfix**: Fixes code blocks breaking in Confluence when `subpagesForSections > 1`
- Works with cloned DOM elements to prevent mutation
- Fixes issues #1524 and #1528
- Commit: `4406c7c2`
- Original contribution by @tkleiber

## Why Cherry-pick?
Both changes are important for 4.0:
- Documentation improvements help users configure Kroki correctly
- Confluence bugfix resolves critical publishing issue

## Related
- Original PRs: #1505, #1545 (both merged to `ng`)
- Previous cherry-pick: #1544 (SDKMAN docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)