### PR TITLE
feat: script-based configuration loading — DtcConfig (v4-S8)

### DIFF
--- a/scripts/generateHTML.groovy
+++ b/scripts/generateHTML.groovy
@@ -9,17 +9,11 @@
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 
-// Load configuration
-def configPath = new File(docDir, configFile)
-if (!configPath.exists()) {
-    System.err.println "Configuration file not found: ${configPath.absolutePath}"
-    System.err.println ""
-    System.err.println "Create a 'docToolchainConfig.groovy' in your project root."
-    System.err.println "You can download a template with: ./dtcw downloadTemplate"
-    System.exit(1)
-}
-
-def config = new ConfigSlurper().parse(configPath.toURI().toURL())
+// Load configuration via DtcConfig (v4-S8)
+def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def DtcConfig = new GroovyClassLoader(this.class.classLoader).parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
+def dtcConfig = DtcConfig.load(docDir, configFile)
+def config = dtcConfig.getRaw()
 
 // Resolve paths
 def inputPath = new File(docDir, config.inputPath ?: 'src/docs')

--- a/scripts/lib/DtcConfig.groovy
+++ b/scripts/lib/DtcConfig.groovy
@@ -1,0 +1,71 @@
+// v4: Script-based configuration loading (replaces core/configuration/ConfigBuilder + ConfigService)
+// No package, no compilation — loaded via GroovyShell or 'evaluate' in task scripts.
+//
+// Usage in a task script:
+//   def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+//   def DtcConfig = new GroovyClassLoader(this.class.classLoader).parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
+//   def dtcConfig = DtcConfig.load(docDir, configFile)
+//   def value = dtcConfig.get('confluence.api')
+//   def tree = dtcConfig.getSubTree('confluence')
+
+class DtcConfig {
+
+    private final ConfigObject configObject
+
+    private DtcConfig(ConfigObject configObject) {
+        this.configObject = configObject
+    }
+
+    /**
+     * Load and parse a docToolchainConfig.groovy file.
+     * Injects docDir and mainConfigFile into the config.
+     */
+    static DtcConfig load(String docDir, String mainConfigFile) {
+        def configFile = new File(docDir, mainConfigFile)
+        if (!configFile.exists()) {
+            System.err.println "Configuration file not found: ${configFile.canonicalPath}"
+            System.err.println ""
+            System.err.println "Create a 'docToolchainConfig.groovy' in your project root."
+            System.err.println "You can download a template with: ./dtcw downloadTemplate"
+            System.exit(1)
+        }
+        ConfigObject config = new ConfigSlurper().parse(configFile.toURI().toURL())
+        config.put('docDir', configFile.parent)
+        config.put('mainConfigFile', configFile.name)
+        return new DtcConfig(config)
+    }
+
+    /**
+     * Get a single config property by path (e.g. 'confluence.api').
+     * For first-level keys like 'confluence', returns the full subtree.
+     * Returns null if not found.
+     */
+    Object get(String propertyPath) {
+        def property = configObject.get(propertyPath)
+        if (!property) {
+            property = configObject.flatten().get(propertyPath)
+        }
+        return property
+    }
+
+    /**
+     * Get all properties under a path as a flat map.
+     * E.g. getSubTree('confluence') returns [api: '...', spaceKey: '...', 'proxy.host': '...']
+     * Returns empty map if path not found.
+     */
+    Map getSubTree(String propertyPath) {
+        return configObject.flatten().inject([:]) { result, key, value ->
+            if (key.startsWith(propertyPath)) {
+                result.put(key.replaceFirst("${propertyPath}.", ""), value)
+            }
+            return result
+        }
+    }
+
+    /**
+     * Access the raw ConfigObject (for backward compatibility or advanced use).
+     */
+    ConfigObject getRaw() {
+        return configObject
+    }
+}

