### PR TITLE
docs: add Bausteinsicht to landing page

### DIFF
--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -111,6 +111,17 @@
             <div class="col">
                 <div class="card mb-4 shadow-sm">
                     <div class="card-header">
+                        <h4 class="my-0 fw-normal">Bausteinsicht</h4>
+                    </div>
+                    <div class="card-body">
+                        Architecture-as-code: define building blocks in JSONC, sync bidirectionally with draw.io diagrams. Think Structurizr, but simpler.<br /><br />
+                        <a class="btn btn-primary" href="https://doctoolchain.org/Bausteinsicht/" role="button">learn more</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header">
                         <h4 class="my-0 fw-normal">diagrams.net IntelliJ Plugin</h4>
                     </div>
                     <div class="card-body">


### PR DESCRIPTION
## Summary

- Add Bausteinsicht to the "Sub-Projects & Ecosystem" section on the landing page
- Now 6 ecosystem cards in two clean rows of 3: AsciiDoc Linter, dacli, **Bausteinsicht**, diagrams.net Plugin, iSAQB Template, CI/CD Demo
- Links to https://doctoolchain.org/Bausteinsicht/

## Test plan
- [ ] Verify card renders correctly in the microsite
- [ ] Verify link resolves to Bausteinsicht docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)