### PR TITLE
feat: deprecation warning for Gradle-style --group flag (v4-S29)

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -104,6 +104,10 @@ main() {
     # v4: handle 'tasks' command and validate task name (before environment split)
     if is_v4_installation "${DTC_HOME}"; then
         if [ "${1}" = "tasks" ]; then
+            # v4-S29: Warn about deprecated Gradle-style --group flag
+            if [[ "${2:-}" == "--group" ]]; then
+                echo "Note: v4 uses direct script invocation. --group is ignored." >&2
+            fi
             list_v4_tasks "${DTC_HOME}"
             exit 0
         fi

--- a/test/v4_deprecation_warnings.bats
+++ b/test/v4_deprecation_warnings.bats
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Test deprecation warnings for v3-era Gradle commands in v4 mode
+
+setup() {
+    load 'test_helper.bash'
+    setup_environment
+
+    export DTC_PROJECT_BRANCH=test
+
+    # Create a v4 installation (lib/ directory present)
+    mkdir -p "${DTC_HOME}/lib"
+    mkdir -p "${DTC_HOME}/scripts"
+    touch "${DTC_HOME}/lib/dummy.jar"
+
+    # Create a task script with @task marker
+    echo '// @task' > "${DTC_HOME}/scripts/generateHTML.groovy"
+
+    # Installed local java
+    _mock=$(mock_create_java "${DTC_ROOT}/jdk/bin/java" "17.0.14")
+}
+
+teardown() {
+    mock_teardown
+    rm -rf "${DTC_ROOT}"
+}
+
+# Scenario: User runs dtcw tasks --group doctoolchain
+@test "v4: tasks with --group shows warning that --group is ignored" {
+    run ./dtcw tasks --group doctoolchain
+    assert_success
+    assert_output --partial "Available tasks:"
+    assert_output --partial "generateHTML"
+    assert_output --partial "--group"
+    assert_output --partial "ignored"
+}
+
+# Scenario: User runs dtcw tasks --group (without value)
+@test "v4: tasks with --group but no value still lists tasks" {
+    run ./dtcw tasks --group
+    assert_success
+    assert_output --partial "Available tasks:"
+}


### PR DESCRIPTION
## Summary
- `./dtcw tasks --group doctoolchain` now shows tasks with a note that `--group` is ignored in v4
- BATS test for the `--group` scenario
- `gradlew` replacement deferred to S4 (Remove Gradle) — Gradle is still needed during transition

## Test plan
- [x] `bash -n dtcw` — syntax check
- [x] `shellcheck dtcw` — zero warnings
- [x] `./dtcw tasks --group doctoolchain` shows warning + task list

Refs: raifdmueller/docToolchain#35

🤖 Generated with [Claude Code](https://claude.com/claude-code)