### PR TITLE
Inject GoatCounter analytics into the v4 site publish

### DIFF
--- a/.ci.sh
+++ b/.ci.sh
@@ -164,6 +164,9 @@ publish_doc () {
       mkdir -p v4.0.x
       rm -rf v4.0.x/*
       cp -Rf "${BUILD_DIR}"/build/microsite/output/* v4.0.x/.
+      # inject deploy-only analytics into the published copy (no-op when
+      # GOATCOUNTER_ENDPOINT is unset, e.g. on forks)
+      "${BUILD_DIR}"/scripts/injectAnalytics.sh v4.0.x
     fi
 
     #add, commit and push files


### PR DESCRIPTION
GoatCounter analytics weren't carried over to the v4 website.

The injection mechanism (`scripts/injectAnalytics.sh` + `scripts/goatcounter-snippet.html`) exists, and `.ci.sh` called it — but only in the `v2.0.x` publish block. The `main-4.x` block copied the microsite to `v4.0.x` without calling it, so the published v4 site had no analytics snippet.

This mirrors the v2.0.x block by calling `injectAnalytics.sh v4.0.x`.

## Notes
- No-op when `GOATCOUNTER_ENDPOINT` (a GitHub Actions secret) is unset → forks and local builds stay analytics-free.
- The snippet is SRI-pinned and injected at deploy time only — never baked into the jBake templates or a user's microsite.

## Test plan
- [x] `injectAnalytics.sh` no-op when `GOATCOUNTER_ENDPOINT` unset
- [x] injects the snippet before `</head>` when the endpoint is set
- [x] `shellcheck scripts/injectAnalytics.sh` clean

Closes #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)