### PR TITLE
feat(site): GoatCounter analytics injected at deploy time only

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -144,6 +144,9 @@ publish_doc () {
       cd gh-pages
       rm -rf v2.0.x/*
       cp -Rf "${BUILD_DIR}"/build/microsite/output/* v2.0.x/.
+      # inject deploy-only analytics into the published copy (no-op when
+      # GOATCOUNTER_ENDPOINT is unset, e.g. on forks)
+      "${BUILD_DIR}"/scripts/injectAnalytics.sh v2.0.x
     fi
 
     #add, commit and push files

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -77,6 +77,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JDK_VERSION: "${{ matrix.jdk }}-${{ matrix.java }}"
+          # deploy-only web analytics; injected into gh-pages by scripts/injectAnalytics.sh
+          GOATCOUNTER_ENDPOINT: ${{ secrets.GOATCOUNTER_ENDPOINT }}
         run: |
           ./.ci.sh
       - name: Archive test results

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -77,8 +77,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JDK_VERSION: "${{ matrix.jdk }}-${{ matrix.java }}"
-          # deploy-only web analytics; injected into gh-pages by scripts/injectAnalytics.sh
-          GOATCOUNTER_ENDPOINT: ${{ secrets.GOATCOUNTER_ENDPOINT }}
+          # deploy-only web analytics; injected into gh-pages by scripts/injectAnalytics.sh.
+          # Only populated for non-PR events, since publishing never runs on PR builds.
+          GOATCOUNTER_ENDPOINT: ${{ github.event_name != 'pull_request' && secrets.GOATCOUNTER_ENDPOINT || '' }}
         run: |
           ./.ci.sh
       - name: Archive test results

--- a/scripts/goatcounter-snippet.html
+++ b/scripts/goatcounter-snippet.html
@@ -1,0 +1,9 @@
+<!-- GoatCounter analytics — injected at deploy time only, never part of the templates.
+     Pinned to count.v5.js with Subresource Integrity (sha384) so a CDN compromise of
+     gc.zgo.at cannot inject altered code. When bumping the version, update both the
+     src URL and the integrity hash from https://www.goatcounter.com/help/countjs-versions
+     and re-verify with: openssl dgst -sha384 -binary count.vN.js | openssl base64 -A -->
+<script data-goatcounter="__GOATCOUNTER_ENDPOINT__"
+        async src="//gc.zgo.at/count.v5.js"
+        crossorigin="anonymous"
+        integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>

--- a/scripts/goatcounter-snippet.html
+++ b/scripts/goatcounter-snippet.html
@@ -4,6 +4,6 @@
      src URL and the integrity hash from https://www.goatcounter.com/help/countjs-versions
      and re-verify with: openssl dgst -sha384 -binary count.vN.js | openssl base64 -A -->
 <script data-goatcounter="__GOATCOUNTER_ENDPOINT__"
-        async src="//gc.zgo.at/count.v5.js"
+        async src="https://gc.zgo.at/count.v5.js"
         crossorigin="anonymous"
         integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>

--- a/scripts/injectAnalytics.sh
+++ b/scripts/injectAnalytics.sh
@@ -22,6 +22,15 @@ if [ -z "${GOATCOUNTER_ENDPOINT:-}" ]; then
     exit 0
 fi
 
+# The endpoint is substituted into a double-quoted HTML attribute. Require a clean
+# https:// URL so a misconfigured secret cannot break the markup or inject content.
+# Fail the build rather than publish broken or unsafe HTML.
+endpoint_re='^https://[^[:space:]"'\''<>]+$'
+if [[ ! "${GOATCOUNTER_ENDPOINT}" =~ $endpoint_re ]]; then
+    echo "injectAnalytics: GOATCOUNTER_ENDPOINT must be a plain https:// URL without quotes or angle brackets." >&2
+    exit 1
+fi
+
 if [ -z "${TARGET_DIR}" ] || [ ! -d "${TARGET_DIR}" ]; then
     echo "injectAnalytics: target directory '${TARGET_DIR}' does not exist." >&2
     exit 1
@@ -45,13 +54,16 @@ printf '%s\n' "${snippet}" > "${snippet_file}"
 
 injected=0
 skipped=0
+nohead=0
 
 while IFS= read -r -d '' file; do
     if grep -q 'data-goatcounter' "${file}"; then
         skipped=$((skipped + 1))
         continue
     fi
-    awk -v snippetfile="${snippet_file}" '
+    # awk exits non-zero when it found no </head> to insert before, so the file
+    # is left untouched and counted separately instead of as an injection.
+    if awk -v snippetfile="${snippet_file}" '
         BEGIN {
             snippet = ""
             while ((getline line < snippetfile) > 0) {
@@ -70,8 +82,15 @@ while IFS= read -r -d '' file; do
             }
         }
         { print }
-    ' "${file}" > "${file}.tmp" && mv "${file}.tmp" "${file}"
-    injected=$((injected + 1))
+        END { exit(done ? 0 : 1) }
+    ' "${file}" > "${file}.tmp"; then
+        mv "${file}.tmp" "${file}"
+        injected=$((injected + 1))
+    else
+        rm -f "${file}.tmp"
+        nohead=$((nohead + 1))
+        echo "injectAnalytics: no </head> in '${file}', left unchanged." >&2
+    fi
 done < <(find "${TARGET_DIR}" -type f -name '*.html' -print0)
 
-echo "injectAnalytics: injected into ${injected} file(s), skipped ${skipped} already-instrumented file(s)."
+echo "injectAnalytics: injected into ${injected} file(s), skipped ${skipped} already-instrumented, ${nohead} without </head>."

--- a/scripts/injectAnalytics.sh
+++ b/scripts/injectAnalytics.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# injectAnalytics.sh TARGET_DIR
+#
+# Inject the GoatCounter analytics snippet into every *.html below TARGET_DIR,
+# right before the first </head>. This runs at deploy time only (see .ci.sh →
+# publish_doc), so the snippet never ends up in the jBake templates or in a
+# locally generated site.
+#
+# The endpoint is taken from the GOATCOUNTER_ENDPOINT environment variable
+# (a GitHub Actions secret). If it is empty or unset, this script is a no-op,
+# so forks and local builds without the secret stay analytics-free.
+
+set -o nounset -o pipefail -o errexit
+
+TARGET_DIR="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNIPPET_TEMPLATE="${SCRIPT_DIR}/goatcounter-snippet.html"
+
+if [ -z "${GOATCOUNTER_ENDPOINT:-}" ]; then
+    echo "injectAnalytics: GOATCOUNTER_ENDPOINT not set — skipping analytics injection."
+    exit 0
+fi
+
+if [ -z "${TARGET_DIR}" ] || [ ! -d "${TARGET_DIR}" ]; then
+    echo "injectAnalytics: target directory '${TARGET_DIR}' does not exist." >&2
+    exit 1
+fi
+
+if [ ! -f "${SNIPPET_TEMPLATE}" ]; then
+    echo "injectAnalytics: snippet template '${SNIPPET_TEMPLATE}' not found." >&2
+    exit 1
+fi
+
+# Substitute the placeholder with the real endpoint (bash replace handles the
+# slashes in the URL safely, unlike a sed expression).
+template="$(cat "${SNIPPET_TEMPLATE}")"
+snippet="${template//__GOATCOUNTER_ENDPOINT__/${GOATCOUNTER_ENDPOINT}}"
+
+# Hand the resolved snippet to awk via a temp file so multi-line content and
+# any special characters survive untouched.
+snippet_file="$(mktemp)"
+trap 'rm -f "${snippet_file}"' EXIT
+printf '%s\n' "${snippet}" > "${snippet_file}"
+
+injected=0
+skipped=0
+
+while IFS= read -r -d '' file; do
+    if grep -q 'data-goatcounter' "${file}"; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+    awk -v snippetfile="${snippet_file}" '
+        BEGIN {
+            snippet = ""
+            while ((getline line < snippetfile) > 0) {
+                snippet = snippet line "\n"
+            }
+        }
+        # Insert immediately before the first </head>, even when it shares a
+        # line with other markup (minified / single-line HTML). index()/substr()
+        # avoid sub()s special handling of & and \ in the replacement.
+        !done {
+            p = index($0, "</head>")
+            if (p > 0) {
+                printf "%s%s%s\n", substr($0, 1, p - 1), snippet, substr($0, p)
+                done = 1
+                next
+            }
+        }
+        { print }
+    ' "${file}" > "${file}.tmp" && mv "${file}.tmp" "${file}"
+    injected=$((injected + 1))
+done < <(find "${TARGET_DIR}" -type f -name '*.html' -print0)
+
+echo "injectAnalytics: injected into ${injected} file(s), skipped ${skipped} already-instrumented file(s)."


### PR DESCRIPTION
## What & why

Adds privacy-friendly web analytics (GoatCounter) to the published documentation
site **without** putting the tracking snippet into the jBake templates. The snippet
is injected into the generated HTML at deploy time only, so it never appears in a
locally generated site or in the repository's tracked HTML.

## How

- `scripts/goatcounter-snippet.html` — the snippet, pinned to `count.v5.js` with a
  **verified** SHA-384 Subresource Integrity hash and `crossorigin="anonymous"`, so a
  CDN compromise of `gc.zgo.at` cannot inject altered code. Endpoint is a
  `__GOATCOUNTER_ENDPOINT__` placeholder.
- `scripts/injectAnalytics.sh` — inserts the snippet immediately before `</head>` in
  every generated `*.html`. Idempotent (skips already-instrumented files), handles
  single-line/minified HTML, and is a **no-op when `GOATCOUNTER_ENDPOINT` is unset**
  (forks and local builds stay analytics-free).
- `.ci.sh` — runs the injection in `publish_doc` on the freshly cloned `gh-pages`
  copy (`v2.0.x`), which already gates on production branches and non-PR builds.
- `.github/workflows/default-build.yml` — passes the `GOATCOUNTER_ENDPOINT` secret
  into the build.

The endpoint lives in a GitHub Actions secret, so the concrete URL is not in the repo.

## Required before this takes effect

A repo admin must add the `GOATCOUNTER_ENDPOINT` Actions secret on
`docToolchain/docToolchain` (e.g. `https://<code>.goatcounter.com/count`). Without it,
the injection step is a no-op.

## Verification

- SRI hash recomputed locally against the served `count.v5.js` — matches.
- ShellCheck clean on both `scripts/injectAnalytics.sh` and `.ci.sh`.
- Workflow YAML validated.
- End-to-end run against real jBake output: snippet present exactly once, correctly
  before `</head>`; single-line and no-`<head>` cases handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)