### PR TITLE
Fix theme: light navbar, visible logo, sidebar nav

### DIFF
--- a/src/site/assets/css/main.css
+++ b/src/site/assets/css/main.css
@@ -7,8 +7,10 @@
 :root {
     --dtc-primary: #2563eb;
     --dtc-primary-dark: #1d4ed8;
-    --dtc-navbar-bg: #1e293b;
-    --dtc-navbar-hover: #334155;
+    --dtc-navbar-bg: #ffffff;
+    --dtc-navbar-border: #e2e8f0;
+    --dtc-navbar-text: #334155;
+    --dtc-navbar-hover: rgba(37, 99, 235, 0.08);
     --dtc-sidebar-bg: #f8fafc;
     --dtc-sidebar-border: #e2e8f0;
     --dtc-sidebar-active: #2563eb;
@@ -19,7 +21,7 @@
     --dtc-code-bg: #f1f5f9;
     --dtc-link: #2563eb;
     --dtc-link-hover: #1d4ed8;
-    --dtc-footer-bg: #0f172a;
+    --dtc-footer-bg: #1e293b;
     --dtc-font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     --dtc-font-mono: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
@@ -46,7 +48,7 @@ a:hover {
 .td-navbar {
     background: var(--dtc-navbar-bg);
     padding: 0.5rem 1.5rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    border-bottom: 1px solid var(--dtc-navbar-border);
     position: sticky;
     top: 0;
     z-index: 1030;
@@ -54,7 +56,7 @@ a:hover {
 }
 
 .td-navbar .navbar-brand {
-    color: #ffffff;
+    color: var(--dtc-text);
     font-size: 1.15rem;
     font-weight: 600;
     letter-spacing: -0.01em;
@@ -64,7 +66,7 @@ a:hover {
 }
 
 .td-navbar .navbar-brand:hover {
-    color: #ffffff;
+    color: var(--dtc-primary);
 }
 
 span.navbar-logo {
@@ -73,17 +75,13 @@ span.navbar-logo {
     padding-right: 0.5rem;
 }
 
-span.navbar-logo img {
-    filter: brightness(0) invert(1);
-}
-
 .td-navbar-nav-scroll {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
 }
 
 .td-navbar .nav-link {
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--dtc-navbar-text);
     font-size: 0.875rem;
     font-weight: 500;
     padding: 0.5rem 0.75rem;
@@ -94,14 +92,14 @@ span.navbar-logo img {
 
 .td-navbar .nav-link:hover,
 .td-navbar .nav-link.active {
-    color: #ffffff;
+    color: var(--dtc-primary);
     background: var(--dtc-navbar-hover);
 }
 
 .td-search-input {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    color: #ffffff;
+    background: var(--dtc-sidebar-bg);
+    border: 1px solid var(--dtc-border);
+    color: var(--dtc-text);
     font-size: 0.875rem;
     border-radius: 0.375rem;
     padding: 0.375rem 0.75rem;
@@ -110,15 +108,15 @@ span.navbar-logo img {
 }
 
 .td-search-input:focus {
-    background: rgba(255, 255, 255, 0.15);
+    background: #ffffff;
     border-color: var(--dtc-primary);
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.3);
-    color: #ffffff;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+    color: var(--dtc-text);
     outline: none;
 }
 
 .td-search-input::placeholder {
-    color: rgba(255, 255, 255, 0.5);
+    color: var(--dtc-text-muted);
 }
 
 /* ── Layout (.td-outer, .td-main, .td-section) ───────────────── */
@@ -181,6 +179,12 @@ span.navbar-logo img {
 }
 
 /* ── Sidebar Nav ──────────────────────────────────────────────── */
+@media (min-width: 768px) {
+    .td-sidebar-nav.collapse {
+        display: block;
+    }
+}
+
 .td-sidebar-nav {
     font-size: 0.8125rem;
     line-height: 1.4;
@@ -452,19 +456,20 @@ div.bg-light {
 
 /* ── Jumbotron / Hero (landing page) ──────────────────────────── */
 .jumbotron {
-    background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
-    color: #ffffff;
-    border: none;
+    background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
+    color: var(--dtc-text);
+    border: 1px solid #bfdbfe;
     border-radius: 1rem;
     padding: 3rem;
 }
 
 .jumbotron h1 {
-    color: #ffffff;
+    color: var(--dtc-text);
 }
 
 .jumbotron .badge.bg-primary {
     background-color: var(--dtc-primary) !important;
+    color: #ffffff;
     font-size: 0.5em;
     vertical-align: middle;
     padding: 0.35em 0.75em;
@@ -472,17 +477,19 @@ div.bg-light {
 }
 
 .jumbotron .lead {
-    color: rgba(255, 255, 255, 0.9);
+    color: var(--dtc-text);
     font-size: 1.25rem;
+    font-weight: 500;
 }
 
 .jumbotron p {
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--dtc-text-muted);
 }
 
 .jumbotron .btn-primary {
     background-color: var(--dtc-primary);
     border-color: var(--dtc-primary);
+    color: #ffffff;
     padding: 0.625rem 1.5rem;
     font-weight: 600;
     border-radius: 0.5rem;
@@ -491,10 +498,6 @@ div.bg-light {
 .jumbotron .btn-primary:hover {
     background-color: var(--dtc-primary-dark);
     border-color: var(--dtc-primary-dark);
-}
-
-.jumbotron img {
-    filter: brightness(0) invert(1);
 }
 
 /* ── Cards ────────────────────────────────────────────────────── */

--- a/src/site/templates/menu.gsp
+++ b/src/site/templates/menu.gsp
@@ -10,7 +10,7 @@
         new File(config.sourceFolder,"groovy/menu.groovy").text
     )
 %>
-<nav class="js-navbar-scroll navbar navbar-expand navbar-dark flex-column flex-md-row td-navbar">
+<nav class="js-navbar-scroll navbar navbar-expand navbar-light flex-column flex-md-row td-navbar">
     <a class="navbar-brand" href="${content.rootpath}index.html">
         <span class="navbar-logo"><img src="${content.rootpath}images/doctoolchain-logo-blue.png" alt="docToolchain" width="32px" /></span><span
             class="font-weight-bold">${config.site_title}</span>


### PR DESCRIPTION
## Summary

Fixes three issues from the v4 theme (#1592):

- **Logo invisible**: Removed CSS `filter: brightness(0) invert(1)` that made the blue logo unrecognizable on the dark navbar — now shows naturally
- **Dark/unfriendly design**: Switched to a white navbar with subtle bottom border. Changed `navbar-dark` to `navbar-light` in menu.gsp. Lightened the jumbotron (light blue gradient) and footer
- **Empty sidebar bar**: Added `@media (min-width: 768px) { .td-sidebar-nav.collapse { display: block } }` — Bootstrap's `collapse` class was hiding the sidebar navigation on desktop (Docsy had an override for this that was lost)

## Test plan

- [ ] Logo clearly visible in navbar
- [ ] Navbar is white/light with dark text
- [ ] Sidebar navigation is visible on documentation pages
- [ ] Jumbotron hero section on landing page has light blue background
- [ ] Mobile collapse/toggle still works for sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)