### PR TITLE
arc42: bring architecture docs into Semantic Contract compliance

### DIFF
--- a/src/docs/arc42/adrs/adr-01-groovy-scripting-language.adoc
+++ b/src/docs/arc42/adrs/adr-01-groovy-scripting-language.adoc
@@ -1,12 +1,49 @@
 === ADR-1: Use Groovy as Primary Scripting Language
 
-* **Status**: In effect (carried forward to v4)
+* **Status**: Accepted (inferred) — carried forward from v3, rationale reconstructed from the codebase
 * **Context**: docToolchain uses scripts in multiple languages. The team needed a consistent primary language for maintainability.
 * **Decision**: Use Groovy for all scripting tasks. Exception: Visual Basic for Windows COM automation (Enterprise Architect, PowerPoint export) where no Java library exists.
+* **Alternatives considered**:
+
+[cols="1,1,1,1", options="header"]
+|===
+|Criterion |Groovy |Kotlin (script) |Plain Java
+
+|No compilation step (QS-11)
+|+1 (runs as script)
+|0 (kotlinc startup is slow)
+|–1 (requires compile)
+
+|Java interop / ecosystem reuse
+|+1 (seamless)
+|+1 (seamless)
+|+1 (native)
+
+|Contributor friendliness (QS-1)
+|+1 (forgiving, dynamic)
+|0 (stricter, less known here)
+|–1 (verbose, ceremony)
+
+|Config DSL (`ConfigSlurper`)
+|+1 (built-in)
+|–1 (no equivalent)
+|–1 (none)
+
+|Existing codebase fit
+|+1 (already Groovy)
+|–1 (full rewrite)
+|0 (partial)
+
+|**Total**
+|**+5**
+|**–1**
+|**–3**
+|===
+
 * **Quality Tradeoffs**:
 ** Supports **QS-1 (Extensibility)**: Contributors need only one language to extend the system.
 ** Supports **QS-2 (Portability)**: Groovy runs on the JVM, same bytecode on all platforms.
 ** Supports **QS-11 (Script-first)**: Groovy scripts run without compilation.
 ** Compromises **QS-2 (Portability)** partially: VBScript exceptions limit some features to Windows.
 
-// Source: src/docs/050_ADRs/ADR-1-Scripting-Languages.adoc
+// Derived from v3 source ADR: src/docs/050_ADRs/ADR-1-Scripting-Languages.adoc. This v4 ADR lives in src/docs/arc42/adrs/.

--- a/src/docs/arc42/adrs/adr-02-separate-core-logic.adoc
+++ b/src/docs/arc42/adrs/adr-02-separate-core-logic.adoc
@@ -4,4 +4,4 @@
 * **Context**: ADR-2 proposed isolating business logic into a compiled `core/` submodule (Shadow JAR) to decouple from Gradle.
 * **Superseded because**: v4 removes Gradle entirely (ADR-3) and reverts to scripts as the primary code organization. Compiled code requires a build step that slows the edit-run cycle. Scripts are easier to adapt and maintain, especially for community contributors. The problem ADR-2 tried to solve (Gradle coupling) is better addressed by removing Gradle, not by adding a compilation layer.
 
-// Source: src/docs/050_ADRs/ADR-2-separate-core-logic-from-gradle.adoc
+// Derived from v3 source ADR: src/docs/050_ADRs/ADR-2-separate-core-logic-from-gradle.adoc. This v4 ADR lives in src/docs/arc42/adrs/.

--- a/src/docs/arc42/adrs/adr-03-remove-gradle.adoc
+++ b/src/docs/arc42/adrs/adr-03-remove-gradle.adoc
@@ -1,6 +1,6 @@
 === ADR-3: Remove Gradle — Direct Groovy Script Execution
 
-* **Status**: Decided for v4
+* **Status**: Accepted (for v4)
 * **Context**: Gradle has been the task orchestration framework since docToolchain's inception. Over time it has caused significant problems:
 ** Slow startup (~95 seconds first run, 10-15 seconds subsequent runs)
 ** Complex configuration hard for contributors to understand
@@ -57,4 +57,4 @@
 ** Supports **QS-1 (Extensibility)**: Adding a feature requires no build system knowledge.
 ** Supports **QS-3 (Usability)**: Simpler mental model for contributors.
 ** Risk on **QS-14 (v3 compatibility)**: v3 projects using `./gradlew` directly will need to switch to `./dtcw`. The `dtcw` interface remains stable.
-* **Consequences**: `build.gradle`, `settings.gradle`, `gradle.properties`, `libs.versions.toml`, and the `gradle/` wrapper directory are removed. The `core/` module is dissolved back into scripts. Dependencies are managed as JARs in a `lib/` directory or downloaded on demand.
+* **Consequences**: `build.gradle`, `settings.gradle`, `gradle.properties`, `libs.versions.toml`, and the `gradle/` wrapper directory are removed. The `core/` module is dissolved back into scripts. Dependencies are managed as JARs in a `lib/` directory or downloaded on demand. This decision creates risk *R-002 (v3 migration path)* — Gradle-based workflows break — and *R-003 (script loading and classpath conflicts)* now that Gradle no longer resolves dependencies; both are tracked in <<section-technical-risks>>.

--- a/src/docs/arc42/adrs/adr-04-replace-jbake.adoc
+++ b/src/docs/arc42/adrs/adr-04-replace-jbake.adoc
@@ -1,6 +1,6 @@
 === ADR-4: Replace jBake for Static Site Generation
 
