### PR TITLE
issue #1434: enhance Maven repository configuration for air-gapped environments

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -18,6 +18,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 
 === changed
 * https://github.com/docToolchain/docToolchain/pull/1511[exportEA: close application after export with ShutdownEA interface]
+* https://github.com/docToolchain/docToolchain/issues/1434[Gradle: improve Maven repository configuration for air-gapped environments]
 
 == 3.4.2 - 2025-04-05
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,15 +5,27 @@ plugins {
 
 apply plugin:'groovy'
 
-repositories {
-    mavenCentral()
-}
-
 // Workaround to keep project.version in sync with gradle.properties but the modules isolated as hell
 def props = new Properties()
 file("../gradle.properties").withInputStream { props.load(it) }
 def dtc_version = props.getProperty('dtc_version')
 // end of workaround
+
+def deps_maven_repository = findProperty('depsMavenRepository') ?: props.getProperty('depsMavenRepository', 'https://repo.maven.apache.org/maven2/')
+def deps_maven_username = findProperty('depsMavenUsername') ?: props.getProperty('depsMavenUsername', '')
+def deps_maven_password = findProperty('depsMavenPassword') ?: props.getProperty('depsMavenPassword', '')
+
+repositories {
+    maven {
+        url deps_maven_repository
+        if (deps_maven_username || deps_maven_password) {
+            credentials {
+                username deps_maven_username
+                password deps_maven_password
+            }
+        }
+    }
+}
 
 jar {
     manifest {

--- a/core/settings.gradle
+++ b/core/settings.gradle
@@ -1,3 +1,23 @@
+pluginManagement {
+    def settingsProps = new Properties()
+    file("../gradle.properties").withInputStream { settingsProps.load(it) }
+    def settings_maven_repository = providers.gradleProperty('mavenRepository').orElse(settingsProps.getProperty('mavenRepository', 'https://plugins.gradle.org/m2/')).get()
+    def settings_maven_username = providers.gradleProperty('mavenUsername').orElse(settingsProps.getProperty('mavenUsername', '')).get()
+    def settings_maven_password = providers.gradleProperty('mavenPassword').orElse(settingsProps.getProperty('mavenPassword', '')).get()
+
+    repositories {
+        maven {
+            url = uri(settings_maven_repository)
+            if (settings_maven_username || settings_maven_password) {
+                credentials {
+                    username = settings_maven_username
+                    password = settings_maven_password
+                }
+            }
+        }
+    }
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         libs {

--- a/core/settings.gradle
+++ b/core/settings.gradle
@@ -1,9 +1,21 @@
 pluginManagement {
     def settingsProps = new Properties()
-    file("../gradle.properties").withInputStream { settingsProps.load(it) }
-    def settings_maven_repository = providers.gradleProperty('mavenRepository').orElse(settingsProps.getProperty('mavenRepository', 'https://plugins.gradle.org/m2/')).get()
-    def settings_maven_username = providers.gradleProperty('mavenUsername').orElse(settingsProps.getProperty('mavenUsername', '')).get()
-    def settings_maven_password = providers.gradleProperty('mavenPassword').orElse(settingsProps.getProperty('mavenPassword', '')).get()
+    def settingsPropsFile = file("../gradle.properties")
+    def defaultMavenRepository = 'https://plugins.gradle.org/m2/'
+    def defaultMavenUsername = ''
+    def defaultMavenPassword = ''
+
+    if (settingsPropsFile.exists() && settingsPropsFile.canRead()) {
+        try {
+            settingsPropsFile.withInputStream { settingsProps.load(it) }
+        } catch (IOException ignored) {
+            // Keep using CLI properties and hard-coded defaults when the properties file cannot be loaded.
+        }
+    }
+
+    def settings_maven_repository = providers.gradleProperty('mavenRepository').orElse(settingsProps.getProperty('mavenRepository', defaultMavenRepository)).get()
+    def settings_maven_username = providers.gradleProperty('mavenUsername').orElse(settingsProps.getProperty('mavenUsername', defaultMavenUsername)).get()
+    def settings_maven_password = providers.gradleProperty('mavenPassword').orElse(settingsProps.getProperty('mavenPassword', defaultMavenPassword)).get()
 
     repositories {
         maven {

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -3,13 +3,23 @@
  */
 buildscript {
     repositories {
-        mavenCentral()
         maven {
-            credentials {
-                username mavenUsername
-                password mavenPassword
+            url depsMavenRepository
+            if (depsMavenUsername || depsMavenPassword) {
+                credentials {
+                    username depsMavenUsername
+                    password depsMavenPassword
+                }
             }
+        }
+        maven {
             url mavenRepository
+            if (mavenUsername || mavenPassword) {
+                credentials {
+                    username mavenUsername
+                    password mavenPassword
+                }
+            }
         }
     }
     configurations.all {

--- a/scripts/exportMarkdown.gradle
+++ b/scripts/exportMarkdown.gradle
@@ -1,12 +1,22 @@
 buildscript {
     repositories {
-        mavenCentral()
         maven {
-            credentials {
-                username mavenUsername
-                password mavenPassword
+            url depsMavenRepository
+            if (depsMavenUsername || depsMavenPassword) {
+                credentials {
+                    username depsMavenUsername
+                    password depsMavenPassword
+                }
             }
+        }
+        maven {
             url mavenRepository
+            if (mavenUsername || mavenPassword) {
+                credentials {
+                    username mavenUsername
+                    password mavenPassword
+                }
+            }
         }
     }
     dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,26 @@ include 'api'
 include 'services:webservice'
 */
 
+pluginManagement {
+    def settingsProps = new Properties()
+    file("gradle.properties").withInputStream { settingsProps.load(it) }
+    def settings_maven_repository = providers.gradleProperty('mavenRepository').orElse(settingsProps.getProperty('mavenRepository', 'https://plugins.gradle.org/m2/')).get()
+    def settings_maven_username = providers.gradleProperty('mavenUsername').orElse(settingsProps.getProperty('mavenUsername', '')).get()
+    def settings_maven_password = providers.gradleProperty('mavenPassword').orElse(settingsProps.getProperty('mavenPassword', '')).get()
+
+    repositories {
+        maven {
+            url = uri(settings_maven_repository)
+            if (settings_maven_username || settings_maven_password) {
+                credentials {
+                    username = settings_maven_username
+                    password = settings_maven_password
+                }
+            }
+        }
+    }
+}
+
 rootProject.name = 'docToolchain'
 
 dependencyResolutionManagement {

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,10 +18,22 @@ include 'services:webservice'
 
 pluginManagement {
     def settingsProps = new Properties()
-    file("gradle.properties").withInputStream { settingsProps.load(it) }
-    def settings_maven_repository = providers.gradleProperty('mavenRepository').orElse(settingsProps.getProperty('mavenRepository', 'https://plugins.gradle.org/m2/')).get()
-    def settings_maven_username = providers.gradleProperty('mavenUsername').orElse(settingsProps.getProperty('mavenUsername', '')).get()
-    def settings_maven_password = providers.gradleProperty('mavenPassword').orElse(settingsProps.getProperty('mavenPassword', '')).get()
+    def settingsPropsFile = file("gradle.properties")
+    def defaultMavenRepository = 'https://plugins.gradle.org/m2/'
+    def defaultMavenUsername = ''
+    def defaultMavenPassword = ''
+
+    if (settingsPropsFile.exists() && settingsPropsFile.canRead()) {
+        try {
+            settingsPropsFile.withInputStream { settingsProps.load(it) }
+        } catch (IOException ignored) {
+            // Keep using CLI properties and hard-coded defaults when the properties file cannot be loaded.
+        }
+    }
+
+    def settings_maven_repository = providers.gradleProperty('mavenRepository').orElse(settingsProps.getProperty('mavenRepository', defaultMavenRepository)).get()
+    def settings_maven_username = providers.gradleProperty('mavenUsername').orElse(settingsProps.getProperty('mavenUsername', defaultMavenUsername)).get()
+    def settings_maven_password = providers.gradleProperty('mavenPassword').orElse(settingsProps.getProperty('mavenPassword', defaultMavenPassword)).get()
 
     repositories {
         maven {

--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -343,15 +343,19 @@ dtcw.bat tasks --group=doctoolchain
 ---
 
 
-NOTE: If you are behind a corporate proxy, you might need to consider build-script dependencies are fetched from a repository referenced by the property `mavenRepository`.
-By default, the value `https://plugins.gradle.org/m2/` is used. When a repository requiring credentials is used the properties `mavenUsername` and `mavenPassword` can be set as well.
+NOTE: If you are behind a corporate proxy or in an air-gapped environment, configure Maven repositories used by Gradle.
 
-//in which configuration path/file?
+docToolchain supports two repository groups:
+
+* `mavenRepository`, `mavenUsername`, `mavenPassword`: used for Gradle plugin resolution (default: `https://plugins.gradle.org/m2/`)
+* `depsMavenRepository`, `depsMavenUsername`, `depsMavenPassword`: used for regular dependency resolution (default: `https://repo.maven.apache.org/maven2/`)
+
+You can set these properties in your project's `gradle.properties` or pass them through `DTC_OPTS`.
 
 [source, sh]
-.Example command passing a custom maven repository with credentials from the command line
+.Example command passing both repositories and credentials from the command line
 ----
-DTC_OPTS="-PmavenRepository=your_maven_repo -PmavenUsername=your_username -PmavenPassword=your_pw" ./dtcw tasks --group=doctoolchain --info
+DTC_OPTS="-PmavenRepository=https://your-plugin-repo/m2/ -PmavenUsername=your_username -PmavenPassword=your_pw -PdepsMavenRepository=https://your-deps-repo/maven2/ -PdepsMavenUsername=your_username -PdepsMavenPassword=your_pw" ./dtcw tasks --group=doctoolchain --info
 ----
 
 // end::install[]

--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -347,7 +347,7 @@ NOTE: If you are behind a corporate proxy or in an air-gapped environment, confi
 
 docToolchain supports two repository groups:
 
-* `mavenRepository`, `mavenUsername`, `mavenPassword`: used for Gradle plugin resolution (default: `https://plugins.gradle.org/m2/`)
+* `mavenRepository`, `mavenUsername`, `mavenPassword`: used for Gradle plugin resolution and for `buildscript` classpaths in task scripts (default: `https://plugins.gradle.org/m2/`)
 * `depsMavenRepository`, `depsMavenUsername`, `depsMavenPassword`: used for regular dependency resolution (default: `https://repo.maven.apache.org/maven2/`)
 
 You can set these properties in your project's `gradle.properties` or pass them through `DTC_OPTS`.

--- a/src/docs/010_manual/50_Frequently_asked_Questions.adoc
+++ b/src/docs/010_manual/50_Frequently_asked_Questions.adoc
@@ -278,6 +278,8 @@ You could call this instead (remember to replace the values used in our example)
 (IP, port, etc. just an example)
 
 For more information about Gradle proxy configuration, read https://stackoverflow.com/questions/5991194/gradle-proxy-configuration[this article].
+
+If your environment requires internal repositories, configure `mavenRepository` (Gradle plugins) and `depsMavenRepository` (regular dependencies), including optional username/password pairs, either in `gradle.properties` or via `DTC_OPTS`.
 ====
 
 

--- a/src/docs/010_manual/50_Frequently_asked_Questions.adoc
+++ b/src/docs/010_manual/50_Frequently_asked_Questions.adoc
@@ -279,7 +279,7 @@ You could call this instead (remember to replace the values used in our example)
 
 For more information about Gradle proxy configuration, read https://stackoverflow.com/questions/5991194/gradle-proxy-configuration[this article].
 
-If your environment requires internal repositories, configure `mavenRepository` (Gradle plugins) and `depsMavenRepository` (regular dependencies), including optional username/password pairs, either in `gradle.properties` or via `DTC_OPTS`.
+If your environment requires internal repositories, configure `mavenRepository` (used for plugin artifacts and also libraries resolved from `buildscript` classpaths in task scripts) and `depsMavenRepository` (regular dependencies), including optional username/password pairs, either in `gradle.properties` or via `DTC_OPTS`.
 ====
 
 

--- a/src/docs/015_tasks/03_task_generateSite.adoc
+++ b/src/docs/015_tasks/03_task_generateSite.adoc
@@ -209,8 +209,9 @@ In the `docToolchainConfig.groovy` it is possible to amend the configuration of 
 include::{projectRootDir}/Config.groovy[tags=jbakeConfig]
 ----
 
-The plugins are retrieved from a repository configured with project property `depsMavenRepository` (default: `https://repo.maven.apache.org/maven2/`).
-When a repository requiring credentials is used, set `depsMavenUsername` and `depsMavenPassword` as well.
+Additional plugins added to the `jbake` configuration are retrieved from the repository configured with project property `depsMavenRepository` (default: `https://repo.maven.apache.org/maven2/`).
+The Gradle `buildscript` classpath used by `generateSite` is configured separately via `mavenRepository`.
+When repositories requiring credentials are used, set `depsMavenUsername` and `depsMavenPassword` for `depsMavenRepository`, and `mavenUsername` and `mavenPassword` for `mavenRepository`.
 These values can be configured in `gradle.properties` or passed via `DTC_OPTS`.
 
 === Templates and Style

--- a/src/docs/015_tasks/03_task_generateSite.adoc
+++ b/src/docs/015_tasks/03_task_generateSite.adoc
@@ -209,8 +209,9 @@ In the `docToolchainConfig.groovy` it is possible to amend the configuration of 
 include::{projectRootDir}/Config.groovy[tags=jbakeConfig]
 ----
 
-The plugins are retrieved from a repository (by default maven-central) configured with project property `depsMavenRepository`.
-When a repository requiring credentials is used the properties `depsMavenUsername` and `depsMavenPassword` can be set as well.
+The plugins are retrieved from a repository configured with project property `depsMavenRepository` (default: `https://repo.maven.apache.org/maven2/`).
+When a repository requiring credentials is used, set `depsMavenUsername` and `depsMavenPassword` as well.
+These values can be configured in `gradle.properties` or passed via `DTC_OPTS`.
 
 === Templates and Style
 

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -100,5 +100,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/jgenssler-GiN[Jakob Genßler]
 - https://github.com/tkleiber[Torsten Kleiber]
 - https://github.com/davidmpaz[David Paz]
+- https://github.com/steffenboe[Steffen Börner]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
## Pass Maven Repositories to DTC Build Process via Gradle Properties
This PR improves support for restricted and air-gapped environments by making Maven repository resolution configurable for both Gradle plugins and regular dependencies (including optional credentials).

Key points:

- Added configurable repository handling for plugin resolution and dependency resolution.
- Documented how to use these settings via gradle.properties.

resolves #1434 