### PR TITLE
Backport ng-only features to v4

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -144,6 +144,9 @@ publish_doc () {
       cd gh-pages
       rm -rf v2.0.x/*
       cp -Rf "${BUILD_DIR}"/build/microsite/output/* v2.0.x/.
+      # inject deploy-only analytics into the published copy (no-op when
+      # GOATCOUNTER_ENDPOINT is unset, e.g. on forks)
+      "${BUILD_DIR}"/scripts/injectAnalytics.sh v2.0.x
     fi
 
     #add, commit and push files

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -77,6 +77,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JDK_VERSION: "${{ matrix.jdk }}-${{ matrix.java }}"
+          # deploy-only web analytics; injected into gh-pages by scripts/injectAnalytics.sh
+          GOATCOUNTER_ENDPOINT: ${{ secrets.GOATCOUNTER_ENDPOINT }}
         run: |
           ./.ci.sh
       - name: Archive test results

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -77,8 +77,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JDK_VERSION: "${{ matrix.jdk }}-${{ matrix.java }}"
-          # deploy-only web analytics; injected into gh-pages by scripts/injectAnalytics.sh
-          GOATCOUNTER_ENDPOINT: ${{ secrets.GOATCOUNTER_ENDPOINT }}
+          # deploy-only web analytics; injected into gh-pages by scripts/injectAnalytics.sh.
+          # Only populated for non-PR events, since publishing never runs on PR builds.
+          GOATCOUNTER_ENDPOINT: ${{ github.event_name != 'pull_request' && secrets.GOATCOUNTER_ENDPOINT || '' }}
         run: |
           ./.ci.sh
       - name: Archive test results

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ tmp/
 
 # Claude Code
 .claude/
+
+# PR Analysis Report
+PR-ANALYSIS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,3 +438,217 @@ _Updated by `/risk-mitigate` on 2026-03-30_
 | Sampling Review (~20%) | ✅ Present | PR-based review process |
 
 **Summary: 9/10 mitigations present, 1 pending (Property-Based Tests — deferred).**
+
+## Semantic Contracts
+
+These contracts define how we work in this repository. They override the workspace-level contracts where they differ.
+
+*Source: https://llm-coding.github.io/Semantic-Anchors/#/contracts*
+
+### Specification
+
+When we talk about a "specification" or "spec", we mean:
+- Persona Use Cases in Cockburn's Fully Dressed format (Primary Actor, Trigger, Main Success Scenario, Extensions, Postconditions) at User Goal level, with Business Rules (BR-IDs)
+- System Use Cases for each technical interface (API endpoint, CLI command, event, file format): input/validation, processing, output/status codes, error responses
+- Activity Diagrams for all flows (not just the happy path)
+- Acceptance criteria in Gherkin format (Given/When/Then)
+- Individual requirements in EARS syntax where applicable (When/While/If/Shall)
+- Supplementary Specifications as needed: Entity Model, State Machines, Interface Contracts, Validation Rules
+
+### Requirements Discovery
+
+Clarify requirements using the Socratic Method:
+- Ask at most 3 questions at a time, challenge assumptions
+- Use MECE to ensure questions cover all areas without overlap
+- Keep asking until you fully understand the requirements
+
+Frame the scope before writing it down:
+- Impact Mapping connects deliverables to business goals and actors — so you build what moves a goal, not just what was asked.
+- User Story Mapping lays stories along the user's journey and exposes a coherent first slice.
+
+Document the result as a PRD (problem, goals, personas, success criteria, scope).
+
+### Architecture Documentation
+
+Architecture documentation follows arc42. Scaffold the arc42 "with-help" template into the project's `src/docs/` via docToolchain `downloadTemplate` rather than restating chapter structure here — each chapter's help text is its structural spec, which the process fills and then replaces.
+
+Every context, building-block and runtime chapter carries at least one diagram. Diagrams are PlantUML, not Mermaid; building blocks use C4 via PlantUML's bundled C4-PlantUML standard library — the `!include <C4/...>` stdlib form (angle brackets), never the remote `https://` URL and never vendored file copies. Not generic boxes.
+
+Decisions are ADRs (Nygard) with a 3-point Pugh Matrix (-1/0/+1). When the rationale is unconfirmed, ADR Status is "Accepted (inferred)" and Pugh cells needing team judgment are marked `?` rather than guessed. Each ADR's Consequences name the risks the decision creates, referencing the Chapter 11 risk IDs (R-NNN); a decision that creates a risk not yet in Chapter 11 either adds it there or records the consequence as explicitly accepted without a tracked risk. Conversely, Chapter 8 concepts back-reference the ADR that decided them.
+
+Cross-section traceability — arc42 templates do not enforce these, so the contract does:
+- Every Chapter 1.2 quality goal maps to a named approach in Chapter 4.
+- The external systems in Chapter 3 (context) and the Chapter 5 Level-1 building-block view are the same set — one system boundary in both.
+- Every Chapter 5 building block appears in at least one Chapter 6 runtime scenario; Chapter 6 includes at least one error/recovery scenario, not only the happy path.
+- Chapter 9 carries an in-document ADR index (ADR | Title | Status), even when the ADRs live in a separate register.
+- Each Chapter 5 building block states responsibility, interface, and source location.
+
+Chapter 1.2 lists only the top 3-5 quality goals — the ones that drive architecture decisions. Chapter 10 may elaborate further quality characteristics beyond those top goals; that is correct arc42, not a defect. The Chapter 10 quality tree marks each characteristic as either concretising a Chapter 1.2 top goal or as a derived quality requirement, and each Chapter 10 quality scenario cross-links back to the Chapter 1.2 goal it concretises (or is marked "derived"). Each Chapter 10 scenario is written in the six-part quality attribute scenario form (Source, Stimulus, Artifact, Environment, Response, Response Measure); the Response Measure carries a literal figure, so the requirement is testable rather than an adjective.
+
+Chapter 11 separates Risks from Technical Debt into two subsections. Each Risk carries probability, impact, a derived priority, and a mitigation/action cross-referencing an existing mitigation in Chapter 8 or a quality scenario where one exists; risks are ordered by priority. Each Technical Debt item references the specific Chapter 5 building block it burdens.
+
+### Crosscutting Concepts
+
+arc42 leaves Chapter 8 open. We require five baseline crosscutting concepts, in this order:
+
+- 8.1 Threat Model — STRIDE; threats get IDs (T-001…).
+- 8.2 Security — every mitigation references the T-IDs it closes.
+- 8.3 Test — testing pyramid; tests trace to Use Cases and Business Rules.
+- 8.4 Observability — logs, metrics, traces, audit trails.
+- 8.5 Error Handling — retry, circuit breaker, fallback, recovery.
+
+Add further Chapter 8.x concepts (persistence, i18n, accessibility, configuration, performance) only when the system actually has that concern.
+
+### Layer Boundaries
+
+At every layer boundary:
+- Expose only well-defined DTOs and contracts — never domain entities
+- Use explicit mapping at every seam
+- Apply Anti-Corruption Layers when integrating external systems
+- Dependency direction points inward (DIP)
+
+### Backlog Management
+
+Create EPICs and User Stories as GitHub issues from the specification.
+- User Stories follow INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable)
+- Prioritize with MoSCoW (Must/Should/Could/Won't)
+- Mark dependencies between issues
+- Groom the backlog regularly as the project evolves
+
+### Vertical Slicing
+
+Build the first increment as a walking skeleton: a deployable end-to-end slice that wires every architectural layer together and does almost nothing else.
+
+Grow the system as thin vertical slices — each slice cuts through all layers and delivers one small piece of user value. Slices are tracer bullets: kept and refined, never thrown away.
+
+When a technical unknown blocks a slice, run a spike solution first — a timeboxed, throwaway experiment that removes the risk. Spike code is discarded; only its lesson carries into the slice.
+
+### Implement Next
+
+For each issue:
+- Create a feature branch for the EPIC
+- Select next issue from backlog (respect dependencies)
+- Analyze and document analysis as a comment on the issue
+- Implement using TDD (London or Chicago School as appropriate)
+- Each test references its Use Case ID for traceability
+- Commit with Conventional Commits, reference issue number
+- Check if spec or architecture docs need updating
+- When EPIC is complete, create a Pull Request
+
+### Refactoring
+
+Refactoring targets are named code smells, not a vague urge to "clean up".
+
+For any refactoring that does not complete in one step, use the Mikado Method: attempt the change, note what breaks, revert, and do the prerequisites first — never leave the build broken while you dig.
+
+Refactoring commits change structure only. Behaviour changes go in separate commits, and the test suite stays green at every commit.
+
+### Code Quality
+
+Our code follows:
+- SOLID principles
+- DRY, KISS
+- Ubiquitous Language from Domain-Driven Design (same terms in code as in the specification)
+
+### Quality Review
+
+Quality assurance follows three layers:
+- Code review using Fagan Inspection (structured, systematic, with defined phases)
+- Security review based on OWASP Top 10
+- Architecture review using ATAM (scenario-based tradeoff analysis against quality goals)
+- Use a different AI model or fresh session for reviews to avoid blind spots
+
+### Docs-as-Code
+
+Documentation follows Docs-as-Code according to Ralf D. Müller:
+- AsciiDoc as format, PlantUML for inline diagrams, built by docToolchain
+- Version-controlled, peer-reviewed, and built automatically
+- Plain English according to Strunk & White (or Gutes Deutsch nach Wolf Schneider)
+- Projects following this contract include the `dtcw` wrapper and `docToolchainConfig.groovy` so PlantUML / AsciiDoc actually render.
+
+### Socratic Code Theory Recovery
+
+Recover a program's "theory" (Naur 1985) from source code through recursive question refinement.
+
+- Start with 5 root questions: Q1 Problem/Users, Q2 Specification, Q3 Architecture, Q4 Quality Goals, Q5 Risks.
+
+- The second level of the tree is FIXED, not free. Every run emits exactly these nodes, in this order, even when a node's only leaf is [OPEN] or [ANSWERED: not applicable]:
+  - Q1.1-Q1.6: product identity, primary users, channels, why-built, success metrics, segment priority
+  - Q2.1-Q2.6: actors, use-case catalog, per-interface system specs, data/entity model, acceptance criteria, cross-cutting business rules
+  - Q3.1-Q3.12: the twelve arc42 chapters, in arc42 order
+  - Q4.1-Q4.8: the eight ISO/IEC 25010 characteristics; plus Q4.9: which characteristic has priority
+  - Q5.1-Q5.5: technical debt, security risks, operational risks, dependency/supply-chain risks, scaling/performance risks
+
+- Below the fixed second level, decompose adaptively and code-driven; a node is a leaf only when it can be answered from one specific file:line evidence (a directory is too coarse — decompose further) or definitively marked [OPEN]. Depth tracks code density: a small bounded context yields a shallow tree, a large one a deep tree, capped at four levels below a fixed node. Depth varies between runs — expected.
+
+- Q-IDs are stable: Q3.7 is always Deployment View, in every run, so trees from different runs can be diffed node-by-node.
+
+- Each leaf is [ANSWERED] (with file:line evidence) or [OPEN] (with Category, Ask role, and why it is unanswerable from code).
+
+- Quality is not wholly team knowledge. Derive quality scenarios for the Q4 branch and arc42 Chapter 10 from measurable code behaviour — literal thresholds, timeouts, budgets, the threat catalogue and test concept from Q3.8 — as [ANSWERED] with file:line; never invent target numbers. Only the quality-goal ranking (Q4.9) is [OPEN]. arc42 Chapter 10 carries the derivable scenarios, never just an [OPEN] pointer. Chapter 1.2 names only the top 3-5 quality goals; Chapter 10 covers all eight characteristics — mark each Chapter 10 entry as concretising a Chapter 1.2 top goal or as derived.
+
+- Open Questions are the handoff document: always emit one section per role (Product Owner, Architect, Developer, Domain Expert, Operations), even when a section is empty ("No open questions for this role").
+
+- Two-phase workflow: Phase 1 builds the tree; the team answers the Open Questions; Phase 2 synthesizes documentation from the answered tree.
+
+### Concise Response (TLDR)
+
+Responses lead with the conclusion first (BLUF). Keep to essential points. No filler, no preamble. Use short sentences, active voice, and no unnecessary words (Strunk & White).
+
+### Simple Explanation (ELI5)
+
+Explain complex concepts using simple language and everyday analogies. When the explanation feels hard to write, that reveals gaps in understanding — study those areas first (Feynman Technique).
+
+### Explaining and Teaching
+
+When asked to explain or teach something (including "why does X…"), act as a teacher running a dialogue, not a lecture — your goal is that the learner can apply it afterwards, not that you delivered it.
+
+Start by having the learner restate what they already understand (Socratic Method), so you teach the gap, not the whole topic; adjust depth on request (ELI5 / ELI-intern). Keep a short running checklist of what they must grasp — the problem and why it exists, the solution with its design decisions and edge cases, and why it matters — a Definition of Done for understanding, worked one item at a time; for a long or multi-session explanation, persist that checklist as a file so it survives context loss and can be resumed.
+
+Take one small step per turn: fill the gap with questions, not answers; ask, or explain the next smallest piece in a few sentences and then check it — then stop and wait. Never stack several steps in one turn. Lead with why something matters before its mechanics (4MAT), and keep drilling into the why beneath the why — the reasoning behind the design, not just what it does (Naur); cover what and how too.
+
+Check by quizzing, never "makes sense?" — open or multiple-choice questions; for multiple choice, vary which option is correct and don't reveal the answer until the learner has committed. The sharpest check is having them explain it back in their own words (Feynman Technique) or apply it to a fresh case; use a concrete artifact (an example, code, a trace) when it helps. React to the actual answer: if they've got it, advance; if not, give a short targeted hint and re-ask. "Understood" means they can use it on a new case, not recite it (Bloom's Apply, not recall) — don't move on, and don't end, until they've shown that.
+
+Don't announce or walk through the method you're using — let it shape what you do, not what you say. Scale to the question: a small factual ask gets a one-line answer, and the learner can say "just tell me" anytime. If you're unsure of the topic, learn it before teaching.
+
+### Writing Style
+
+Writing follows Gutes Deutsch nach Wolf Schneider (or Plain English according to Strunk & White).
+
+Additionally:
+- Technical terms stay in English (LLM, Prompt, Token, Spec, etc.)
+- Address the reader directly, use first person sparingly but deliberately
+- Use analogies to human thinking to explain technical concepts
+- One thought per paragraph (5-8 sentences is fine)
+- Section headings are statements, not topic announcements
+- First sentence says what the paragraph is about
+- Show code and prompts, don't just claim things work
+- Conclusions make a clear statement — never end with 'it remains exciting'
+
+### TDD, Hamburg Style
+
+Design-led TDD recipe by Ralf Westphal — close the requirements/logic gap before writing code, then test at service boundaries with minimal mocking. Use it when the problem is too complex for pure micro-step Red-Green-Refactor.
+
+- **ACD cycle (Analyze → Design → Code)** precedes the test loop: first model the solution to close the gap between requirements and logic, only then code.
+- **"Right from the start" philosophy** — implement correctly the first time so refactoring is a correction, not routine cleanup.
+- **Service-level testing** — test behind the public API, independent of API technology.
+- **Minimal mocking** — closer to *TDD, Chicago School* than *London School*.
+- **IOSP (Integration Operation Segregation Principle)** — a function is either composition (Integration) or logic (Operation), never both; structural support for simple unit tests.
+- **Deep Work over Small Steps** — accept that some problems can't be sliced into tiny green increments; stay red longer when the design demands it.
+
+Composes: *TDD, London School*, *TDD, Chicago School*, *Red-Green-Refactor*, *IOSP*.
+Sources: https://ralfw.de/hamburg-style-tdd/, https://ralfw.de/tdd-how-it-can-be-done-right/
+
+### Strategic Architecture Analysis
+
+Strategic architecture analysis combines four lenses, each for a different question. Reach for it when evaluating build-vs-buy, assessing architecture fitness for changing requirements, or running a strategic technology-radar review.
+
+Map the value chain with Wardley Mapping to see how each component evolves — what is commodity, what is genesis, and where the strategic differentiation actually sits.
+
+Classify each challenge with the Cynefin Framework — Clear, Complicated, Complex, or Chaotic — so the response fits the domain instead of forcing one playbook onto every problem.
+
+When a decision has a wide solution space, lay the dimensions and their options out in a Morphological Box and combine them deliberately, rather than anchoring on the first design that comes to mind.
+
+Evaluate the shortlisted architectures against the quality goals with ATAM, naming the sensitivity points, the tradeoff points, and the risks each option carries.
+
+When the root cause of a problem stays unclear, drill down with the Five Whys before committing to a direction.

--- a/scripts/goatcounter-snippet.html
+++ b/scripts/goatcounter-snippet.html
@@ -1,0 +1,9 @@
+<!-- GoatCounter analytics — injected at deploy time only, never part of the templates.
+     Pinned to count.v5.js with Subresource Integrity (sha384) so a CDN compromise of
+     gc.zgo.at cannot inject altered code. When bumping the version, update both the
+     src URL and the integrity hash from https://www.goatcounter.com/help/countjs-versions
+     and re-verify with: openssl dgst -sha384 -binary count.vN.js | openssl base64 -A -->
+<script data-goatcounter="__GOATCOUNTER_ENDPOINT__"
+        async src="//gc.zgo.at/count.v5.js"
+        crossorigin="anonymous"
+        integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>

--- a/scripts/goatcounter-snippet.html
+++ b/scripts/goatcounter-snippet.html
@@ -4,6 +4,6 @@
      src URL and the integrity hash from https://www.goatcounter.com/help/countjs-versions
      and re-verify with: openssl dgst -sha384 -binary count.vN.js | openssl base64 -A -->
 <script data-goatcounter="__GOATCOUNTER_ENDPOINT__"
-        async src="//gc.zgo.at/count.v5.js"
+        async src="https://gc.zgo.at/count.v5.js"
         crossorigin="anonymous"
         integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>

--- a/scripts/injectAnalytics.sh
+++ b/scripts/injectAnalytics.sh
@@ -22,6 +22,15 @@ if [ -z "${GOATCOUNTER_ENDPOINT:-}" ]; then
     exit 0
 fi
 
+# The endpoint is substituted into a double-quoted HTML attribute. Require a clean
+# https:// URL so a misconfigured secret cannot break the markup or inject content.
+# Fail the build rather than publish broken or unsafe HTML.
+endpoint_re='^https://[^[:space:]"'\''<>]+$'
+if [[ ! "${GOATCOUNTER_ENDPOINT}" =~ $endpoint_re ]]; then
+    echo "injectAnalytics: GOATCOUNTER_ENDPOINT must be a plain https:// URL without quotes or angle brackets." >&2
+    exit 1
+fi
+
 if [ -z "${TARGET_DIR}" ] || [ ! -d "${TARGET_DIR}" ]; then
     echo "injectAnalytics: target directory '${TARGET_DIR}' does not exist." >&2
     exit 1
@@ -45,13 +54,16 @@ printf '%s\n' "${snippet}" > "${snippet_file}"
 
 injected=0
 skipped=0
+nohead=0
 
 while IFS= read -r -d '' file; do
     if grep -q 'data-goatcounter' "${file}"; then
         skipped=$((skipped + 1))
         continue
     fi
-    awk -v snippetfile="${snippet_file}" '
+    # awk exits non-zero when it found no </head> to insert before, so the file
+    # is left untouched and counted separately instead of as an injection.
+    if awk -v snippetfile="${snippet_file}" '
         BEGIN {
             snippet = ""
             while ((getline line < snippetfile) > 0) {
@@ -70,8 +82,15 @@ while IFS= read -r -d '' file; do
             }
         }
         { print }
-    ' "${file}" > "${file}.tmp" && mv "${file}.tmp" "${file}"
-    injected=$((injected + 1))
+        END { exit(done ? 0 : 1) }
+    ' "${file}" > "${file}.tmp"; then
+        mv "${file}.tmp" "${file}"
+        injected=$((injected + 1))
+    else
+        rm -f "${file}.tmp"
+        nohead=$((nohead + 1))
+        echo "injectAnalytics: no </head> in '${file}', left unchanged." >&2
+    fi
 done < <(find "${TARGET_DIR}" -type f -name '*.html' -print0)
 
-echo "injectAnalytics: injected into ${injected} file(s), skipped ${skipped} already-instrumented file(s)."
+echo "injectAnalytics: injected into ${injected} file(s), skipped ${skipped} already-instrumented, ${nohead} without </head>."

--- a/scripts/injectAnalytics.sh
+++ b/scripts/injectAnalytics.sh
@@ -41,10 +41,14 @@ if [ ! -f "${SNIPPET_TEMPLATE}" ]; then
     exit 1
 fi
 
-# Substitute the placeholder with the real endpoint (bash replace handles the
-# slashes in the URL safely, unlike a sed expression).
+# HTML-escape & in the endpoint so entities like &quot; cannot break out of
+# the double-quoted attribute context after browser entity expansion.
+safe_endpoint="${GOATCOUNTER_ENDPOINT//&/&amp;}"
+
+# Substitute the placeholder with the escaped endpoint (bash replace handles
+# the slashes in the URL safely, unlike a sed expression).
 template="$(cat "${SNIPPET_TEMPLATE}")"
-snippet="${template//__GOATCOUNTER_ENDPOINT__/${GOATCOUNTER_ENDPOINT}}"
+snippet="${template//__GOATCOUNTER_ENDPOINT__/${safe_endpoint}}"
 
 # Hand the resolved snippet to awk via a temp file so multi-line content and
 # any special characters survive untouched.

--- a/scripts/injectAnalytics.sh
+++ b/scripts/injectAnalytics.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# injectAnalytics.sh TARGET_DIR
+#
+# Inject the GoatCounter analytics snippet into every *.html below TARGET_DIR,
+# right before the first </head>. This runs at deploy time only (see .ci.sh →
+# publish_doc), so the snippet never ends up in the jBake templates or in a
+# locally generated site.
+#
+# The endpoint is taken from the GOATCOUNTER_ENDPOINT environment variable
+# (a GitHub Actions secret). If it is empty or unset, this script is a no-op,
+# so forks and local builds without the secret stay analytics-free.
+
+set -o nounset -o pipefail -o errexit
+
+TARGET_DIR="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNIPPET_TEMPLATE="${SCRIPT_DIR}/goatcounter-snippet.html"
+
+if [ -z "${GOATCOUNTER_ENDPOINT:-}" ]; then
+    echo "injectAnalytics: GOATCOUNTER_ENDPOINT not set — skipping analytics injection."
+    exit 0
+fi
+
+if [ -z "${TARGET_DIR}" ] || [ ! -d "${TARGET_DIR}" ]; then
+    echo "injectAnalytics: target directory '${TARGET_DIR}' does not exist." >&2
+    exit 1
+fi
+
+if [ ! -f "${SNIPPET_TEMPLATE}" ]; then
+    echo "injectAnalytics: snippet template '${SNIPPET_TEMPLATE}' not found." >&2
+    exit 1
+fi
+
+# Substitute the placeholder with the real endpoint (bash replace handles the
+# slashes in the URL safely, unlike a sed expression).
+template="$(cat "${SNIPPET_TEMPLATE}")"
+snippet="${template//__GOATCOUNTER_ENDPOINT__/${GOATCOUNTER_ENDPOINT}}"
+
+# Hand the resolved snippet to awk via a temp file so multi-line content and
+# any special characters survive untouched.
+snippet_file="$(mktemp)"
+trap 'rm -f "${snippet_file}"' EXIT
+printf '%s\n' "${snippet}" > "${snippet_file}"
+
+injected=0
+skipped=0
+
+while IFS= read -r -d '' file; do
+    if grep -q 'data-goatcounter' "${file}"; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+    awk -v snippetfile="${snippet_file}" '
+        BEGIN {
+            snippet = ""
+            while ((getline line < snippetfile) > 0) {
+                snippet = snippet line "\n"
+            }
+        }
+        # Insert immediately before the first </head>, even when it shares a
+        # line with other markup (minified / single-line HTML). index()/substr()
+        # avoid sub()s special handling of & and \ in the replacement.
+        !done {
+            p = index($0, "</head>")
+            if (p > 0) {
+                printf "%s%s%s\n", substr($0, 1, p - 1), snippet, substr($0, p)
+                done = 1
+                next
+            }
+        }
+        { print }
+    ' "${file}" > "${file}.tmp" && mv "${file}.tmp" "${file}"
+    injected=$((injected + 1))
+done < <(find "${TARGET_DIR}" -type f -name '*.html' -print0)
+
+echo "injectAnalytics: injected into ${injected} file(s), skipped ${skipped} already-instrumented file(s)."

--- a/src/docs/015_tasks/03_task_publishToConfluence.adoc
+++ b/src/docs/015_tasks/03_task_publishToConfluence.adoc
@@ -123,6 +123,29 @@ To authenticate with username and API token, use:
     credentials = "user:${new File("/users/me/apitoken").text}"`.bytes.encodeBase64().toString()` to ........
 You can create an API-token in https://confluence.atlassian.com/cloud/api-tokens-938839638.html[your profile].
 
+[IMPORTANT]
+====
+Atlassian is deprecating unscoped (classic) API tokens.
+If you receive a `403 - Forbidden` error with an existing token, create a new *scoped API token* and select the following scopes:
+
+[%header,cols="1,2"]
+|===
+|Scope |Purpose
+
+|`read:me`
+|Verify API credentials (read current user info)
+
+|`read:confluence-content.all`
+|Read pages, attachments, and labels
+
+|`write:confluence-content`
+|Create, update, and delete pages, attachments, and labels
+
+|`read:confluence-space.summary`
+|Read space information (required when using API V2)
+|===
+====
+
 To authenticate with username and password, use:
     credentials = ......
 

--- a/src/docs/020_tutorial/070_publishToConfluence.adoc
+++ b/src/docs/020_tutorial/070_publishToConfluence.adoc
@@ -334,6 +334,14 @@ NOTE: This method only works for Confluence Cloud.
 I can use an API token.
 The key has to be generated from the central Atlassian account.
 
+[IMPORTANT]
+====
+Atlassian is deprecating unscoped (classic) API tokens.
+When creating a new API token, you must select specific scopes.
+If you receive a `403 - Forbidden` error, you likely need to create a new scoped API token.
+See the required scopes below.
+====
+
 . Navigate to your central Atlassian profile.
 +
 [.center]
@@ -352,6 +360,27 @@ image::070-third.png[width=80%]
 NOTE: Here is the https://id.atlassian.com/manage-profile/security/api-tokens[shortcut] to this page.
 
 . Now, click **Create API token**.
+
+. When prompted to select scopes, choose the following scopes required by docToolchain:
++
+[%header,cols="1,2"]
+|===
+|Scope |Purpose
+
+|`read:me`
+|Verify API credentials (read current user info)
+
+|`read:confluence-content.all`
+|Read pages, attachments, and labels
+
+|`write:confluence-content`
+|Create, update, and delete pages, attachments, and labels
+
+|`read:confluence-space.summary`
+|Read space information (required when using API V2)
+|===
++
+NOTE: If you also use the `wipeConfluenceSpace` task, `write:confluence-content` already covers page deletion for API V1. For API V2, `delete:page:confluence` may also be needed.
 
 . Store your API token in a safe location.
 

--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -79,6 +79,69 @@
                 </div>
             </div>
         </div>
+        <div class="row row-cols-1 mb-3">
+            <div class="col">
+                <h2 class="mt-4">Sub-Projects &amp; Ecosystem</h2>
+                <p>docToolchain is more than a single tool &mdash; it's a growing ecosystem of related projects to support your docs-as-code journey.</p>
+            </div>
+        </div>
+        <div class="row row-cols-1 row-cols-md-3 mb-3 text-center">
+            <div class="col">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header">
+                        <h4 class="my-0 fw-normal">AsciiDoc Linter</h4>
+                    </div>
+                    <div class="card-body">
+                        A linter for AsciiDoc files to help you keep your documentation clean and consistent.<br /><br />
+                        <a class="btn btn-primary" href="https://doctoolchain.org/asciidoc-linter" role="button">learn more</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header">
+                        <h4 class="my-0 fw-normal">dacli</h4>
+                    </div>
+                    <div class="card-body">
+                        A command-line interface to simplify and streamline your docs-as-code workflow with docToolchain.<br /><br />
+                        <a class="btn btn-primary" href="https://doctoolchain.org/dacli" role="button">learn more</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header">
+                        <h4 class="my-0 fw-normal">diagrams.net IntelliJ Plugin</h4>
+                    </div>
+                    <div class="card-body">
+                        Edit diagrams.net (draw.io) diagrams directly inside IntelliJ IDEA without leaving your IDE.<br /><br />
+                        <a class="btn btn-primary" href="https://github.com/docToolchain/diagrams.net-intellij-plugin" role="button">learn more</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header">
+                        <h4 class="my-0 fw-normal">iSAQB Template</h4>
+                    </div>
+                    <div class="card-body">
+                        A ready-to-use documentation template following the iSAQB arc42 software architecture documentation standard.<br /><br />
+                        <a class="btn btn-primary" href="https://github.com/docToolchain/iSAQB-Template" role="button">learn more</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header">
+                        <h4 class="my-0 fw-normal">CI/CD Demo</h4>
+                    </div>
+                    <div class="card-body">
+                        A demo project showing how to integrate docToolchain into your CI/CD pipeline for automated documentation builds.<br /><br />
+                        <a class="btn btn-primary" href="https://github.com/docToolchain/ci-cd-demo" role="button">learn more</a>
+                    </div>
+                </div>
+            </div>
+        </div>
         <!--div class="row row-cols-1">
             <div class="col">
                 <div class="card mb-12 shadow-sm">

--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -111,6 +111,17 @@
             <div class="col">
                 <div class="card mb-4 shadow-sm">
                     <div class="card-header">
+                        <h4 class="my-0 fw-normal">Bausteinsicht</h4>
+                    </div>
+                    <div class="card-body">
+                        Architecture-as-code: define building blocks in JSONC, sync bidirectionally with draw.io diagrams. Think Structurizr, but simpler.<br /><br />
+                        <a class="btn btn-primary" href="https://doctoolchain.org/Bausteinsicht/" role="button">learn more</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card mb-4 shadow-sm">
+                    <div class="card-header">
                         <h4 class="my-0 fw-normal">diagrams.net IntelliJ Plugin</h4>
                     </div>
                     <div class="card-body">


### PR DESCRIPTION
## Summary

Cherry-picks all ng-only features to main-4.x per #1581:

- `.gitignore`: Add `.claude/` and `PR-ANALYSIS.md` entries
- **Landing page ecosystem section** (#1550) + Bausteinsicht addition
- **GoatCounter analytics** injection for gh-pages deploy + hardening fix
- **Confluence docs**: Document required scopes for scoped API tokens
- **CLAUDE.md**: Add comprehensive Semantic Contracts section

## Test plan

- [ ] Verify landing page renders ecosystem section correctly via `generateSite`
- [ ] Verify GoatCounter snippet is injected only on gh-pages deploy
- [ ] Verify Confluence scoped token docs are accessible in generated site
- [ ] Review CLAUDE.md contracts for completeness

Closes #1581

🤖 Generated with [Claude Code](https://claude.com/claude-code)