### PR TITLE
feat: script-based HTTP client — DtcRestClient (v4-S9)

### DIFF
--- a/scripts/lib/DtcRestClient.groovy
+++ b/scripts/lib/DtcRestClient.groovy
@@ -1,0 +1,96 @@
+// v4: Script-based HTTP client (replaces core/http/BasicRestClient + RequestFailedException)
+// No package, no compilation — loaded via GroovyClassLoader in task scripts.
+// Requires Apache HttpClient 5.x JARs on classpath (from lib/).
+//
+// Usage in a task script:
+//   def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+//   def cl = new GroovyClassLoader(this.class.classLoader)
+//   cl.parseClass(new File(scriptDir, 'lib/DtcRestClient.groovy'))
+//   def client = new DtcRestClient()
+//   // ... configure and use
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder
+import org.apache.hc.core5.http.ClassicHttpRequest
+import org.apache.hc.core5.http.Header
+import org.apache.hc.core5.http.HttpHeaders
+import org.apache.hc.core5.http.HttpHost
+import org.apache.hc.core5.http.HttpResponse
+import org.apache.hc.core5.http.io.HttpClientResponseHandler
+import org.apache.hc.core5.net.URIBuilder
+
+/**
+ * Exception for failed HTTP requests with actionable error messages (QS-17).
+ */
+class DtcRequestFailedException extends RuntimeException {
+
+    DtcRequestFailedException(HttpResponse response, Exception reason) {
+        super(buildMessage(response, reason), reason)
+    }
+
+    private static String buildMessage(HttpResponse response, Exception reason) {
+        String responseLog = response != null ? "${response.code} ${response.reasonPhrase}" : "<none>"
+        String reasonLog = reason != null ? reason.message : "<none>"
+        String possibleSolution
+
+        switch (response.code) {
+            case 401:
+                possibleSolution = "please check your credentials in config file or passed parameters"
+                break
+            case 400:
+                possibleSolution = "please check your config file or passed parameters"
+                break
+            case 429:
+                possibleSolution = "please check if you need to decrease the rate limit in your config file"
+                break
+            default:
+                possibleSolution = "please check your config. If you are sure that everything is correct, " +
+                    "please open an issue at https://github.com/docToolchain/docToolchain/issues"
+        }
+
+        return "something went wrong - request failed" + " (" +
+            "\nresponse: ${responseLog}, " +
+            "\nreason: ${reasonLog}, " +
+            "\npossible solution: ${possibleSolution})"
+    }
+}
+
+/**
+ * Base HTTP client using Apache HttpClient 5.x.
+ * Sets User-Agent and Host headers automatically.
+ */
+class DtcRestClient {
+
+    protected HttpClientBuilder httpClientBuilder
+
+    DtcRestClient() {
+        this.httpClientBuilder = HttpClientBuilder.create()
+        httpClientBuilder.addRequestInterceptorFirst { request, entityDetails, context ->
+            request.setHeader(HttpHeaders.USER_AGENT, "docToolchain_v4")
+            Header hostHeader = request.getHeader(HttpHeaders.HOST)
+            if (hostHeader == null) {
+                String host = new URIBuilder(request.uri.toString()).host
+                request.setHeader(HttpHeaders.HOST, host)
+            }
+        }
+    }
+
+    /**
+     * Execute an HTTP request and return the response body.
+     * Returns Optional.empty() if response is null.
+     */
+    def doRequest(HttpHost targetHost, ClassicHttpRequest httpRequest, HttpClientResponseHandler<String> responseHandler) {
+        try (CloseableHttpClient httpClient = httpClientBuilder.build()) {
+            return Optional.ofNullable(httpClient.execute(targetHost, httpRequest, responseHandler))
+        } catch (IOException e) {
+            System.err.println("HTTP request failed: ${httpRequest.method} ${httpRequest.uri}")
+            System.err.println("Target: ${targetHost.toURI()}")
+            System.err.println("Reason: ${e.message}")
+            throw new RuntimeException(e)
+        }
+    }
+
+    protected getHttpClientBuilder() {
+        return httpClientBuilder
+    }
+}

