### PR TITLE
Subtle v4 theme: color scheme and typography

### DIFF
--- a/src/site/assets/css/theme-v4.css
+++ b/src/site/assets/css/theme-v4.css
@@ -1,0 +1,91 @@
+/* docToolchain v4 — color & typography overrides
+ * Loaded after main.min.css (Docsy). Only overrides colors and fonts,
+ * layout structure stays untouched.
+ */
+
+/* ── Typography ───────────────────────────────────────────────── */
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ── Navbar ────────────────────────────────────────────────────── */
+.td-navbar {
+    background: #1e3a5f;
+}
+
+.td-navbar .nav-link:hover,
+.td-navbar .nav-link:focus {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 0.25rem;
+}
+
+/* ── Links & primary color ────────────────────────────────────── */
+a {
+    color: #2563eb;
+}
+
+a:hover {
+    color: #1d4ed8;
+}
+
+.btn-primary,
+.btn-primary:active {
+    background-color: #2563eb;
+    border-color: #2563eb;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background-color: #1d4ed8;
+    border-color: #1d4ed8;
+}
+
+.btn-outline-primary {
+    color: #2563eb;
+    border-color: #2563eb;
+}
+
+.btn-outline-primary:hover {
+    background-color: #2563eb;
+    border-color: #2563eb;
+}
+
+/* ── Sidebar active state ─────────────────────────────────────── */
+.td-sidebar-link.active,
+.td-sidebar-link__section.active {
+    color: #2563eb;
+    font-weight: 600;
+}
+
+/* ── Footer ───────────────────────────────────────────────────── */
+footer.bg-dark {
+    background: #1e293b !important;
+}
+
+/* ── Landing page hero ────────────────────────────────────────── */
+.bg-light.jumbotron,
+div.bg-light.jumbotron {
+    background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%) !important;
+    border: 1px solid #bfdbfe;
+    border-radius: 0.75rem;
+}
+
+/* ── Cards ────────────────────────────────────────────────────── */
+.card {
+    border-radius: 0.5rem;
+    transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.card-header {
+    border-radius: 0.5rem 0.5rem 0 0 !important;
+}
+
+/* ── Badge (v4 badge on landing page) ─────────────────────────── */
+.badge.bg-primary {
+    background-color: #2563eb !important;
+}

--- a/src/site/templates/header.gsp
+++ b/src/site/templates/header.gsp
@@ -38,6 +38,7 @@
         rel="stylesheet">
     <link href="${content.rootpath}css/asciidoctor.css" rel="stylesheet">
     <link href="${content.rootpath}css/prettify.css" rel="stylesheet">
+    <link href="${content.rootpath}css/theme-v4.css" rel="stylesheet">
 
     <!-- favicon generated with https://www.favicon-generator.org/ -->
     <link rel="shortcut icon" href="${content.rootpath}favicon.ico">


### PR DESCRIPTION
## Summary

Subtle theme refresh that keeps the Docsy layout intact. Adds a small override CSS (`theme-v4.css`, 91 lines) loaded after the Docsy `main.min.css`.

**Includes the reverts from #1594** — this single PR reverts the broken theme (#1592, #1593) and adds the new subtle overrides instead.

### What changes visually
- **Font**: Modern system font stack (SF Pro on macOS, Segoe UI on Windows, Roboto on Android/Linux) — no external font files needed
- **Navbar**: Deeper, richer blue (`#1e3a5f` vs old `#30638e`)
- **Links & buttons**: Vibrant blue (`#2563eb`)
- **Footer**: Modern dark slate (`#1e293b`)
- **Landing page hero**: Light blue gradient background
- **Cards**: Rounded corners, subtle hover shadow
- **Sidebar**: Blue highlight for active page

### What stays the same
- Complete Docsy layout structure (all td-* classes)
- All template files (except one `<link>` in header.gsp)
- The 287KB main.min.css blob — untouched
- All JS functionality

Closes #1595

## Test plan

- [ ] `./gradlew generateSite` builds
- [ ] Pages look like before but with fresher colors
- [ ] Navbar is a deeper blue
- [ ] Links are vibrant blue
- [ ] Landing page hero has light blue gradient
- [ ] Cards have subtle hover effect
- [ ] No layout breakage on any page type

🤖 Generated with [Claude Code](https://claude.com/claude-code)