### PR TITLE
docs: fix Kroki configuration confusion

### DIFF
--- a/src/docs/020_tutorial/170_kroki-configuration.adoc
+++ b/src/docs/020_tutorial/170_kroki-configuration.adoc
@@ -1,7 +1,7 @@
-ifndef::imagesdir[:imagesdir: ../../images]
-:diagram-server-url: https://kroki.io/
-:diagram-server-type: kroki_io
-:kroki-server-url: https://kroki.io/
+:jbake-title: Kroki Configuration Guide
+:jbake-order: 170
+
+include::_config.adoc[]
 
 == Kroki Configuration Guide
 
@@ -11,11 +11,14 @@ This guide provides comprehensive instructions for configuring Kroki with docToo
 
 Kroki is a service that converts text-based diagrams (PlantUML, Mermaid, GraphViz, etc.) into images without requiring local tool installations. However, configuring Kroki in docToolchain can be confusing due to historical evolution of diagram extensions.
 
+IMPORTANT: **docToolchain uses the `asciidoctor-diagram` extension version 2.3.1** with Kroki delegation capabilities. This means you should use the `:diagram-server-*` attributes for proper functionality.
+
+
 === The Two Extensions
 
 There are two different AsciiDoc extensions that support Kroki:
 
-==== asciidoctor-diagram: The All-Rounder
+==== asciidoctor-diagram: The All-Rounder (Used by docToolchain)
 
 The original `asciidoctor-diagram` extension existed before Kroki and supported local tools. In version 2.1.0, Kroki support was added:
 
@@ -25,7 +28,7 @@ The original `asciidoctor-diagram` extension existed before Kroki and supported 
 :diagram-server-type: kroki_io
 ----
 
-This extension can use both local tools AND delegate to Kroki servers.
+This extension can use both local tools AND delegate to Kroki servers. **This is what docToolchain uses.**
 
 ==== asciidoctor-kroki: The Specialist
 
@@ -36,13 +39,22 @@ The specialized `asciidoctor-kroki` extension was built exclusively for Kroki:
 :kroki-server-url: https://kroki.io/
 ----
 
-This extension is optimized specifically for Kroki integration.
+This extension is optimized specifically for Kroki integration, but is **not used by docToolchain**.
 
-=== Recommended Configuration
+=== Required Configuration for docToolchain
 
-==== Defensive Configuration Strategy
+Since docToolchain uses `asciidoctor-diagram`, you **must** use these attributes:
 
-To ensure compatibility with both extensions, use all attributes:
+[source,asciidoc]
+----
+// Required for docToolchain (uses asciidoctor-diagram)
+:diagram-server-url: https://kroki.io/
+:diagram-server-type: kroki_io
+----
+
+=== Defensive Configuration Strategy (Recommended)
+
+To ensure compatibility with both extensions and future changes, use all attributes:
 
 [source,asciidoc]
 ----
@@ -57,9 +69,11 @@ To ensure compatibility with both extensions, use all attributes:
 [source,groovy]
 ----
 asciidoctorAttributes = [
-    // Defensive Kroki configuration
+    // Required for docToolchain (asciidoctor-diagram)
     'diagram-server-url': 'https://kroki.io/',
     'diagram-server-type': 'kroki_io',
+
+    // Optional defensive configuration
     'kroki-server-url': 'https://kroki.io/',
     
     // Other attributes...
@@ -158,8 +172,8 @@ a|[source,asciidoc]
 ....
 graph TD
     A[AsciiDoc Document] --> B{Extension Type?}
-    B -->\|asciidoctor-diagram\| C[diagram-server-url]
-    B -->\|asciidoctor-kroki\| D[kroki-server-url]
+    B -->|asciidoctor-diagram| C[diagram-server-url]
+    B -->|asciidoctor-kroki| D[kroki-server-url]
     C --> E[Kroki Server]
     D --> E
     E --> F[Rendered Diagram]
@@ -170,8 +184,8 @@ a|[mermaid]
 ....
 graph TD
     A[AsciiDoc Document] --> B{Extension Type?}
-    B -->\|asciidoctor-diagram\| C[diagram-server-url]
-    B -->\|asciidoctor-kroki\| D[kroki-server-url]
+    B -->|asciidoctor-diagram| C[diagram-server-url]
+    B -->|asciidoctor-kroki| D[kroki-server-url]
     C --> E[Kroki Server]
     D --> E
     E --> F[Rendered Diagram]
@@ -246,7 +260,7 @@ For a complete list, visit https://kroki.io/#support[kroki.io].
    ----
 
 2. **Verify attribute configuration**:
-   - Ensure all three attributes are set for maximum compatibility
+   - Ensure at minimum the `:diagram-server-url:` and `:diagram-server-type:` attributes are set
    - Check for typos in attribute names
 
 3. **Test with simple diagram**:
@@ -306,18 +320,6 @@ docker run -d --name kroki-mermaid yuzutech/kroki-mermaid
 docker run -d --name kroki-bpmn yuzutech/kroki-bpmn
 ----
 
-==== Performance Optimization
-
-For high-volume documentation:
-
-[source,groovy]
-----
-asciidoctorAttributes = [
-    'kroki-fetch-diagram': 'true',  // Cache diagrams locally
-    'kroki-default-format': 'svg',  // Use SVG for better quality
-]
-----
-
 === Security Considerations
 
 ==== Network Security
@@ -337,7 +339,7 @@ asciidoctorAttributes = [
 This approach offers several benefits:
 
 ✅ **Future-proof**: Works with extension updates +
-✅ **Flexible**: docToolchain can switch between extensions +
+✅ **Flexible**: if docToolchain ever switches between extensions, this setup will still work +
 ✅ **Robust**: No breaking changes with upgrades +
 ✅ **Team-friendly**: Team members don't need to know implementation details
 


### PR DESCRIPTION
## Summary
- Clarify asciidoctor-diagram usage in Kroki configuration docs
- Fix confusing documentation that mixed up Kroki and asciidoctor-diagram settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)