### PR TITLE
fix: suppress missing contributors include in v4 docs

### DIFF
--- a/src/docs/_feedback.adoc
+++ b/src/docs/_feedback.adoc
@@ -3,4 +3,4 @@ ifndef::backend-pdf[]
 //image::https://img.shields.io/badge/create-an%20issue-blue.svg[link="https://github.com/docToolchain/docToolchain/issues/new?title=&body=%0A%0A%5BEnter%20feedback%20here%5D%0A%0A%0A---%0A%23page:{filename}", float=right]
 endif::[]
 
-ifdef::filename[include::{targetDir}/contributors/{filename}[]]
+ifdef::filename[include::{targetDir}/contributors/{filename}[opts=optional]]


### PR DESCRIPTION
## Summary

- The `_feedback.adoc` template includes contributor info from `{targetDir}/contributors/{filename}`, but the `exportContributors` task doesn't exist in v4
- This causes "Unresolved directive" errors on every page that uses `_feedback.adoc`
- Fix: add `opts=optional` to the include directive so missing files are silently skipped

## Test plan

- [ ] Verify "Unresolved directive" errors disappear from generated docs
- [ ] Pages that do have contributor files still show them correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)