### PR TITLE
feat(wrapper): install Java 25 (LTS) by default

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -538,11 +538,11 @@ java_help_and_die() {
         "Alternatively you can use SDKMAN! (https://sdkman.io) to manage your Java installations" \
         ""
     if ! is_environment_available sdk; then
-        how_to_install_sdkman "Java 17"
+        how_to_install_sdkman "Java 25"
     fi
     # TODO: This will break when we change Java version
     printf "%s\n" \
-        "    $ sdk install java 17.0.14-tem" \
+        "    $ sdk install java 25.0.3-tem" \
         "" \
         "If you prefer not to install Java on your host, you can run docToolchain in a" \
         "docker container. For this case dtcw provides the 'docker' execution environment." \
@@ -560,7 +560,7 @@ how_to_install_sdkman() {
 }
 
 local_install_java() {
-    version=17
+    version=25
     implementation=hotspot
     heapsize=normal
     imagetype=jdk
@@ -628,7 +628,7 @@ how_to_install_doctoolchain() {
         "    \$ sdk install doctoolchain ${version}" \
         "" \
         "Note that running docToolchain in 'local' or 'sdk' environment needs a" \
-        "Java runtime major version 17 installed on your host." \
+        "Java runtime major version 17, 21 or 25 installed on your host." \
         "" \
         "3. 'docker': pull the docToolchain image and execute docToolchain in a container environment." \
         "" \

--- a/dtcw.ps1
+++ b/dtcw.ps1
@@ -497,7 +497,7 @@ function how_to_install_sdkman() {
 }
 
 function local_install_java() {
-    $version = "17"
+    $version = "25"
     $implementation = "hotspot"
     $heapsize = "normal"
     $imagetype = "jdk"
@@ -560,7 +560,7 @@ following docToolchain environments:
     > ./dtcw.ps1 local install doctoolchain
 
 Note that running docToolchain in 'local' environment needs a
-Java runtime major version 17 installed on your host.
+Java runtime major version 17, 21 or 25 installed on your host.
 
 2. 'docker': pull the docToolchain image and execute docToolchain in a container environment.
 

--- a/src/docs/010_manual/20_install.adoc
+++ b/src/docs/010_manual/20_install.adoc
@@ -9,7 +9,7 @@ include::../_feedback.adoc[]
 
 == Prerequisites
 
-* *Java 17, 21 or 25* — check with `java -version` (`./dtcw4 local install java` installs Java 17 for you)
+* *Java 17, 21 or 25* — check with `java -version` (`./dtcw4 local install java` installs Java 25 for you)
 * *git* — needed to clone docToolchain during installation
 * *Bash* — `dtcw4` is a Bash script (on Windows, use WSL2)
 

--- a/test/install_java.bats
+++ b/test/install_java.bats
@@ -45,12 +45,12 @@ teardown() {
     # Execute
     PATH="${minimal_system}" run -0 ./dtcw local install java
 
-    assert_equal "$(mock_get_call_args "${mock_curl}")" "--fail --location --output ${DTC_ROOT}/jdk/jdk.tar.gz https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
+    assert_equal "$(mock_get_call_args "${mock_curl}")" "--fail --location --output ${DTC_ROOT}/jdk/jdk.tar.gz https://api.adoptium.net/v3/binary/latest/25/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
 
     assert_line "Environments with docToolchain [${DTC_VERSION}]: none"
     assert_line "Using environment: local"
 
-    assert_line "Downloading JDK Temurin 17 [linux/x64] from Adoptium to ${DTC_ROOT}/jdk/jdk.tar.gz"
+    assert_line "Downloading JDK Temurin 25 [linux/x64] from Adoptium to ${DTC_ROOT}/jdk/jdk.tar.gz"
     assert_line "Extracting JDK from archive file."
     assert_line "Successfully installed Java in '${DTC_ROOT}/jdk'."
 
@@ -81,12 +81,12 @@ teardown() {
     # Execute
     PATH="${minimal_system}" run -0 ./dtcw local install java
 
-    assert_equal "$(mock_get_call_args "${mock_curl}")" "--fail --location --output ${DTC_ROOT}/jdk/jdk.tar.gz https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
+    assert_equal "$(mock_get_call_args "${mock_curl}")" "--fail --location --output ${DTC_ROOT}/jdk/jdk.tar.gz https://api.adoptium.net/v3/binary/latest/25/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
 
     assert_line "Environments with docToolchain [${DTC_VERSION}]: local"
     assert_line "Using environment: local"
 
-    assert_line "Downloading JDK Temurin 17 [linux/x64] from Adoptium to ${DTC_ROOT}/jdk/jdk.tar.gz"
+    assert_line "Downloading JDK Temurin 25 [linux/x64] from Adoptium to ${DTC_ROOT}/jdk/jdk.tar.gz"
     assert_line "Extracting JDK from archive file."
     assert_line "Successfully installed Java in '${DTC_ROOT}/jdk'."
 


### PR DESCRIPTION
Follow-up to the Java 25 / Groovy 5 / Gradle 9 runtime upgrade already on `main-4.x`.

## What

`./dtcw local install java` (and `./dtcw4 local install java`) now installs **Java 25 (LTS)** instead of Java 17.

- `dtcw` / `dtcw.ps1`: the Adoptium install version `17` → `25`.
- SDKMAN hint: `sdk install java 17.0.14-tem` → `25.0.3-tem`.
- The "local environment needs a Java runtime …" notices now say **17, 21 or 25**.
- `010_manual/20_install.adoc`: "`install java` installs Java 25 for you".
- `install_java.bats`: the download-URL / "Downloading JDK Temurin …" assertions updated to 25.

## Why

The v4 runtime runs on Java 17/21/25 (verified end-to-end on Temurin 25.0.3), but the bundled installer still pulled 17. New users running `install java` should get the current LTS.

## Scope / safety

- The **version gate is unchanged** (`17 | 21 | 25`): an existing Java 17 or 21 host JDK is still accepted — only the version the installer downloads moves to the newest LTS.
- The Adoptium endpoint `…/v3/binary/latest/25/ga/<os>/<arch>/jdk/hotspot/normal/eclipse` is the same one used to verify the Java 25 runtime, so the download path is known-good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)