--- a/scripts/lib/DtcConfigTest.groovy
+++ b/scripts/lib/DtcConfigTest.groovy
@@ -1,0 +1,89 @@
+// v4: Self-contained test for DtcConfig (runs without Spock/JUnit)
+// Usage: groovy scripts/lib/DtcConfigTest.groovy
+
+def DtcConfig = new GroovyClassLoader(this.class.classLoader).parseClass(new File('scripts/lib/DtcConfig.groovy'))
+
+def passed = 0
+def failed = 0
+
+def assertEq(name, actual, expected) {
+    if (actual == expected) {
+        println "  PASS: ${name}"
+        return true
+    } else {
+        println "  FAIL: ${name} — expected '${expected}', got '${actual}'"
+        return false
+    }
+}
+
+// Setup: create a temp config file
+def tmpDir = File.createTempDir('dtcconfig-test', '')
+def configFile = new File(tmpDir, 'testConfig.groovy')
+configFile.text = """
+outputPath = 'build/docs'
+inputPath = 'src/docs'
+
+confluence = [:]
+confluence.with {
+    api = 'https://my.confluence/rest/api/'
+    spaceKey = 'asciidoc'
+    proxy = [
+        host: 'proxy.example.com',
+        port: 8080,
+        schema: 'https'
+    ]
+}
+"""
+
+println "=== DtcConfig.load() ==="
+def config = DtcConfig.load(tmpDir.absolutePath, 'testConfig.groovy')
+if (assertEq('config loaded', config != null, true)) passed++ else failed++
+
+println "\n=== get() simple property ==="
+if (assertEq('outputPath', config.get('outputPath'), 'build/docs')) passed++ else failed++
+if (assertEq('inputPath', config.get('inputPath'), 'src/docs')) passed++ else failed++
+if (assertEq('docDir injected', config.get('docDir'), tmpDir.absolutePath)) passed++ else failed++
+if (assertEq('mainConfigFile injected', config.get('mainConfigFile'), 'testConfig.groovy')) passed++ else failed++
+
+println "\n=== get() nested property ==="
+if (assertEq('confluence.api', config.get('confluence.api'), 'https://my.confluence/rest/api/')) passed++ else failed++
+if (assertEq('confluence.spaceKey', config.get('confluence.spaceKey'), 'asciidoc')) passed++ else failed++
+
+println "\n=== get() first-level tree ==="
+def confluence = config.get('confluence')
+if (assertEq('confluence is map', confluence instanceof Map, true)) passed++ else failed++
+if (assertEq('confluence.api from tree', confluence.api, 'https://my.confluence/rest/api/')) passed++ else failed++
+
+println "\n=== get() nested tree returns null ==="
+if (assertEq('confluence.proxy via get()', config.get('confluence.proxy'), null)) passed++ else failed++
+
+println "\n=== get() non-existing ==="
+if (assertEq('non-existing', config.get('non-sense'), null)) passed++ else failed++
+
+println "\n=== getSubTree() ==="
+def confTree = config.getSubTree('confluence')
+if (assertEq('subtree size', confTree.size(), 5)) passed++ else failed++
+if (assertEq('subtree api', confTree.api, 'https://my.confluence/rest/api/')) passed++ else failed++
+if (assertEq('subtree proxy.host', confTree['proxy.host'], 'proxy.example.com')) passed++ else failed++
+if (assertEq('subtree proxy.port', confTree['proxy.port'], 8080)) passed++ else failed++
+
+println "\n=== getSubTree() second level ==="
+def proxyTree = config.getSubTree('confluence.proxy')
+if (assertEq('proxy subtree size', proxyTree.size(), 3)) passed++ else failed++
+if (assertEq('proxy host', proxyTree.host, 'proxy.example.com')) passed++ else failed++
+
+println "\n=== getSubTree() non-existing ==="
+def empty = config.getSubTree('non-sense')
+if (assertEq('empty subtree', empty, Collections.EMPTY_MAP)) passed++ else failed++
+
+println "\n=== getRaw() ==="
+if (assertEq('raw is ConfigObject', config.getRaw() instanceof ConfigObject, true)) passed++ else failed++
+
+// Cleanup
+tmpDir.deleteDir()
+
+println "\n========================================="
+println "Results: ${passed} passed, ${failed} failed"
+if (failed > 0) {
+    System.exit(1)
+}

--- a/scripts/publishToConfluence.groovy
+++ b/scripts/publishToConfluence.groovy
@@ -12,16 +12,11 @@ import org.docToolchain.tasks.Asciidoc2ConfluenceTask
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 
-// Load configuration
-def configPath = new File(docDir, configFile)
-if (!configPath.exists()) {
-    System.err.println "Configuration file not found: ${configPath.absolutePath}"
-    System.err.println ""
-    System.err.println "Create a 'docToolchainConfig.groovy' in your project root."
-    System.exit(1)
-}
-
-def config = new ConfigSlurper().parse(configPath.toURI().toURL())
+// Load configuration via DtcConfig (v4-S8)
+def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def DtcConfig = new GroovyClassLoader(this.class.classLoader).parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
+def dtcConfig = DtcConfig.load(docDir, configFile)
+def config = dtcConfig.getRaw()
 
 // Validate Confluence settings
 if (!config.confluence?.api) {


### PR DESCRIPTION
## Summary
- New `scripts/lib/DtcConfig.groovy` — replaces `core/configuration/ConfigBuilder` + `ConfigService`
- No compilation, no package — loaded via `GroovyClassLoader` in task scripts
- API: `DtcConfig.load(docDir, configFile)` → `get()`, `getSubTree()`, `getRaw()`
- `generateHTML.groovy` and `publishToConfluence.groovy` migrated to use `DtcConfig`
- 19 self-contained tests verify behavioral parity with core ConfigService

## Test plan
- [x] `DtcConfigTest.groovy` — 19 tests pass (simple properties, nested, subtrees, edge cases)
- [x] `./gradlew core:test` — existing core tests still pass (no regression)
- [x] `bash -n dtcw` — syntax check

## Design decisions
- Single file instead of two (ConfigBuilder + ConfigService merged) — simpler for script-based loading
- `GroovyClassLoader.parseClass()` pattern for loading — works without `evaluate()` issues
- `getRaw()` provides escape hatch for scripts that need the full ConfigObject

Refs: raifdmueller/docToolchain#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)