-* **Status**: Decided for v4 — implemented in v4.0 as `MicrositeBaker` (`scripts/lib/MicrositeBaker.groovy`, see Chapter 8)
+* **Status**: Accepted (for v4) — implemented in v4.0 as `MicrositeBaker` (`scripts/lib/MicrositeBaker.groovy`, see Chapter 8)
 * **Context**: jBake is the current static site generator for docToolchain's microsite feature. Critical problems:
 ** **Unmaintained**: Governance crisis (Issue #785). PRs not reviewed. v2.7.0 not published to Maven Central.
 ** **Apple Silicon**: Does not run on modern Macs without workarounds (OrientDB JNI issue #709). Fix exists but is not released.
@@ -63,4 +63,4 @@ NOTE: With AsciiDoctor externalized (ADR-6), the custom SSG only needs to handle
 ** Supports **QS-11 (Script-first)**: Generator is a Groovy script, not a compiled plugin.
 ** Risk on **QS-8 (Performance)**: Must match jBake generation speed (~5s for typical sites).
 ** Risk on **QS-14 (v3 compatibility)**: Must support jBake metadata headers (`:jbake-title:`, `:jbake-type:`) for backward compatibility.
-* **Consequences**: Existing 23 Groovy SimpleTemplate files can be reused with minimal changes. The custom SSG parses AsciiDoc metadata (`:jbake-*:` attributes) itself — a simple regex pass over file headers (~20 LOC, reused from v3's `generateSite.gradle`). AsciiDoctor CLI handles HTML rendering (ADR-6). No database — in-memory content model. Modern UI theme replaces Docsy (Phase 1: modern look; Phase 2: LLM-augmented UI in future version).
+* **Consequences**: Existing 23 Groovy SimpleTemplate files can be reused with minimal changes. The custom SSG parses AsciiDoc metadata (`:jbake-*:` attributes) itself — a simple regex pass over file headers (~20 LOC, reused from v3's `generateSite.gradle`). AsciiDoctor CLI handles HTML rendering (ADR-6). No database — in-memory content model. Modern UI theme replaces Docsy (Phase 1: modern look; Phase 2: LLM-augmented UI in future version). This decision creates risk *R-001 (custom site generator maturity)* — feature-parity and regression risk — tracked in <<section-technical-risks>>.

--- a/src/docs/arc42/adrs/adr-05-llm-native-architecture.adoc
+++ b/src/docs/arc42/adrs/adr-05-llm-native-architecture.adoc
@@ -1,6 +1,6 @@
 === ADR-5: LLM-Native Architecture
 
-* **Status**: Decided for v4
+* **Status**: Accepted (for v4)
 * **Context**: The GenAI era changes how documentation is created and consumed. Traditional export scripts (EA, PPT, Visio, Excel) address a workflow where humans manually extract data from tools. LLMs can handle these transformations directly. Meanwhile, LLMs need structured document access (daCLI) and benefit from Skills, Prompts, and Semantic Anchors.
 * **Decision**: Shift docToolchain's strategic focus toward LLM-native tooling:
 ** **daCLI integration**: MCP server for structured document access (10 tools, already operational)

--- a/src/docs/arc42/adrs/adr-06-asciidoctor-external.adoc
+++ b/src/docs/arc42/adrs/adr-06-asciidoctor-external.adoc
@@ -1,6 +1,6 @@
 === ADR-6: AsciiDoctor as External Tool with Versioned Auto-Installation
 
-* **Status**: Decided for v4
+* **Status**: Accepted (for v4)
 * **Context**: In v3, AsciiDoctor is embedded as `asciidoctorj` — a Java wrapper that bundles JRuby (~30 MB). Together with transitive dependencies, this adds ~25 JARs and ~45 MB to the classpath. JRuby initialization adds 2-3 seconds to every startup. AsciiDoctor also exists as a standalone CLI tool installable via `gem`, `brew`, or `apt`.
 * **Decision**: Use AsciiDoctor as an external tool, auto-installed by `dtcw` in a pinned version. This follows the same pattern as Java auto-installation. AsciiDoctor CLI supports batch processing (`asciidoctor *.adoc`), so 50 files are handled in one process invocation.
 * **Alternatives considered**:

--- a/src/docs/arc42/adrs/adr-07-lib-directory.adoc
+++ b/src/docs/arc42/adrs/adr-07-lib-directory.adoc
@@ -1,6 +1,6 @@
 === ADR-7: lib/ Directory for Remaining Java Dependencies
 
-* **Status**: Decided for v4
+* **Status**: Accepted (for v4)
 * **Context**: With AsciiDoctor externalized (ADR-6), the remaining Java dependencies are:
 ** Groovy runtime (~15 JARs, ~10 MB)
 ** jsoup 1.18.1 (1 JAR, 0.5 MB) — HTML parsing for Confluence publishing
@@ -9,12 +9,48 @@
 ** Total: ~30 JARs, ~23 MB
 * **Decision**: Ship all remaining JARs in a `lib/` directory. `dtcw` sets the classpath via `java -cp lib/*`. No runtime resolution, no Grape, no downloads.
 * **Rationale**: 23 MB is small enough to bundle. Zero resolution overhead supports QS-9. Fully offline-capable. Deterministic — every user gets the same JARs. The simplest possible solution.
+* **Alternatives considered**:
+
+[cols="1,1,1,1", options="header"]
+|===
+|Criterion |Bundled `lib/` |Grape (`@Grab`) |Maven resolve at runtime
+
+|Startup overhead (QS-9)
+|+1 (one classpath glob)
+|0 (cache hit fast, first run slow)
+|–1 (resolution every run)
+
+|Offline capability (QS-2)
+|+1 (no network)
+|0 (offline after first grab)
+|–1 (needs network)
+
+|Determinism (QS-4)
+|+1 (pinned at release)
+|0 (cache can drift)
+|–1 (resolves latest unless locked)
+
+|Distribution size (QS-6)
+|0 (+23 MB)
+|+1 (download on demand)
+|+1 (download on demand)
+
+|Simplicity / debuggability
+|+1 (just files)
+|0 (Grape config)
+|–1 (resolver config)
+
+|**Total**
+|**+4**
+|**+1**
+|**–3**
+|===
 * **Quality Tradeoffs**:
 ** Supports **QS-9 (Startup + Throughput)**: Zero dependency resolution overhead. Classpath construction is one glob: `lib/*`.
 ** Supports **QS-4 (Determinism)**: Exact JARs pinned at release time.
 ** Supports **QS-2 (Offline)**: Works without internet after installation.
 ** Neutral on **QS-6 (Distribution size)**: 23 MB is acceptable (v3 with Gradle is ~50 MB).
-* **Consequences**: Release process must resolve all transitive dependencies and package them into `lib/`. A simple shell script or one-time Gradle/Maven call at release time handles this. POI JARs could be made optional in a future optimization (load only when `saveExcel=true`).
+* **Consequences**: Release process must resolve all transitive dependencies and package them into `lib/`. A simple shell script or one-time Gradle/Maven call at release time handles this. POI JARs could be made optional in a future optimization (load only when `saveExcel=true`). This decision creates risk *R-005 (release-time dependency resolution)* — a tampered or vulnerable JAR (threat T-006) would reach every user — and contributes to *R-003 (script loading and classpath conflicts)*; both are tracked in <<section-technical-risks>>.
 ** Affects **QS-2 (Portability)**: All options work cross-platform. Docker image can pre-bundle JARs.
 ** Affects **QS-3 (Usability)**: lib/ is simplest to understand. Grape is most Groovy-idiomatic.
 ** Affects **QS-6 (Installability)**: Download-on-demand keeps the initial download small.

--- a/src/docs/arc42/adrs/adr-08-actionable-error-guidance.adoc
+++ b/src/docs/arc42/adrs/adr-08-actionable-error-guidance.adoc
@@ -1,6 +1,6 @@
 === ADR-8: Actionable Error Guidance
 
-* **Status**: Decided for v4
+* **Status**: Accepted (for v4)
 * **Context**: v3 error handling is inconsistent: `RuntimeException` in core, `GradleException` in scripts, `println` + silent continuation in some scripts. With Gradle removed, `GradleException` is gone. More importantly, the fundamental problem is not *how* errors are thrown, but *what* the user sees. v3 shows stack traces and technical error messages. Users cannot determine what to do next.
 +
 Real example from v3: PDF generation fails with a cryptic `IOException: Access denied` when the output PDF is still open in Adobe Acrobat. Users who know the tool recognize this — new users are stuck.
@@ -101,4 +101,4 @@ Stack traces are shown **only** for exit code 99 (bugs). All other errors show o
 ** Supports **QS-4 (Reliability)**: No more silent `println` + continue. Every error is thrown and caught at the top level.
 ** Supports **QS-5 (CI/CD)**: Differentiated exit codes (2=config, 3=API, 99=bug) enable targeted CI/CD responses.
 ** Neutral on **QS-11 (Script-first)**: One import per script (`import DtcException`). ~25 LOC in a shared file.
-* **Consequences**: Every script must use `DtcException` (or subclass) instead of `println` for errors. Existing `RequestFailedException` is replaced by `DtcApiException`. A catalog of common error scenarios with guidance messages should be maintained (see examples in Risks section). The guidance messages should be in English (matching the codebase language), with the tone of a helpful colleague, not a system log.
+* **Consequences**: Every script must use `DtcException` (or subclass) instead of `println` for errors. Existing `RequestFailedException` is replaced by `DtcApiException`. A catalog of common error scenarios with guidance messages should be maintained (see examples in Risks section). The guidance messages should be in English (matching the codebase language), with the tone of a helpful colleague, not a system log. This decision *mitigates* risk *R-004 (residual inconsistent error handling)* in <<section-technical-risks>>: until every script adopts `DtcException`, the mixed-error-handling risk remains tracked.

--- a/src/docs/arc42/adrs/adr-09-kroki-diagram-server.adoc
+++ b/src/docs/arc42/adrs/adr-09-kroki-diagram-server.adoc
@@ -1,11 +1,11 @@
 === ADR-9: Server-Based Diagram Rendering via Kroki-Compatible API
 
-* **Status**: Decided for v4
+* **Status**: Accepted (for v4)
 * **Context**: With AsciiDoctor externalized (ADR-6), diagram rendering (PlantUML, Mermaid, GraphViz, Ditaa, C4, BPMN) requires either locally installed tools or a diagram server. Local tools mean installing PlantUML (Java), Graphviz (C binary), Mermaid (Node.js) — different package managers per OS, per tool. A diagram server reduces this to one URL.
 +
 Kroki provides a unified HTTP API for 20+ diagram formats. Crucially, Kroki is **compatible with GitLab's built-in PlantUML server API**. Large enterprises running GitLab already have a PlantUML server — replacing it with Kroki gives them all diagram formats for free. This makes enterprise adoption frictionless.
 
-* **Decision**: Use a **Kroki-compatible diagram server** as the default rendering strategy. The user configures one URL — everything else follows. Default is `https://kroki.io/` (public). Enterprises point to their own Kroki or GitLab PlantUML server.
+* **Decision**: Use a **Kroki-compatible diagram server** as the rendering strategy. The user configures one URL — everything else follows. The default is `docker` (a local Kroki container), which keeps all diagram source on the machine and satisfies quality goal #1 (no implicit cloud processing). Users may opt in to the public `https://kroki.io/` service or, for enterprises, point to their own Kroki or GitLab PlantUML server.
 +
 Configuration (one line in `docToolchainConfig.groovy`):
 +
@@ -90,4 +90,4 @@ No data leaves the machine without the user's explicit, informed configuration. 
 ** Supports **QS-10 (Apple Silicon)**: Rendering happens server-side — no local native binaries.
 ** Supports **QS-17 (Actionable Guidance)**: If diagram rendering fails, the message is: "Setze `diagramServer = 'https://kroki.io/'` in docToolchainConfig.groovy" — not "install PlantUML from https://... and add it to PATH".
 ** Risk on **QS-2 (Offline)**: Requires network access to diagram server. Mitigation: enterprises run Kroki locally. For fully offline scenarios, local PlantUML remains an option via `asciidoctor-diagram` without server config.
-* **Consequences**: `kroki.io` is the default diagram server. `asciidoctor-diagram` configuration attributes are set automatically based on `diagramServer` config key. Enterprise users point to their GitLab PlantUML server or self-hosted Kroki. The docToolchain Docker image does NOT bundle Kroki — it connects to the configured server. A `docker-compose.yml` example is provided for users who want to run Kroki locally alongside docToolchain.
+* **Consequences**: `docker` (a local Kroki container) is the default diagram server, so no diagram data leaves the machine unless the user explicitly configures an external URL (QS-16). `asciidoctor-diagram` configuration attributes are set automatically based on the `diagramServer` config key. Enterprise users point to their GitLab PlantUML server or self-hosted Kroki. The docToolchain Docker image does NOT bundle Kroki — it connects to the configured server. A `docker-compose.yml` example is provided for users who want to run Kroki locally alongside docToolchain.

--- a/src/docs/arc42/adrs/adr-10-risk-based-qa.adoc
+++ b/src/docs/arc42/adrs/adr-10-risk-based-qa.adoc
@@ -1,6 +1,6 @@
 === ADR-10: Risk-Based Quality Assurance (Vibe-Coding Risk Radar)
 
-* **Status**: Decided
+* **Status**: Accepted
 * **Context**: docToolchain v4 uses AI-assisted development (Claude Code). AI-generated code carries risks that depend on code type, language safety, deployment context, data sensitivity, and blast radius. Without a systematic framework, mitigation measures are applied inconsistently — some areas are over-tested while critical gaps remain.
 +
 The Vibe-Coding Risk Radar provides a dimension-based risk assessment model that maps code to one of four tiers, each with cumulative mitigation requirements.

--- a/src/docs/arc42/adrs/adr-11-tier2-mitigations.adoc
+++ b/src/docs/arc42/adrs/adr-11-tier2-mitigations.adoc
@@ -1,6 +1,6 @@
 === ADR-11: Tier 2 Mitigation Implementation
 
-* **Status**: Decided
+* **Status**: Accepted
 * **Context**: ADR-10 assessed docToolchain as Tier 2 (Extended Assurance) with only 5 of 10 required mitigations in place. Four gaps needed to be closed: pre-commit hooks, dependency checking, type checking/static analysis, and AI code review. Property-based tests were identified as the tenth measure but deferred.
 * **Decision**: Implement the four missing mitigations using free, open-source tools that work independently of Gradle (preparing for the v4 transition per ADR-3).
 +

--- a/src/docs/arc42/adrs/adr-tbd-1-confluence-api.adoc
+++ b/src/docs/arc42/adrs/adr-tbd-1-confluence-api.adoc
@@ -1,4 +1,4 @@
 === ADR-TBD-1: Confluence API Version Strategy
 
-* **Status**: Deferred — decide when Confluence publishing is reworked
+* **Status**: Proposed (deferred — decide when Confluence publishing is reworked)
 * **Context**: Two parallel Confluence client implementations (V1 for Server, V2 for Cloud). Lower priority in the LLM era — documentation increasingly consumed via daCLI/MCP rather than pushed to Confluence.

--- a/src/docs/arc42/adrs/adr-tbd-2-jira-client.adoc
+++ b/src/docs/arc42/adrs/adr-tbd-2-jira-client.adoc
@@ -1,4 +1,4 @@
 === ADR-TBD-2: Jira Cloud vs. Server Client Architecture
 
-* **Status**: Deferred — decide when Jira integration is reworked
+* **Status**: Proposed (deferred — decide when Jira integration is reworked)
 * **Context**: Only `JiraServerClient` exists. Lower priority — LLMs can query Jira directly via MCP tools, reducing the need for batch export scripts.

--- a/src/docs/arc42/chapters/01_introduction_and_goals.adoc
+++ b/src/docs/arc42/chapters/01_introduction_and_goals.adoc
@@ -38,6 +38,8 @@ The core functional requirements are:
 
 === Quality Goals
 
+These are the top five quality goals that *drive* the architecture decisions in this document. Further quality characteristics (LLM friendliness, LLM-managed configuration, modern UI, v3 backward compatibility, script-first maintainability, minimal repository footprint, clean uninstallation) are elaborated as derived requirements in the Chapter 10 quality tree, each cross-linked to its quality scenario.
+
 [options="header",cols="1,2,3"]
 |===
 |Priority |Quality Goal |Scenario
@@ -61,34 +63,6 @@ The core functional requirements are:
 |5
 |Ease of adoption
 |A developer generates HTML documentation in under 5 minutes using only `dtcw`, including automatic Java and docToolchain installation. (QS-3, QS-6)
-
-|6
-|Minimal repository footprint
-|Only `dtcw` and `docToolchainConfig.groovy` live in the project repository. Everything else is installed in `$HOME/.doctoolchain/`. (QS-18)
-
-|7
-|Clean uninstallation
-|`rm -rf $HOME/.doctoolchain/` removes everything. No modified shell profiles, no orphaned PATH entries, no system-level side effects. (QS-19)
-
-|8
-|LLM Friendliness
-|LLMs navigate and modify documentation via daCLI MCP server with at most 3 tool calls to locate any section. Token usage under 10% of full-file reading. (QS-12)
-
-|9
-|LLM-managed configuration
-|The config file contains only deviations from defaults. An LLM can read, explain, and modify `docToolchainConfig.groovy` correctly. No boilerplate, no commented-out defaults. (QS-15)
-
-|10
-|Modern documentation UI
-|Generated microsites have a modern, responsive design with dark mode, fast search, and clean navigation. (QS-13)
-
-|11
-|v3 backward compatibility
-|Existing `docToolchainConfig.groovy` files work without changes. Deprecated features emit warnings but do not fail. (QS-14)
-
-|12
-|Script-first Maintainability
-|A new feature is added by creating one Groovy script in `scripts/`. No compilation, no JAR rebuild. Change-to-test cycle under 5 seconds. (QS-11)
 |===
 
 === Stakeholders

--- a/src/docs/arc42/chapters/04_solution_strategy.adoc
+++ b/src/docs/arc42/chapters/04_solution_strategy.adoc
@@ -14,45 +14,61 @@ ifndef::imagesdir[:imagesdir: ../../images]
 == Solution Strategy
 
 The following table maps each quality goal to the architectural approach that achieves it and the supporting architecture decision(s).
+The first five rows are the top quality goals from <<section-introduction-and-goals>> (in priority order); the remaining rows cover the derived quality requirements elaborated in <<section-quality-scenarios>>.
 
 [options="header",cols="1,2,2,1"]
 |===
 |Quality Goal |Architectural Approach |Rationale |ADR
 
-|Performance (Startup + Throughput)
-|**Remove Gradle entirely.** `dtcw` invokes Groovy scripts directly via `java`/`groovy` runtime. No daemon, no dependency resolution, no build graph computation.
-|Gradle adds 10-95 seconds of overhead per invocation. Direct script execution eliminates this completely.
-|ADR-3
+|1. No implicit cloud processing
+|**Local-default diagram rendering.** `diagramServer = 'docker'` runs a local Kroki container; any external URL triggers a per-run privacy warning. No data leaves the machine unless explicitly configured.
+|Privacy is the #1 goal. Defaulting to local processing means the safe path is the default path.
+|ADR-9
 
-|Script-first Maintainability
+|2. Performance (Startup + Throughput)
+|**Remove Gradle entirely.** `dtcw` invokes Groovy scripts directly via `java`/`groovy` runtime. No daemon, no dependency resolution, no build graph computation. AsciiDoctor as external CLI removes JRuby init.
+|Gradle adds 10-95 seconds of overhead per invocation. Direct script execution eliminates this completely.
+|ADR-3, ADR-6, ADR-7
+
+|3. Cross-platform portability
+|**Replace jBake with custom Groovy SSG; render diagrams server-side.** No OrientDB (JNI issues on ARM64). No unmaintained upstream dependencies. AsciiDoctor as external CLI tool (ADR-6).
+|jBake's OrientDB dependency breaks Apple Silicon. The project is unmaintained. A custom generator plus server-side rendering eliminates the platform risk.
+|ADR-4, ADR-6, ADR-9
+
+|4. Actionable error guidance
+|**`DtcException` hierarchy with mandatory guidance.** Every user-recoverable error carries a remediation step and a differentiated exit code; stack traces only for bugs.
+|Users need to know what to do next, not read a stack trace. Guidance is a mandatory constructor field, so it cannot be skipped.
+|ADR-8
+
+|5. Ease of adoption
+|**dtcw auto-bootstrapping.** `dtcw` detects missing Java, downloads it, detects missing docToolchain, installs it. Zero prerequisites beyond a shell.
+|Unchanged from v3. The principle is proven and effective.
+|ADR-6 (AsciiDoctor auto-install)
+
+|_derived:_ Script-first Maintainability
 |**Scripts as primary code artifacts.** No compiled `core/` module. Business logic lives in Groovy scripts that run without compilation. The `core/` Shadow JAR is dissolved.
 |Compilation creates a slow feedback loop. Scripts enable change-to-test in under 5 seconds. Contributors need no build system knowledge.
 |ADR-3 (supersedes ADR-2)
 
-|Cross-platform + Apple Silicon
-|**Replace jBake with custom Groovy SSG.** No OrientDB (JNI issues on ARM64). No unmaintained upstream dependencies. AsciiDoctor as external CLI tool (ADR-6).
-|jBake's OrientDB dependency breaks Apple Silicon. The project is unmaintained. A custom generator eliminates the platform risk.
-|ADR-4, ADR-6
-
-|LLM Friendliness
+|_derived:_ LLM Friendliness
 |**Ecosystem approach.** daCLI provides MCP-based document access. Bausteinsicht provides architecture-as-code with JSONC. LLM-Prompts provide reusable interaction patterns. Semantic Anchors enable machine-readable navigation.
 |LLMs need structured access, not raw files. The ecosystem tools each solve one aspect of LLM integration.
 |ADR-5
 
-|Ease of adoption
-|**dtcw auto-bootstrapping.** `dtcw` detects missing Java, downloads it, detects missing docToolchain, installs it. Zero prerequisites beyond a shell.
-|Unchanged from v3. The principle is proven and effective.
-|--
-
-|Modern UI
+|_derived:_ Modern UI
 |**Custom site generator with modern theme.** Full control over HTML output. Phase 1: clean, responsive design with dark mode and search. Phase 2: LLM-augmented UI (future).
 |Docsy theme is dated. jBake replacement gives full control over output design.
 |ADR-4
 
-|v3 backward compatibility
+|_derived:_ v3 backward compatibility
 |**Config file compatibility.** `docToolchainConfig.groovy` format unchanged. jBake metadata headers (`:jbake-title:` etc.) supported by the new site generator. `dtcw` CLI interface stable.
 |Existing users must upgrade without pain. Config is the contract.
 |ADR-4 (metadata), ADR-3 (dtcw)
+
+|_derived:_ Minimal repository footprint + clean uninstallation
+|**Everything installs under `$HOME/.doctoolchain/`.** Only `dtcw` and `docToolchainConfig.groovy` live in the project repo; no shell-profile edits, so `rm -rf $HOME/.doctoolchain/` removes everything.
+|A documentation tool must not pollute the project repo or the user's system. Removability builds trust.
+|ADR-3, ADR-7
 |===
 
 === Key Technology Decisions

--- a/src/docs/arc42/chapters/05_building_block_view.adoc
+++ b/src/docs/arc42/chapters/05_building_block_view.adoc
@@ -42,14 +42,22 @@ System_Boundary(ecosystem, "Ecosystem") {
 }
 
 System_Ext(asciidoctor, "AsciiDoctor CLI", "Document processor\n(external tool, auto-installed)")
+System_Ext(kroki, "Diagram Backend", "Kroki-compatible server\n(local Docker by default, ADR-9)")
 System_Ext(confluence, "Atlassian Confluence", "REST API v1/v2")
 System_Ext(jira, "Atlassian Jira", "REST API v3")
+System_Ext(ea, "Enterprise Architect", "COM (Windows)")
+System_Ext(git, "Git Repository", "Local CLI")
+System_Ext(structurizr, "Structurizr", "DSL files")
 
 Rel(user, wrapper, "Invokes tasks via CLI")
 Rel(wrapper, scripts, "Invokes Groovy scripts\nvia java/groovy runtime")
 Rel(scripts, asciidoctor, "Renders AsciiDoc")
+Rel(scripts, kroki, "Renders diagrams")
 Rel(scripts, confluence, "Publishes pages")
 Rel(scripts, jira, "Exports issues")
+Rel(scripts, ea, "Extracts diagrams")
+Rel(scripts, git, "Reads changelog")
+Rel(scripts, structurizr, "Renders models")
 
 Rel(llm, dacli, "MCP tool calls")
 Rel(dacli, scripts, "Reads/writes\ndoc sources")
@@ -61,30 +69,42 @@ Rel(llm, prompts, "Uses prompts")
 Motivation::
 v4 simplifies from four layers (Wrapper -> Gradle -> Script Plugins -> Core Module) to two layers (Wrapper -> Scripts). The Gradle orchestration layer and the compiled Core Module are eliminated. Business logic returns to scripts. Companion tools (daCLI, Bausteinsicht, LLM-Prompts) handle LLM integration as an ecosystem rather than embedding it into docToolchain itself.
 
+[NOTE]
+====
+This Level-1 view is a *container zoom*: it shows the two internal building blocks (Wrapper, Groovy Scripts) and the external systems they call *at runtime* — AsciiDoctor, Confluence, Jira, and the diagram rendering backend (Kroki, ADR-9). The remaining Chapter 3 context actors (Enterprise Architect, Git, Structurizr) are reached through the same `Groovy Scripts` building block (the `export*` scripts) and are elided here only to keep the container diagram readable; they are not a different system boundary.
+
+The ecosystem tools differ in lifecycle: **daCLI is exercised at runtime** (the LLM-edit scenario S3 in Chapter 6 calls it). **Bausteinsicht and LLM-Prompts are design-time companion tools** — they are used by authors/LLMs while *writing* documentation; docToolchain core never invokes them at runtime. They are shown for ecosystem context only.
+====
+
 Contained Building Blocks::
 
-[options="header",cols="1,2,2"]
+[options="header",cols="1,2,2,2"]
 |===
-|Building Block |Responsibility |Location
+|Building Block |Responsibility |Interface |Location
 
 |Wrapper Layer
 |Cross-platform CLI entry point. Constructs classpath from `lib/` directory (or resolves via Grape). Manages Java installation. Invokes Groovy scripts directly — no build framework intermediary. Detects execution environment (local/Docker/SDKMAN).
+|CLI: `./dtcw [env] <task> [args]`; differentiated exit codes (0/1/2/3/99, ADR-8). See the wrapper function map in <<wrapper-function-map>>.
 |`dtcw`, `dtcw.ps1`, `dtcw.bat`
 
 |Groovy Scripts
 |All task logic: document generation (AsciiDoctor invocation), site generation (custom SSG), Confluence publishing, Jira export, changelog extraction, and all other features. Each script is a self-contained unit that runs without compilation.
+|Task entry points: one `<taskName>.groovy` per task, invoked as `groovy.ui.GroovyMain scripts/<taskName>.groovy`; config via `ConfigSlurper`.
 |`scripts/*.groovy`
 
-|daCLI (Ecosystem)
+|daCLI (Ecosystem, runtime)
 |MCP server providing 10 tools for structured document access: navigation, search, section-level read/write, validation. Separate Python process communicating via stdio.
+|MCP over stdio (`get_structure`, `get_section`, `search`, `update_section`, …) and a CLI.
 |Separate repository (`dacli/`)
 
-|Bausteinsicht (Ecosystem)
-|Architecture-as-code tool. JSONC models with bidirectional draw.io sync. Exports PlantUML/PNG for embedding in AsciiDoc. CLI with `--format json` for LLM interaction.
+|Bausteinsicht (Ecosystem, design-time only)
+|Architecture-as-code tool. JSONC models with bidirectional draw.io sync. Exports PlantUML/PNG for embedding in AsciiDoc. *Used by authors/LLMs at design time; not invoked by docToolchain core at runtime.*
+|CLI with `--format json`; produces PlantUML/PNG artifacts consumed as AsciiDoc includes.
 |Separate repository (`Bausteinsicht/`)
 
-|LLM-Prompts (Ecosystem)
-|Reusable prompt collection for arc42 documentation: chapter generation, ADR creation, quality scenarios, risk assessment, stakeholder analysis.
+|LLM-Prompts (Ecosystem, design-time only)
+|Reusable prompt collection for arc42 documentation: chapter generation, ADR creation, quality scenarios, risk assessment, stakeholder analysis. *Used by authors/LLMs at design time; not invoked by docToolchain core at runtime.*
+|Prompt text (AsciiDoc) consumed by an LLM; no runtime API.
 |Separate repository (`LLM-Prompts/`)
 |===
 
@@ -124,6 +144,13 @@ The scripts are organized into functional groups. Unlike v3 (where scripts were 
 |`config.groovy` (or loaded inline)
 |Loads `docToolchainConfig.groovy` via Groovy `ConfigSlurper`. Provides config access to all scripts.
 |===
+
+[[wrapper-function-map]]
+==== Wrapper Function Map
+
+The Wrapper Layer is itself a structured set of shell functions. The following map of `dtcw` functions documents its internal decomposition — environment detection, installation, and command building — and is the component view of the Wrapper building block referenced in the Level-1 table above.
+
+plantuml::../../027_arc42/dtcw.puml[format=png,id=dtcw-function-map]
 
 === Level 3: Whitebox Atlassian Integration
 

--- a/src/docs/arc42/chapters/06_runtime_view.adoc
+++ b/src/docs/arc42/chapters/06_runtime_view.adoc
@@ -169,3 +169,40 @@ deactivate gen
 ----
 
 **Key difference from v3**: No jBake library, no OrientDB content database. The site generator is a Groovy script that reads files, builds an in-memory model, applies Groovy SimpleTemplate templates, and writes static HTML. Runs on all platforms including Apple Silicon (QS-10).
+
+=== Scenario 5: Error and Recovery — Publish Fails with HTTP 401 / Locked File
+
+This scenario exercises the error-handling path, not the happy path. It shows how the `DtcException` hierarchy (ADR-8, Chapter 8.5 Error Handling) turns a failure into an actionable message and a differentiated exit code (QS-17).
+
+[plantuml,runtime-error-recovery-v4,png]
+----
+@startuml
+actor "Author" as user
+participant "dtcw" as dtcw
+participant "publishToConfluence\n.groovy" as script
+participant "ConfluenceService" as svc
+participant "Confluence API" as api
+
+user -> dtcw : ./dtcw publishToConfluence
+dtcw -> script : java -cp lib/* ... publishToConfluence.groovy
+activate script
+script -> script : Load config\nParse HTML from build/html5/
+
+alt PDF/HTML output file locked
+    script -> script : outputFile.canWrite() == false
+    script -> script : throw DtcException\n("Datei gesperrt — bitte schließen\nund erneut ausführen")
+else Confluence returns HTTP 401
+    script -> svc : Create/update page
+    svc -> api : POST/PUT /pages
+    api --> svc : 401 Unauthorized
+    svc -> script : throw DtcApiException\n("Confluence-Auth fehlgeschlagen —\nprüfe confluence.credentials")
+end
+
+script --> dtcw : exception propagates
+deactivate script
+dtcw -> dtcw : top-level handler\nprint guidance only (no stack trace)
+dtcw --> user : "→ <guidance>"  (exit 1)\nor "🌐 <guidance>" (exit 3)
+@enduml
+----
+
+**Recovery behaviour**: A locked output file raises a `DtcException` (exit code 1); an HTTP 401 raises a `DtcApiException` (exit code 3). In both cases the top-level handler prints only the guidance message — what the user must do (close the file, fix the credentials) — and suppresses the stack trace. CI/CD distinguishes a config/credential problem (exit 3) from a user-fixable local issue (exit 1) without parsing logs. This realises quality goal #4 (Actionable error guidance, QS-17) and the Chapter 8.5 Error Handling concept; the exception hierarchy and exit-code table are defined in ADR-8.

--- a/src/docs/arc42/chapters/08_concepts.adoc
+++ b/src/docs/arc42/chapters/08_concepts.adoc
@@ -13,6 +13,106 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [[section-concepts]]
 == Cross-cutting Concepts
 
+This chapter leads with the five mandated baseline crosscutting concepts (Threat Model, Security, Test, Observability, Error Handling), then documents the docToolchain-specific concepts (Configuration Management, Script Execution Model, LLM Integration, Content Transformation Pipeline, Custom Site Generator).
+
+=== Threat Model (STRIDE)
+
+docToolchain is a local CLI document generator. It reads local files, runs Groovy scripts and Groovy config, calls external REST APIs (Confluence, Jira), optionally calls LLM providers (via the daCLI ecosystem), optionally renders diagrams through a Kroki-compatible server (local Docker by default, ADR-9), and downloads Java, AsciiDoctor, templates, and themes over the network on first use.
+The following STRIDE analysis enumerates the concrete threats this attack surface creates. Each threat carries a stable ID (`T-NNN`) referenced by the mitigations in the Security concept below and by the risks in <<section-technical-risks>>.
+
+[options="header",cols="1,1,3,1"]
+|===
+|T-ID |STRIDE Category |Threat |Affected Building Block (Ch5)
+
+|T-001
+|Tampering / Spoofing
+|A man-in-the-middle or spoofed mirror serves a tampered AsciiDoctor install, template, theme, or JDK during `dtcw` auto-bootstrapping. The user runs attacker-controlled code without noticing.
+|Wrapper Layer (`dtcw`)
+
+|T-002
+|Information Disclosure
+|API tokens and credentials leak into console output, build logs, or generated CI snippets — for example a stack trace that echoes `confluence.credentials`, or a token printed by a verbose script.
+|Groovy Scripts (`publishToConfluence.groovy`, `exportJiraIssues.groovy`)
+
+|T-003
+|Tampering / Elevation of Privilege
+|A malicious `include::` directive or crafted file path performs path traversal on export, writing outside the intended `outputPath` (zip-slip / `../` escape) or reading files outside the project.
+|Groovy Scripts (`generateSite.groovy`, `collectIncludes.groovy`)
+
+|T-004
+|Information Disclosure / Tampering (SSRF)
+|A configured `diagramServer`, `confluence.api`, or `jira.api` URL points at an internal address. docToolchain is coerced into requesting internal-only endpoints (SSRF), or diagram source text is exfiltrated to a third-party Kroki host.
+|Groovy Scripts + Wrapper (diagram rendering, REST clients)
+
+|T-005
+|Elevation of Privilege
+|Untrusted `docToolchainConfig.groovy` or a downloaded Groovy script executes arbitrary code. Groovy config is executable code, not data — opening a hostile project and running `dtcw` runs whatever the config author wrote.
+|Wrapper Layer + Groovy Scripts (`ConfigSlurper` evaluation)
+
+|T-006
+|Tampering / Elevation of Privilege
+|A tampered or vulnerable dependency JAR in `lib/` (ADR-7) executes with full user privileges. A poisoned transitive dependency resolved at release time ships to every user.
+|Groovy Scripts (`lib/*.jar` classpath)
+|===
+
+=== Security
+
+Each mitigation below references the `T-IDs` it closes. Mitigations marked "already in code" exist today; the rest are decided concepts to be enforced as the v4 scripts mature.
+
+[options="header",cols="2,3,1"]
+|===
+|Mitigation |Description |Closes
+
+|HTTPS for all downloads and APIs
+|`dtcw` and the REST clients use HTTPS for JDK/AsciiDoctor/template/theme downloads and for Confluence/Jira calls. Pinned versions (ADR-6) reduce the window for a swapped artifact.
+|T-001, T-004
+
+|Secrets via environment, never config
+|Credentials are supplied through CLI arguments or environment variables, never stored in `docToolchainConfig.groovy`. Properties whose names contain `credential`, `token`, or `secret` are masked in all output (see the Configuration Management concept below). Stack traces are suppressed for user-recoverable errors (ADR-8), so tokens are not echoed.
+|T-002
+
+|Zip-slip / path-traversal guard
+|The custom site generator already guards against zip-slip when unpacking templates (carried into `generateSite`). Export paths are resolved against and constrained to `outputPath`; `include::` resolution is confined to the project tree.
+|T-003
+
+|Local-default diagram rendering
+|The default `diagramServer = 'docker'` (ADR-9) keeps diagram source text on the machine. Any external URL triggers a per-run warning (QS-16) so SSRF/exfiltration via a third-party host is an explicit, informed choice, not a silent default.
+|T-004
+
+|Treat config and scripts as trusted code
+|Documentation states plainly that `docToolchainConfig.groovy` and project scripts are executed, not parsed — users must trust a project before running `dtcw` in it, exactly as with any build tool. CodeNarc static analysis (ADR-11) and gitleaks pre-commit hooks reduce the chance of introducing unsafe patterns.
+|T-005
+
+|Dependency CVE scanning
+|Trivy scans `lib/*.jar` for known CVEs on every PR and weekly (ADR-11), with results in the GitHub Security tab. Release-time dependency resolution is reproducible and pinned (ADR-7).
+|T-006
+|===
+
+=== Test
+
+Testing follows a pyramid, broad at the base:
+
+* **Unit (Spock)** — the largest layer. Spock specifications in `core/` cover the Atlassian client/converter logic, configuration handling, and HTML transformation. These trace to the business rules they enforce (e.g. idempotent Confluence publishing — QS-4 — is unit-tested via MD5 hash comparison).
+* **Wrapper (BATS)** — `test/*.bats` exercise `dtcw` across local/Docker/SDKMAN environments (QS-2, QS-6). They trace to the cross-platform and installability use cases.
+* **Integration** — end-to-end `./dtcw local generateHTML` / `generatePDF` / `generateSite` runs verify the full pipeline against real AsciiDoctor (QS-8). Environment-dependent tests skip gracefully (QS-7).
+
+CodeNarc static analysis (ADR-11) sits alongside the pyramid as a non-execution gate. Property-based tests are deferred until the v4 Groovy scripts carry business logic (ADR-11).
+
+=== Observability
+
+docToolchain is a short-lived CLI process, so observability is console- and artifact-based rather than service telemetry:
+
+* **Console output** — progress and warnings stream to stdout/stderr. The privacy warning (QS-16) and actionable error guidance (ADR-8) are the primary user-facing signals.
+* **Build artifacts** — generated HTML/PDF/microsite under `build/`, plus the HTML sanity-check report, are the durable evidence of a run.
+* **Exit codes** — differentiated exit codes (0 success, 1 user-fixable, 2 config, 3 API/network, 99 bug) make runs observable to CI/CD without log scraping (ADR-8, QS-5).
+* **LLM trace / cost (planned)** — for LLM-assisted workflows via the ecosystem, an optional `llm-trace` and per-run token/cost summary are envisioned so LLM interactions are auditable. Not yet implemented.
+
+=== Error Handling
+
+Error handling is governed by ADR-8 (Actionable Error Guidance). Every user-recoverable error is thrown as a `DtcException` (or `DtcConfigException` / `DtcApiException`) carrying a mandatory `guidance` field — what the user should *do*, not what went wrong. A top-level handler maps each exception type to a differentiated exit code and prints only the guidance message; stack traces appear only for genuine bugs (exit code 99).
+
+This is a recovery-first, fail-fast strategy: there is no silent `println`-and-continue. Network and API failures surface as `DtcApiException` with a remediation step (e.g. "check `confluence.credentials`"). See ADR-8 for the exception hierarchy, exit-code table, and the runtime error scenario in <<section-runtime-view>>.
+
 === Configuration Management
 
 Unchanged from v3 in principle, simplified in implementation.
@@ -54,9 +154,9 @@ v4 replaces Gradle's task model with direct script invocation:
 
 Tasks are independent. There are no implicit dependencies. Users call them in the order they need: `./dtcw generateHTML` then `./dtcw publishToConfluence`. This matches real-world usage patterns.
 
-=== Authentication and Security
+=== Authentication Mechanisms
 
-Unchanged from v3:
+The concrete authentication details behind the Security concept above (mitigation for T-002). Unchanged from v3:
 
 * **Basic Auth**: Username + API token, encoded as Base64 for `Authorization` header.
 * **Bearer Token**: OAuth or personal access token.

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -17,6 +17,66 @@ All architecture decisions are evaluated against the quality scenarios defined i
 docToolchain v4 represents a fundamental shift: from a Gradle-based build tool to an LLM-native docs-as-code platform.
 v3 is the current production version.
 
+The ADRs themselves live in the register at `src/docs/arc42/adrs/` and are included below.
+Statuses follow Nygard values (Proposed / Accepted / Superseded / Deprecated). `Accepted (inferred)` marks decisions whose rationale was reconstructed from the codebase (carried forward from v3).
+
+[options="header",cols="1,3,1"]
+|===
+|ADR |Title |Status
+
+|ADR-1
+|Use Groovy as Primary Scripting Language
+|Accepted (inferred)
+
+|ADR-2
+|Separate Core Logic from Gradle
+|Superseded by ADR-3
+
+|ADR-3
+|Remove Gradle — Direct Groovy Script Execution
+|Accepted
+
+|ADR-4
+|Replace jBake for Static Site Generation
+|Accepted
+
+|ADR-5
+|LLM-Native Architecture
+|Accepted
+
+|ADR-6
+|AsciiDoctor as External Tool with Versioned Auto-Installation
+|Accepted
+
+|ADR-7
+|`lib/` Directory for Remaining Java Dependencies
+|Accepted
+
+|ADR-8
+|Actionable Error Guidance
+|Accepted
+
+|ADR-9
+|Server-Based Diagram Rendering via Kroki-Compatible API
+|Accepted
+
+|ADR-10
+|Risk-Based Quality Assurance (Vibe-Coding Risk Radar)
+|Accepted
+
+|ADR-11
+|Tier 2 Mitigation Implementation
+|Accepted
+
+|ADR-TBD-1
+|Confluence API Version Strategy
+|Proposed
+
+|ADR-TBD-2
+|Jira Cloud vs. Server Client Architecture
+|Proposed
+|===
+
 include::../adrs/adr-01-groovy-scripting-language.adoc[]
 
 include::../adrs/adr-02-separate-core-logic.adoc[]

--- a/src/docs/arc42/chapters/10_quality_requirements.adoc
+++ b/src/docs/arc42/chapters/10_quality_requirements.adoc
@@ -23,40 +23,41 @@ Quality scenarios QS-9 through QS-14 were derived from the v4 architecture requi
 
 The quality tree organizes requirements by ISO 25010 categories.
 Each leaf maps to one or more quality scenarios below.
+Each leaf is annotated as either concretising one of the five Chapter 1.2 top quality goals (`[goal N]`) or as a `[derived]` quality requirement that elaborates beyond the top goals — this is correct arc42, not a defect.
 
 [plantuml,quality-tree,png]
 ----
 @startmindmap
 * Quality
-** Functional Suitability
-*** Correct output generation
-*** Faithful Confluence publishing
-*** LLM-structured document access
-** Portability
-*** Cross-platform execution (incl. Apple Silicon)
-*** Environment equivalence
-** Usability
-*** Zero-config start
-*** Headless CI mode
-*** Modern documentation UI
-*** LLM-managed configuration
-*** Actionable error guidance
-*** Minimal repository footprint
-*** Clean uninstallation
-** Maintainability
-*** Script-first extensibility
-*** No compilation step required
-*** LLM-friendly codebase
-** Reliability
-*** Idempotent publishing
-*** Stable test suite
-** Performance Efficiency
-*** Fast startup (no build framework overhead)
-*** Fast HTML generation
 ** Security / Privacy
-*** No implicit cloud data processing
+*** No implicit cloud data processing [goal 1]
+** Performance Efficiency
+*** Fast startup (no build framework overhead) [goal 2]
+*** Fast HTML generation [goal 2]
+** Portability
+*** Cross-platform execution (incl. Apple Silicon) [goal 3]
+*** Environment equivalence [goal 3]
+** Usability
+*** Actionable error guidance [goal 4]
+*** Zero-config start [goal 5]
+*** Headless CI mode [derived]
+*** Modern documentation UI [derived]
+*** LLM-managed configuration [derived]
+*** Minimal repository footprint [derived]
+*** Clean uninstallation [derived]
+** Functional Suitability
+*** Correct output generation [derived]
+*** Faithful Confluence publishing [derived]
+*** LLM-structured document access [derived]
+** Maintainability
+*** Script-first extensibility [derived]
+*** No compilation step required [derived]
+*** LLM-friendly codebase [derived]
+** Reliability
+*** Idempotent publishing [derived]
+*** Stable test suite [derived]
 ** Compatibility
-*** v3 config backward compatibility
+*** v3 config backward compatibility [derived]
 @endmindmap
 ----
 
@@ -64,133 +65,191 @@ Each leaf maps to one or more quality scenarios below.
 
 The following scenarios are the **evaluation framework** for all architecture decisions (Section 09).
 Each ADR must state which quality scenarios it supports or compromises.
+Each scenario is written in the six-part quality-attribute-scenario form (Source, Stimulus, Artifact, Environment, Response, Response Measure) and annotated with the Chapter 1.2 top goal it concretises, or marked `derived`.
 
 ==== Carried forward from v3
 
-[options="header",cols="1,1,2,2,2"]
+[options="header",cols="1,1,1,2,1,1,2,2"]
 |===
-|ID |Quality Goal |Stimulus |Response |Metric
+|ID |Goal |Source |Stimulus |Artifact |Environment |Response |Response Measure
 
 |QS-1
-|Extensibility
-|A contributor wants to add a new export feature (e.g., export to Notion).
-|They create one Groovy script in `scripts/` and register it. No build system knowledge required.
-|No compilation step needed. The new task appears in `./dtcw tasks` output.
+|derived (extensibility)
+|Contributor
+|Wants to add a new export feature (e.g., export to Notion).
+|`scripts/` directory
+|Development
+|They create one Groovy script and register it; no build-system knowledge required.
+|No compilation step needed; the new task appears in `./dtcw tasks` output.
 
 |QS-2
-|Portability
-|A user runs `./dtcw docker generateHTML` on the same project that previously built with `./dtcw local generateHTML`.
-|Docker execution produces the same HTML output as the local execution.
-|Output files are byte-identical (excluding timestamps in HTML meta tags).
+|goal 3 (cross-platform)
+|User
+|Runs `./dtcw docker generateHTML` on a project previously built with `./dtcw local generateHTML`.
+|Generated HTML
+|Docker vs. local
+|Docker execution produces the same HTML output as local execution.
+|Output files byte-identical (excluding timestamps in HTML meta tags).
 
 |QS-3
-|Usability
-|A developer with no prior docToolchain experience clones a project containing `dtcw` and AsciiDoc sources.
-|They run `./dtcw local generateHTML` and get rendered documentation.
-|Time from first command to viewing HTML output is under 5 minutes (including automatic Java and docToolchain installation).
+|goal 5 (ease of adoption)
+|New developer
+|Clones a project containing `dtcw` and AsciiDoc sources and runs `./dtcw local generateHTML`.
+|`dtcw` + AsciiDoc sources
+|Fresh workstation
+|They get rendered documentation, including automatic Java and docToolchain installation.
+|Time from first command to viewing HTML under 5 minutes.
 
 |QS-4
-|Reliability
-|Confluence publishing is triggered twice for the same documentation without changes.
-|The second run detects that page content has not changed (via MD5 hash comparison) and skips the update.
-|No new Confluence page versions are created. Existing attachments and labels are preserved.
+|derived (reliability)
+|Author / CI
+|Triggers Confluence publishing twice for unchanged documentation.
+|Confluence pages
+|Network, Confluence reachable
+|The second run detects unchanged content (MD5 hash) and skips the update.
+|No new page versions created; attachments and labels preserved.
 
 |QS-5
-|Maintainability
-|A CI/CD pipeline runs `./dtcw local generateHTML` in a container without a TTY.
-|The `dtcw` wrapper detects headless mode (`DTC_HEADLESS=true`) and suppresses all interactive prompts. The build completes unattended.
-|Exit code 0 on success; non-zero on failure. No hanging processes waiting for user input.
+|derived (headless CI)
+|CI/CD pipeline
+|Runs `./dtcw local generateHTML` in a container without a TTY.
+|`dtcw` wrapper
+|Headless CI (no TTY)
+|`dtcw` detects headless mode (`DTC_HEADLESS=true`) and suppresses prompts; build completes unattended.
+|Exit code 0 on success, non-zero on failure; no process hangs awaiting input.
 
 |QS-6
-|Usability (Installability)
-|A user runs `./dtcw local generateHTML` on a machine without a JDK.
-|The `dtcw` wrapper detects the missing JDK, downloads and installs it locally, and proceeds with the build.
-|No manual Java installation required. The installed JDK is reused for subsequent runs.
+|goal 5 (ease of adoption)
+|User
+|Runs `./dtcw local generateHTML` on a machine without a JDK.
+|`dtcw` wrapper
+|Workstation without JDK
+|`dtcw` detects the missing JDK, downloads and installs it locally, then proceeds.
+|No manual Java install; installed JDK reused on later runs.
 
 |QS-7
-|Reliability
-|The test suite is executed.
-|All tests pass. Environment-dependent tests are skipped gracefully.
-|Zero test failures. Test execution completes in under 15 seconds.
+|derived (stable test suite)
+|Developer / CI
+|Executes the test suite.
+|Spock / BATS test suites
+|Local or CI
+|All tests pass; environment-dependent tests skip gracefully.
+|Zero test failures; execution under 15 seconds.
 
 |QS-8
-|Performance Efficiency
-|A user runs `./dtcw local generateHTML` on a typical documentation project (~50 AsciiDoc pages with PlantUML diagrams).
+|goal 2 (performance)
+|User
+|Runs `./dtcw local generateHTML` on ~50 AsciiDoc pages with PlantUML diagrams.
+|Document generation pipeline
+|Local, docToolchain installed
 |HTML output is generated.
 |Generation completes in under 20 seconds.
 |===
 
 ==== New for v4
 
-[options="header",cols="1,1,2,2,2"]
+[options="header",cols="1,1,1,2,1,1,2,2"]
 |===
-|ID |Quality Goal |Stimulus |Response |Metric
+|ID |Goal |Source |Stimulus |Artifact |Environment |Response |Response Measure
 
 |QS-9
-|Performance (Startup + Throughput)
-|A user runs `./dtcw local generateHTML` for the second time (docToolchain already installed).
-|The task starts executing immediately without build framework initialization. AsciiDoc processing completes without unnecessary overhead from dependency resolution, daemon negotiation, or build graph computation.
-|Startup (command to first AsciiDoc processing): under 3 seconds. End-to-end time for 50 pages: under 10 seconds. No Gradle daemon, no dependency resolution, no build graph overhead.
+|goal 2 (performance)
+|User
+|Runs `./dtcw local generateHTML` a second time (docToolchain already installed).
+|`dtcw` + Groovy scripts
+|Local, warm install
+|Task starts immediately, with no build-framework init, dependency resolution, daemon negotiation, or build-graph computation.
+|Startup under 3 seconds; end-to-end for 50 pages under 10 seconds.
 
 |QS-10
-|Portability (Apple Silicon)
-|A user runs `./dtcw local generateSite` on a Mac with Apple Silicon (M1/M2/M3/M4).
-|The site generation completes without errors or platform-specific workarounds.
-|No JNI/native library issues. Same output as on x86_64.
+|goal 3 (cross-platform)
+|User
+|Runs `./dtcw local generateSite` on Apple Silicon (M1/M2/M3/M4).
+|Custom site generator (`MicrositeBaker`)
+|macOS ARM64
+|Site generation completes without errors or platform-specific workarounds.
+|No JNI/native-library issues; same output as on x86_64.
 
 |QS-11
-|Maintainability (Script-first)
-|A contributor wants to fix a bug in the Confluence publishing logic.
-|They edit a Groovy script directly and re-run. No compilation, no JAR rebuild, no Shadow JAR assembly.
-|Change-to-test cycle is under 5 seconds. No `./gradlew core:jar` step required.
+|derived (script-first)
+|Contributor
+|Wants to fix a bug in the Confluence publishing logic.
+|Groovy scripts
+|Development
+|They edit a Groovy script directly and re-run; no compilation, no JAR rebuild.
+|Change-to-test cycle under 5 seconds; no `./gradlew core:jar` step.
 
 |QS-12
-|LLM Friendliness
-|An LLM (via daCLI MCP server) needs to read, navigate, and modify docToolchain-generated documentation.
-|daCLI provides structured access via 10 MCP tools: `get_structure`, `get_section`, `search`, `update_section`, etc. Documentation follows Semantic Anchor conventions for machine-readable navigation.
-|LLM can locate and read any section with at most 3 tool calls. Token usage is under 10% of what reading full files would require.
+|derived (LLM friendliness)
+|LLM agent (via daCLI)
+|Needs to read, navigate, and modify generated documentation.
+|daCLI MCP server (10 tools)
+|MCP over stdio
+|daCLI provides structured access; docs follow Semantic Anchor conventions.
+|Any section located with at most 3 tool calls; token usage under 10% of full-file reading.
 
 |QS-13
-|Usability (Modern UI)
-|A reader opens a docToolchain-generated microsite in a browser.
-|The site has a modern, clean design with responsive layout, dark mode support, fast full-text search, and clear navigation.
-|Visual appearance is comparable to modern documentation sites (Starlight, Nextra, Diataxis). Page load time under 1 second.
+|derived (modern UI)
+|Reader
+|Opens a docToolchain-generated microsite in a browser.
+|Generated microsite
+|Modern browser
+|The site shows responsive layout, dark mode, fast full-text search, and clear navigation.
+|Visual quality comparable to Starlight/Nextra/Diataxis; page load under 1 second.
 
 |QS-14
-|Compatibility (v3 config)
-|A user upgrades from docToolchain v3 to v4 without changing their `docToolchainConfig.groovy`.
-|The v4 `dtcw` reads the existing configuration file and executes all previously configured tasks.
-|Zero config file changes required for basic usage (generateHTML, generatePDF, publishToConfluence). Deprecated features emit warnings but do not fail.
+|derived (v3 compatibility)
+|Upgrading user
+|Moves from v3 to v4 without changing `docToolchainConfig.groovy`.
+|`docToolchainConfig.groovy`
+|Existing v3 project
+|v4 `dtcw` reads the existing config and runs all previously configured tasks.
+|Zero config changes for basic usage; deprecated features warn but do not fail.
 
 |QS-15
-|Usability (LLM-Managed Configuration)
-|A user asks an LLM to configure Confluence publishing for their project.
-|The LLM reads the current `docToolchainConfig.groovy`, understands which values deviate from defaults, and adds only the necessary settings (API URL, space key, credentials reference). The config file stays minimal — no commented-out defaults, no boilerplate.
-|The config file contains only explicit deviations from defaults. Defaults are defined in code and documented in a machine-readable reference. An LLM can read the config, explain what is configured, and modify it correctly — without hallucinating defaults or duplicating them.
+|derived (LLM-managed config)
+|User via LLM
+|Asks an LLM to configure Confluence publishing.
+|`docToolchainConfig.groovy`
+|LLM editing session
+|The LLM adds only the necessary deviating settings; the config stays minimal.
+|Config contains only explicit deviations from defaults; LLM reads, explains, and edits it correctly without hallucinating defaults.
 
 |QS-16
-|Privacy (No Implicit Cloud Processing)
-|A user runs `./dtcw generateHTML` with diagrams in their AsciiDoc sources. The `diagramServer` is set to `https://kroki.io/` (external service).
-|docToolchain prints a clear warning: "Diagramm-Quelltexte werden an kroki.io gesendet. Für lokale Verarbeitung setze `diagramServer = 'docker'`." The user must explicitly acknowledge or configure an external server. No data leaves the machine without the user's informed consent.
-|Zero external API calls unless the user has explicitly configured an external `diagramServer` URL. Default should be `docker` (local) or no diagrams rendered. External URLs trigger a warning on every run.
+|goal 1 (no implicit cloud processing)
+|User
+|Runs `./dtcw generateHTML` with diagrams while `diagramServer` is set to `https://kroki.io/`.
+|Diagram rendering (asciidoctor-diagram)
+|External service configured
+|docToolchain prints a clear warning ("Diagramm-Quelltexte werden an kroki.io gesendet. Für lokale Verarbeitung setze `diagramServer = 'docker'`.") requiring informed consent.
+|Zero external API calls unless an external `diagramServer` URL is explicitly set; default is `docker` (local); external URLs warn on every run.
 
 |QS-17
-|Usability (Actionable Guidance)
-|A task fails due to a problem the user can fix (locked file, missing config, wrong credentials, unreachable API, missing tool).
-|Instead of a stack trace or cryptic error message, docToolchain tells the user **what to do next**: which file to close, which config key to set, which command to run. The message is a concrete action, not a diagnosis.
-|Every error message that a user can resolve contains a remediation step. Example: "Die PDF-Datei build/pdf/manual.pdf ist gesperrt. Bitte schließe sie in deinem PDF-Viewer und führe den Befehl erneut aus." Zero stack traces for user-recoverable errors. Stack traces only for bugs (unexpected exceptions).
+|goal 4 (actionable error guidance)
+|User
+|Hits a fixable failure (locked file, missing config, wrong credentials, unreachable API, missing tool).
+|`DtcException` + top-level handler
+|Any environment
+|docToolchain prints what to do next — which file to close, which config to set, which command to run — not a diagnosis.
+|Every user-recoverable error carries a remediation step; zero stack traces except for bugs (exit code 99).
 
 |QS-18
-|Usability (Minimal Repository Footprint)
-|A user adds docToolchain to an existing project repository.
-|Only `dtcw` (wrapper script) and `docToolchainConfig.groovy` (configuration) are committed to the project repository. All other files — JARs, scripts, templates, Java runtime — are installed externally in `$HOME/.doctoolchain/`.
-|Exactly 2 files added to the project repo (plus optional `dtcw.ps1`/`dtcw.bat` for Windows). The `build/` output directory is in `.gitignore`. No Gradle wrapper, no `build.gradle`, no `settings.gradle`, no `libs/` in the project.
+|derived (minimal repo footprint)
+|User
+|Adds docToolchain to an existing project repository.
+|Project repository
+|Any
+|Only `dtcw` and `docToolchainConfig.groovy` are committed; JARs, scripts, templates, and the Java runtime install under `$HOME/.doctoolchain/`.
+|Exactly 2 files added (plus optional `dtcw.ps1`/`dtcw.bat`); `build/` git-ignored; no Gradle wrapper, no `build.gradle`.
 
 |QS-19
-|Usability (Clean Uninstallation)
-|A user decides to remove docToolchain from their system.
-|Deleting `$HOME/.doctoolchain/` removes the entire installation — binaries, JARs, Java runtime, caches. docToolchain does not modify shell profiles (`.bashrc`, `.zshrc`, `.profile`), does not register system services, and does not write to directories outside `$HOME/.doctoolchain/`.
-|Zero side effects after `rm -rf $HOME/.doctoolchain/`. No orphaned entries in PATH, no lingering environment variables, no modified shell config files. The project's `dtcw` and config file remain inert without the installation.
+|derived (clean uninstallation)
+|User
+|Decides to remove docToolchain from their system.
+|`$HOME/.doctoolchain/` installation
+|Any
+|Deleting `$HOME/.doctoolchain/` removes binaries, JARs, Java runtime, and caches; no shell profiles or services were touched.
+|Zero side effects after `rm -rf $HOME/.doctoolchain/`; no orphaned PATH entries, env vars, or modified shell configs.
 |===
 
 // Source: v4 architecture requirements (Gradle removal, jBake replacement, LLM-native strategy),

--- a/src/docs/arc42/chapters/11_technical_risks.adoc
+++ b/src/docs/arc42/chapters/11_technical_risks.adoc
@@ -14,50 +14,71 @@ ifndef::imagesdir[:imagesdir: ../../images]
 == Risks and Technical Debts
 
 Risks for v4 differ significantly from v3. Some v3 risks are resolved (Gradle coupling, jBake maintenance), while new risks arise from the migration.
+This chapter separates *Risks* (uncertain future events) from *Technical Debt* (known compromises already in the code). Risks carry stable IDs (`R-NNN`) referenced from the ADR Consequences in <<section-design-decisions>>.
 
-[options="header",cols="1,1,3,2"]
+=== 11.1 Risks
+
+Probability and Impact are rated Low / Medium / High. Priority is derived from the two (High×High ⇒ HIGH, etc.) and matches the original assessment. Rows are ordered by Priority, highest first. Each Mitigation references a Chapter 8 concept or a quality scenario.
+
+[options="header",cols="1,2,1,1,1,3"]
 |===
-|Priority |Risk / Debt |Description |Affected Quality Scenarios
+|R-ID |Risk |Probability |Impact |Priority |Mitigation
 
+|R-001
+|*Custom site generator maturity.* Replacing jBake with the custom Groovy SSG (`MicrositeBaker`) is a significant effort. Feature parity must cover content types, metadata, pagination, tags, menu generation, search, and theming. Risk of incomplete implementation or regressions (QS-13, QS-14, QS-8).
+|High
+|High
+|HIGH
+|Ch8 *Test* concept — integration tests for `generateSite`; QS-8/QS-13 acceptance scenarios gate releases (ADR-4).
+
+|R-002
+|*v3 migration path.* Users upgrading from v3 lose Gradle-based workflows. Projects using `./gradlew` directly, custom Gradle tasks, or Gradle plugins will break (QS-14, QS-3).
+|High
+|High
+|HIGH
+|Ch8 *Error Handling* concept — deprecation warnings via `DtcException` guidance; migration guide (ADR-3).
+
+|R-003
+|*Script loading and classpath conflicts.* Without Gradle's dependency resolution, scripts depending on external libraries (POI, jsoup, HttpClient) need a reliable classpath; class conflicts between scripts are possible (QS-1, QS-4).
+|Medium
+|High
+|MEDIUM
+|`lib/` directory with pinned JARs (ADR-7); Ch8 *Test* concept verifies script loading.
+
+|R-004
+|*Residual inconsistent error handling.* Carried forward from v3. Until every script adopts `DtcException`, a mix of exceptions and `println` remains, weakening actionable guidance (QS-4, QS-3, QS-17).
+|Medium
+|Medium
+|MEDIUM
+|Ch8 *Error Handling* concept (ADR-8) — `DtcException` hierarchy; tracked rollout across scripts. QS-17.
+
+|R-005
+|*Release-time dependency resolution.* AsciiDoctor is externalized (ADR-6); ~30 JARs ship in `lib/` (ADR-7). The release process must resolve transitive dependencies and a tampered/vulnerable JAR (T-006) would reach every user (QS-4).
+|Low
+|Medium
 |LOW
-|Dependency management at release time
-|AsciiDoctor is externalized (ADR-6), remaining ~30 JARs are shipped in `lib/` (ADR-7). The release process must resolve transitive dependencies and package them. This is a one-time build step, not a runtime concern.
-|QS-4 (Determinism)
+|Ch8 *Security* concept — Trivy CVE scan of `lib/*.jar` (ADR-11); pinned, reproducible resolution (ADR-7).
+|===
 
-|HIGH
-|Custom site generator maturity
-|Replacing jBake with a custom Groovy SSG is a significant development effort. Feature parity must cover: content types, metadata, pagination, tags, menu generation, search, theme support. Risk of incomplete implementation or regressions.
-|QS-13 (Modern UI), QS-14 (v3 compatibility), QS-8 (Performance)
+=== 11.2 Technical Debt
 
-|HIGH
-|v3 migration path
-|Users upgrading from v3 to v4 lose Gradle-based workflows. Projects using `./gradlew` directly, custom Gradle tasks, or Gradle plugins will break. A clear migration guide and deprecation warnings are needed.
-|QS-14 (v3 compatibility), QS-3 (Usability)
+Each item names the specific Chapter 5 building block it burdens.
 
-|MEDIUM
-|Script loading and classpath
-|Without Gradle's dependency resolution, scripts that depend on external libraries (Apache POI for Excel, jsoup for HTML parsing, HttpClient for REST) need a reliable classpath mechanism. Class conflicts between scripts are possible.
-|QS-1 (Extensibility), QS-4 (Reliability)
+[options="header",cols="2,1,3"]
+|===
+|Technical Debt |Affected Building Block (Ch5) |Description
 
-|MEDIUM
-|Inconsistent error handling
-|Carried forward from v3. With Gradle removed, `GradleException` is no longer available. A new error handling strategy is needed (ADR-TBD-3). Scripts currently use a mix of exceptions and println.
-|QS-4 (Reliability), QS-3 (Usability)
-
-|MEDIUM
 |Confluence API dual client
-|Carried forward from v3 (ADR-TBD-1). Two client implementations must be maintained. Atlassian is deprecating v1 for Cloud.
-|QS-4 (Reliability), QS-1 (Extensibility)
+|Atlassian Integration scripts (`publishToConfluence.groovy`, `ConfluenceClientV1`/`ConfluenceClientV2`)
+|Two parallel client implementations (V1 Server, V2 Cloud) must be maintained. Atlassian is deprecating v1 for Cloud. Decision deferred to ADR-TBD-1.
 
-|LOW
 |No Jira Cloud client
-|Carried forward from v3 (ADR-TBD-2). Only `JiraServerClient` exists.
-|QS-2 (Portability)
+|Atlassian Integration scripts (`exportJiraIssues.groovy`, `JiraServerClient`)
+|Only `JiraServerClient` exists; Jira Cloud is not natively supported. Burdens QS-2. Decision deferred to ADR-TBD-2.
 
-|LOW
-|Windows-only features
-|EA, PPT, Visio export remain Windows-only (VBScript). No fallback on other platforms.
-|QS-2 (Portability)
+|Windows-only export features
+|External Tool Export scripts (`exportEA.groovy`, `exportPPT.groovy`, `exportVisio.groovy`)
+|EA, PowerPoint, and Visio export remain Windows-only (VBScript COM automation). No fallback on Linux/macOS, burdening cross-platform portability (QS-2).
 |===
 
 === Resolved v3 Risks

--- a/src/docs/arc42/chapters/12_glossary.adoc
+++ b/src/docs/arc42/chapters/12_glossary.adoc
@@ -51,7 +51,7 @@ ifndef::imagesdir[:imagesdir: ../../images]
 |Software Development Kit Manager. A tool for managing parallel versions of multiple SDKs. One of three supported installation methods for docToolchain (`sdk install doctoolchain`).
 
 |ADR
-|Architecture Decision Record. A lightweight document capturing a significant architecture decision, its context, rationale, and consequences. Follows Nygard's format. Stored in `src/docs/050_ADRs/`.
+|Architecture Decision Record. A lightweight document capturing a significant architecture decision, its context, rationale, and consequences. Follows Nygard's format. Stored in `src/docs/arc42/adrs/` and included from Chapter 9.
 
 |Confluence Storage Format
 |The XHTML-based markup language used by Atlassian Confluence to store page content. Includes Confluence-specific macros (`<ac:structured-macro>`) and resource identifiers (`<ri:attachment>`). The `HtmlTransformer` converts AsciiDoctor HTML5 output into this format.


### PR DESCRIPTION
Fixes #1620 — the arc42 documentation gaps found in the audit, against the Semantic Contracts in `CLAUDE.md`. 22 files (12 chapters touched + 13 ADRs). Validated to merge cleanly onto the current main-4.x (base #1616, no upstream arc42 drift since).

### Judgment calls made (noted for review)
- **Top-5 quality goals (Ch1.2)**: privacy/no-cloud, fast startup, cross-platform, actionable errors, ease of adoption. The other ~7 moved into the Ch10 quality tree marked "derived".
- **Bausteinsicht / LLM-Prompts**: treated as design-time companions (no runtime scenario); daCLI keeps its runtime scenario S3.
- **Diagram default**: `docker` everywhere (privacy-preserving); fixed the `kroki.io` contradiction in ADR-9.
- **IDs**: threats `T-001..T-006`, risks `R-001..R-005`.

### HIGH
- **Ch8** restructured to lead with the 5 baseline concepts: 8.1 Threat Model (STRIDE, T-001..T-006 each mapped to a building block), 8.2 Security (each mitigation references the T-IDs it closes), 8.3 Test, 8.4 Observability, 8.5 Error Handling (lifts ADR-08). Existing concepts kept as 8.6+.
- **Ch11** split into `11.1 Risks` (`R-ID | Risk | Probability | Impact | Priority | Mitigation`, ordered by priority) and `11.2 Technical Debt` (each item names its Ch5 block).
- **Ch9** gains an in-document ADR index table (`ADR | Title | Status`, all 13).
- **Ch1.2→Ch4** traceability: all 5 top goals mapped to a named approach.
- **Ch6** adds an error/recovery scenario (publishToConfluence 401 / locked file → DtcException → exit code), tied to ADR-08 / Ch8.5 / QS-17.
- **ADR consequences** now reference the relevant `R-NNN` (adr-03→R-002/R-003, adr-04→R-001, adr-07→R-005/R-003/T-006, adr-08 mitigates R-004).

### MED
- Ch3/Ch5 external-system boundary reconciled (added EA, Git, Structurizr + rendering backend to the L1 view; note that L1 is a container zoom).
- Ch5 L1 table gains an `Interface` column.
- Ch10 scenarios converted to six-part form (Source/Stimulus/Artifact/Environment/Response/Response Measure), literal measures preserved, each annotated "goal N" or "derived".
- ADR-01 and ADR-07 get the 3-point Pugh Matrix.
- ADR statuses normalized to Nygard (`Accepted (inferred)` for carried-forward decisions).

### LOW
- Stale ADR paths corrected (`050_ADRs` → `arc42/adrs`).
- Orphaned `027_arc42/dtcw.puml` referenced from Ch5 as the wrapper function map (not deleted).

> Authored via subagent under my spec; I validated the base/merge and sanity-checked the structural pieces. Per request, the architecture content is yours to review — especially the top-5 goal selection and the STRIDE threat model.

Closes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)