### PR TITLE
v4: downloadTemplate prompt + image fix, and diagram-tool hints

### DIFF
--- a/scripts/downloadTemplate.groovy
+++ b/scripts/downloadTemplate.groovy
@@ -147,6 +147,16 @@ if (srcDir.exists()) {
 
 if (chaptersDir.exists()) {
     chaptersDir.eachFileRecurse { file ->
+        // Guard hard `:imagesdir:` lines in non-chapter includes (e.g. config.adoc).
+        // A hard setting there overrides the imagesdir the build provides, so the
+        // combined document and the microsite would resolve images against the
+        // wrong folder (./images relative to the page instead of the shared
+        // images/ directory). ifndef makes it a fallback for editor preview only.
+        if (file.name.endsWith('.adoc') && !(file.name ==~ /[0-9]+_.*/)) {
+            def text = file.getText('utf-8')
+            def guarded = text.replaceAll(/(?m)^:imagesdir: (.+)$/, 'ifndef::imagesdir[:imagesdir: $1]')
+            if (guarded != text) file.write(guarded, 'utf-8')
+        }
         if (file.name.endsWith('.adoc') && file.name ==~ /[0-9]+_.*/) {
             def text = file.getText('utf-8')
             def title = ""
@@ -178,7 +188,16 @@ def mainSource = template == "arc42" ? "${template}-template.adoc" : "${template
 def mainFile = new File(outputDir, mainSource)
 def targetFile = new File(outputDir, "${template}.adoc")
 if (mainFile.exists()) {
-    def mainText = ":imagesdir: ../images\n:jbake-menu: -\n" + mainFile.text.replaceAll('src/', 'chapters/')
+    def rawMain = mainFile.text.replaceAll('src/', 'chapters/')
+    // Drop the arc42 help-style include: common/styles/ exists only in the
+    // arc42-template git repository, not in the distributed asciidoc zip, so the
+    // include always resolves to "file not found" (a SEVERE) without it.
+    rawMain = rawMain.readLines()
+        .findAll { !(it =~ /include::.*common\/styles\/arc42-help-style\.adoc/) }
+        .join('\n') + '\n'
+    // ifndef so the build (generateSite/HTML/PDF) can set imagesdir to the right
+    // folder; the ../images fallback is for editor preview of this file alone.
+    def mainText = "ifndef::imagesdir[:imagesdir: ../images]\n:jbake-menu: -\n" + rawMain
     targetFile.write(mainText, 'utf-8')
     if (mainFile != targetFile) mainFile.delete()
 }
@@ -194,8 +213,6 @@ if (configFileObj.exists()) {
     configText = configText
         .replaceAll('[, \\t\\r\\n]+/[*]{2} inputFiles [*]{2}/',
             ",\n\t[file: '${template}/${template}.adoc', formats: ['html','pdf']],\n\t/** inputFiles **/")
-        .replaceAll('/[*]{2} imageDirs [*]{2}/',
-            "'images/.',\n\t/** imageDirs **/")
         .replaceAll('[, \\t\\r\\n]+/[*]{2} imageDirs [*]{2}/',
             ",\n\t'images/.',\n\t/** imageDirs **/")
         .replaceAll("\\[,", "[")

--- a/scripts/downloadTemplate.groovy
+++ b/scripts/downloadTemplate.groovy
@@ -46,7 +46,27 @@ def templateArg = args.find { !it.startsWith('-') }
 def langArg = args.find { it.startsWith('--lang=') }?.split('=', 2)?.getAt(1)
 def helpArg = args.find { it.startsWith('--help=') }?.split('=', 2)?.getAt(1)
 
-def template = templateArg ?: 'arc42'
+def template
+if (templateArg) {
+    template = templateArg
+} else if (isHeadless) {
+    template = 'arc42'
+    println "${color('green', "Headless mode: using default template 'arc42'.")}"
+} else {
+    def keys = templates.keySet() as List
+    def reader = System.console() ?: new BufferedReader(new InputStreamReader(System.in))
+    println "${color('green', 'Which template do you want to install?')}"
+    keys.eachWithIndex { name, i -> println "  ${i + 1}) ${name}" }
+    print "${color('green', "Choice [1-${keys.size()}] or name (default: 1 = ${keys[0]}): ")}"
+    def input = (reader instanceof Console ? reader.readLine() : reader.readLine())?.trim()
+    if (!input) {
+        template = keys[0]
+    } else if (input.isInteger() && (input as int) in (1..keys.size())) {
+        template = keys[(input as int) - 1]
+    } else {
+        template = input
+    }
+}
 if (!templates.containsKey(template)) {
     System.err.println "Unknown template '${template}'. Available: ${templates.keySet().join(', ')}"
     System.exit(1)

--- a/scripts/generateHTML.groovy
+++ b/scripts/generateHTML.groovy
@@ -45,6 +45,9 @@ if (!htmlFiles) {
 def imageDirs = config.imageDirs ?: ['images']
 def asciidoctor = Asciidoctor.Factory.create()
 asciidoctor.requireLibrary('asciidoctor-diagram')
+def diagramHints = new GroovyClassLoader(this.class.classLoader)
+    .parseClass(new File(scriptDir, 'lib/DiagramToolHints.groovy')).newInstance()
+diagramHints.register(asciidoctor)
 println "AsciidoctorJ ${Asciidoctor.class.package.implementationVersion ?: '2.5.x'} ready (with diagram support)"
 
 def failed = false
@@ -90,6 +93,7 @@ htmlFiles.each { entry ->
     }
 }
 
+diagramHints.printHints()
 asciidoctor.close()
 println ""
 if (failed) {

--- a/scripts/generatePDF.groovy
+++ b/scripts/generatePDF.groovy
@@ -48,6 +48,9 @@ def asciidoctor = Asciidoctor.Factory.create()
 // Register PDF converter by requiring the gem
 asciidoctor.requireLibrary('asciidoctor-pdf')
 asciidoctor.requireLibrary('asciidoctor-diagram')
+def diagramHints = new GroovyClassLoader(this.class.classLoader)
+    .parseClass(new File(scriptDir, 'lib/DiagramToolHints.groovy')).newInstance()
+diagramHints.register(asciidoctor)
 println "AsciidoctorJ PDF ready (with diagram support)"
 
 def failed = false
@@ -103,6 +106,7 @@ pdfFiles.each { entry ->
     }
 }
 
+diagramHints.printHints()
 asciidoctor.close()
 println ""
 if (failed) {

--- a/scripts/lib/DiagramToolHints.groovy
+++ b/scripts/lib/DiagramToolHints.groovy
@@ -1,0 +1,86 @@
+// v4: Turn cryptic asciidoctor-diagram "Could not find the 'xxx' executable"
+// failures into an actionable hint — how to install the tool, or how to render
+// diagrams remotely via a Kroki server (no local tools needed).
+//
+// AsciidoctorJ delivers diagram failures (e.g.
+//   "Could not find the 'dot' executable in PATH; ...")
+// to registered LogHandlers. The raw message still goes to stderr — AsciidoctorJ
+// does not let us selectively suppress a single record — so we collect the
+// missing tools and print one consolidated hint block at the end.
+//
+// Usage:
+//   def Hints = new GroovyClassLoader(this.class.classLoader)
+//       .parseClass(new File(scriptDir, 'lib/DiagramToolHints.groovy'))
+//   def hints = Hints.newInstance()
+//   hints.register(asciidoctor)   // right after Asciidoctor.Factory.create()
+//   ... convert ...
+//   hints.printHints()            // before asciidoctor.close()
+
+import org.asciidoctor.Asciidoctor
+import org.asciidoctor.log.LogHandler
+import org.asciidoctor.log.LogRecord
+
+class DiagramToolHints {
+
+    // executable name -> description + install commands
+    private static final Map TOOLS = [
+        dot  : [name: 'Graphviz',    purpose: 'GraphViz (and some PlantUML) diagrams',
+                install: ['Linux (Debian/Ubuntu): sudo apt-get install -y graphviz',
+                          'macOS:                 brew install graphviz']],
+        mmdc : [name: 'Mermaid CLI', purpose: 'Mermaid diagrams',
+                install: ['npm install -g @mermaid-js/mermaid-cli']],
+        ditaa: [name: 'ditaa',       purpose: 'ditaa diagrams',
+                install: ['Linux (Debian/Ubuntu): sudo apt-get install -y ditaa']],
+    ]
+
+    private final Set<String> missing = new LinkedHashSet<>()
+
+    /** Register a log handler that records missing diagram executables. */
+    void register(Asciidoctor asciidoctor) {
+        asciidoctor.registerLogHandler({ LogRecord record ->
+            def msg = record?.message
+            if (msg) {
+                def m = (msg =~ /Could not find the '([\w.+-]+)' executable/)
+                if (m) {
+                    missing << m[0][1]
+                }
+            }
+        } as LogHandler)
+    }
+
+    boolean hasMissing() { !missing.isEmpty() }
+
+    /** Print one consolidated, actionable hint for every missing tool. */
+    void printHints() {
+        if (missing.isEmpty()) {
+            return
+        }
+        def out = System.err
+        def line = '-' * 72
+        out.println ""
+        out.println line
+        out.println "Some diagrams were not rendered - a local diagram tool is missing:"
+        out.println ""
+        missing.each { tool ->
+            def info = TOOLS[tool]
+            if (info) {
+                out.println "  * '${tool}' (${info.name}) - needed for ${info.purpose}"
+                info.install.each { out.println "        ${it}" }
+            } else {
+                out.println "  * '${tool}' executable not found in PATH"
+            }
+        }
+        out.println ""
+        out.println "  Or render diagrams remotely via a Kroki server (no local tools"
+        out.println "  needed) by adding to docToolchainConfig.groovy:"
+        out.println ""
+        out.println "      asciidoctorAttributes = ["
+        out.println "          'diagram-server-url' : 'https://kroki.io/',"
+        out.println "          'diagram-server-type': 'kroki_io',"
+        out.println "      ]"
+        out.println ""
+        out.println "  See the 'Kroki Configuration Guide' in the docToolchain tutorial"
+        out.println "  (https://doctoolchain.org) or run your own server: https://kroki.io"
+        out.println line
+    }
+}

--- a/scripts/lib/MicrositeBaker.groovy
+++ b/scripts/lib/MicrositeBaker.groovy
@@ -106,6 +106,8 @@ class MicrositeBaker {
 
         asciidoctor = Asciidoctor.Factory.create()
         asciidoctor.requireLibrary('asciidoctor-diagram')
+        def diagramHints = loadDiagramHints()
+        diagramHints?.register(asciidoctor)
 
         crawl()
         buildModelLists()
@@ -113,8 +115,20 @@ class MicrositeBaker {
         renderSpecialPages()
         copyAssets()
 
+        diagramHints?.printHints()
         asciidoctor.close()
         println "MicrositeBaker: rendered ${allContent.size()} content pages."
+    }
+
+    // Load the DiagramToolHints helper from the same scripts/lib directory.
+    private Object loadDiagramHints() {
+        try {
+            def libDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+            return new GroovyClassLoader(getClass().classLoader)
+                    .parseClass(new File(libDir, 'DiagramToolHints.groovy')).newInstance()
+        } catch (Throwable ignored) {
+            return null
+        }
     }
 
     // --- config model (site_*, sourceFolder, contentFolder, jbake props) ---


### PR DESCRIPTION
Two v4 (`main-4.x`) usability fixes since the last sync (#1614).

## downloadTemplate (arc42 / req42) — #55
- **Restore the interactive template prompt** that v4 had lost. A bare
  `downloadTemplate` now asks arc42 / req42 (and lists any custom
  `DTC_TEMPLATEn`); an explicit arg and headless mode still work unchanged.
- **Make the template images actually display.** The reorganised template set
  `:imagesdir:` *hard* (notably in the bundled `config.adoc`), which overrode
  the imagesdir the build provides — so the microsite resolved images against
  `output/arc42/images/` instead of the shared `output/images/`, and the arc42
  logo plus every content image came up broken. Now the `:imagesdir:` settings
  are `ifndef`-guarded (build wins, `../images` is only an editor-preview
  fallback).
- Drop the dangling `common/styles/arc42-help-style.adoc` include — that path
  exists only in the arc42-template git repo, not the distributed zip, so it
  only ever produced an "include file not found" SEVERE.
- Fix `imageDirs` being inserted twice into the project config.

## Diagram-tool hints — #54
When a diagram tool (`dot`/Graphviz, `mmdc`/Mermaid, `ditaa`) is missing,
asciidoctor-diagram only emits a cryptic `Could not find the '…' executable`.
This adds an actionable hint after rendering: how to install the tool, or how
to render remotely via a Kroki server instead. Wired into generateHTML,
generatePDF and generateSite; lists only the tools that actually failed.

Both verified end-to-end on JDK 25 (arc42 plain + withhelp for the template
fix; a Mermaid block with `mmdc` absent for the hint).