--- a/scripts/lib/DtcRestClientTest.groovy
+++ b/scripts/lib/DtcRestClientTest.groovy
@@ -1,0 +1,56 @@
+// v4: Self-contained test for DtcRestClient (runs without Spock/JUnit)
+// Usage: groovy scripts/lib/DtcRestClientTest.groovy
+//
+// Tests class loading, construction, and error messages.
+// Full HTTP tests require a running server (covered in S6/S7).
+
+def cl = new GroovyClassLoader(this.class.classLoader)
+cl.parseClass(new File('scripts/lib/DtcRestClient.groovy'))
+def RestClientClass = cl.loadClass('DtcRestClient')
+def ExceptionClass = cl.loadClass('DtcRequestFailedException')
+
+def passed = 0
+def failed = 0
+
+def assertEq(name, actual, expected) {
+    if (actual == expected) {
+        println "  PASS: ${name}"
+        return true
+    } else {
+        println "  FAIL: ${name} — expected '${expected}', got '${actual}'"
+        return false
+    }
+}
+
+println "=== DtcRestClient construction ==="
+def client = RestClientClass.newInstance()
+if (assertEq('client created', client != null, true)) passed++ else failed++
+if (assertEq('has httpClientBuilder', client.httpClientBuilder != null, true)) passed++ else failed++
+
+println "\n=== DtcRequestFailedException ==="
+// Simulate a 401 response
+def mockResponse = [getCode: { 401 }, getReasonPhrase: { 'Unauthorized' }] as org.apache.hc.core5.http.HttpResponse
+def ex = ExceptionClass.newInstance(mockResponse, new Exception("test error"))
+if (assertEq('exception message contains 401', ex.message.contains('401'), true)) passed++ else failed++
+if (assertEq('exception suggests credentials', ex.message.contains('credentials'), true)) passed++ else failed++
+
+// Simulate a 429 response
+def mock429 = [getCode: { 429 }, getReasonPhrase: { 'Too Many Requests' }] as org.apache.hc.core5.http.HttpResponse
+def ex429 = ExceptionClass.newInstance(mock429, new Exception("rate limited"))
+if (assertEq('429 suggests rate limit', ex429.message.contains('rate limit'), true)) passed++ else failed++
+
+// Simulate a 400 response
+def mock400 = [getCode: { 400 }, getReasonPhrase: { 'Bad Request' }] as org.apache.hc.core5.http.HttpResponse
+def ex400 = ExceptionClass.newInstance(mock400, new Exception("bad request"))
+if (assertEq('400 suggests config', ex400.message.contains('config'), true)) passed++ else failed++
+
+// Simulate a 500 response
+def mock500 = [getCode: { 500 }, getReasonPhrase: { 'Internal Server Error' }] as org.apache.hc.core5.http.HttpResponse
+def ex500 = ExceptionClass.newInstance(mock500, new Exception("server error"))
+if (assertEq('500 suggests github issue', ex500.message.contains('github.com'), true)) passed++ else failed++
+
+println "\n========================================="
+println "Results: ${passed} passed, ${failed} failed"
+if (failed > 0) {
+    System.exit(1)
+}


### PR DESCRIPTION
## Summary
- New `scripts/lib/DtcRestClient.groovy` — replaces `core/http/BasicRestClient` + `RequestFailedException`
- `DtcRestClient`: Apache HttpClient 5.x wrapper with auto User-Agent/Host headers
- `DtcRequestFailedException`: actionable error messages per HTTP status code (401→credentials, 429→rate limit, etc.)
- 7 self-contained tests verify construction and all error message paths
- Core module unchanged — additive, used by future S6 (Confluence) and S7 (Jira) scripts

## Test plan
- [x] `DtcRestClientTest.groovy` — 7 tests pass (construction, 401/400/429/500 error messages)
- [x] `./gradlew core:test` — existing core tests still pass

## Design decisions
- Two classes in one file (DtcRestClient + DtcRequestFailedException) — keeps loading simple
- User-Agent hardcoded to `docToolchain_v4` instead of reading from package manifest (no JAR in script mode)
- Error messages match v3 behavior for backward compatibility

Refs: raifdmueller/docToolchain#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)