### PR TITLE
Hotfix: unbreak main-4.x build (arc42 dtcw.puml include + ADR-4 table)

### DIFF
--- a/src/docs/arc42/adrs/adr-04-replace-jbake.adoc
+++ b/src/docs/arc42/adrs/adr-04-replace-jbake.adoc
@@ -45,14 +45,10 @@
 |Gradle independence
 |–1 (needs custom runner or jBake Java API)
 |+1 (pure Groovy script)
-|0
-|–1
-|+1
-|+1
 
 |**Total**
 |**0**
-|**+6**
+|**+5**
 |===
 
 NOTE: With AsciiDoctor externalized (ADR-6), the custom SSG only needs to handle template rendering and content model — AsciiDoc processing is done by the external AsciiDoctor CLI. This reduces the estimated effort to ~300 LOC of new code. Metadata parsing (~50 LOC) and menu builder (167 LOC) are reused from v3's `generateSite.gradle` and `menu.groovy`.

--- a/src/docs/arc42/chapters/05_building_block_view.adoc
+++ b/src/docs/arc42/chapters/05_building_block_view.adoc
@@ -145,13 +145,6 @@ The scripts are organized into functional groups. Unlike v3 (where scripts were 
 |Loads `docToolchainConfig.groovy` via Groovy `ConfigSlurper`. Provides config access to all scripts.
 |===
 
-[[wrapper-function-map]]
-==== Wrapper Function Map
-
-The Wrapper Layer is itself a structured set of shell functions. The following map of `dtcw` functions documents its internal decomposition — environment detection, installation, and command building — and is the component view of the Wrapper building block referenced in the Level-1 table above.
-
-plantuml::../../027_arc42/dtcw.puml[format=png,id=dtcw-function-map]
-
 === Level 3: Whitebox Atlassian Integration
 
 The Atlassian integration scripts contain the richest business logic. In v3 this was the compiled `core/` module; in v4 it returns to script form.

--- a/src/docs/arc42/chapters/05_building_block_view.adoc
+++ b/src/docs/arc42/chapters/05_building_block_view.adoc
@@ -84,7 +84,7 @@ Contained Building Blocks::
 
 |Wrapper Layer
 |Cross-platform CLI entry point. Constructs classpath from `lib/` directory (or resolves via Grape). Manages Java installation. Invokes Groovy scripts directly — no build framework intermediary. Detects execution environment (local/Docker/SDKMAN).
-|CLI: `./dtcw [env] <task> [args]`; differentiated exit codes (0/1/2/3/99, ADR-8). See the wrapper function map in <<wrapper-function-map>>.
+|CLI: `./dtcw [env] <task> [args]`; differentiated exit codes (0/1/2/3/99, ADR-8).
 |`dtcw`, `dtcw.ps1`, `dtcw.bat`
 
 |Groovy Scripts


### PR DESCRIPTION
## Urgent — main-4.x CI has been red since 2026-06-20

The arc42 restructure (#1623) broke `generateSite` in CI. Because the deploy (and the GoatCounter injection from #1625) only runs after a successful build, **no gh-pages update has happened since 2026-06-20 22:03** — which is why GoatCounter still doesn't appear on the v4 site. The secret is set (v2.0.x is injected); the build just never reached the publish step.

### Root cause (both from #1623)
1. **FATAL** — `src/docs/arc42/chapters/05_building_block_view.adoc:153`: `plantuml::../../027_arc42/dtcw.puml[]`. The microsite renders from `build/microsite/tmp/site/`, where `027_arc42/` is not copied, so asciidoctor-diagram throws `SystemCallError (ENOENT)` and aborts under `set -o errexit`:
   ```
   No such file or directory - .../build/microsite/tmp/site/027_arc42/dtcw.puml
   ```
   The file was just a bare list of `dtcw` function names (not a real diagram), so the "Wrapper Function Map" subsection is removed. `027_arc42/dtcw.puml` goes back to orphaned status (tracked in #1630).
2. **SEVERE** — `adrs/adr-04-replace-jbake.adoc`: the Pugh matrix had 4 orphan cells after "Gradle independence" (cell count not a multiple of the 3-column grid) → `dropping cells from incomplete row`. Removed the orphans; corrected the Custom-SSG total `+6` → `+5`.

### Verification
`./dtcw4 local generateSite` now completes locally — "rendered 133 content pages", no fatal error. Remaining SEVEREs in the log (`mmdc` missing, some `ppt` include paths) are pre-existing and non-fatal.

Once merged, the next main-4.x build will publish the v4 site again and inject GoatCounter.

Refs #1630, #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)