### PR TITLE
Restore per-task source link in the docs (lost in v3→v4)

### DIFF
--- a/src/docs/015_tasks/03_task_copyThemes.adoc
+++ b/src/docs/015_tasks/03_task_copyThemes.adoc
@@ -47,3 +47,8 @@ After copying, the task reminds you to set the matching config property (`micros
 
 * xref:03_task_generateSite.adoc[generateSite] — uses the `jBakeTheme`
 * xref:03_task_generatePDF.adoc[generatePDF] — uses the `pdfTheme`
+
+=== Source
+
+:param_source_file: scripts/copyThemes.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_downloadTemplate.adoc
+++ b/src/docs/015_tasks/03_task_downloadTemplate.adoc
@@ -37,3 +37,8 @@ export DTC_HEADLESS=true
 
 * https://arc42.org/[Arc42]
 * https://req42.de/[Req42]
+
+=== Source
+
+:param_source_file: scripts/downloadTemplate.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_exportExcel.adoc
+++ b/src/docs/015_tasks/03_task_exportExcel.adoc
@@ -39,3 +39,8 @@ As CSV:
 === Further Reading
 
 * https://github.com/uniqueck/asciidoctorj-office-extension[asciidoctorj-office-extension] — an alternative approach
+
+=== Source
+
+:param_source_file: scripts/exportExcel.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_exportPPT.adoc
+++ b/src/docs/015_tasks/03_task_exportPPT.adoc
@@ -25,3 +25,8 @@ Use https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regio
 === Further Reading
 
 * https://rdmueller.github.io/PPT-as-asciidoc-editor/[Do More with Slides]
+
+=== Source
+
+:param_source_file: scripts/exportPPT.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_generateCICD.adoc
+++ b/src/docs/015_tasks/03_task_generateCICD.adoc
@@ -63,3 +63,8 @@ The generated pipeline:
 * xref:03_task_generateSite.adoc[generateSite] — the task the pipeline runs
 * https://docs.github.com/en/pages[GitHub Pages]
 * https://docs.gitlab.com/ee/user/project/pages/[GitLab Pages]
+
+=== Source
+
+:param_source_file: scripts/generateCICD.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_generateHTML.adoc
+++ b/src/docs/015_tasks/03_task_generateHTML.adoc
@@ -65,3 +65,8 @@ NOTE: If Graphviz is not installed, add `!pragma layout smetana` as the first li
 
 * https://rdmueller.github.io/single-file-html/[Single-file HTML]
 * https://rdmueller.github.io/plantuml-without-graphviz/[PlantUML without Graphviz]
+
+=== Source
+
+:param_source_file: scripts/generateHTML.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_generatePDF.adoc
+++ b/src/docs/015_tasks/03_task_generatePDF.adoc
@@ -46,3 +46,8 @@ To customize colors, fonts, headers, and footers, create a `custom-theme.yml` fi
 
 * https://docs.asciidoctor.org/pdf-converter/latest/theme/[AsciidoctorJ PDF Theming Guide]
 * https://rdmueller.github.io/pdf-output/[Beyond HTML — PDF Output]
+
+=== Source
+
+:param_source_file: scripts/generatePDF.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_generateSite.adoc
+++ b/src/docs/015_tasks/03_task_generateSite.adoc
@@ -141,3 +141,8 @@ The microsite includes a search input field that can be linked to an external se
 === CI/CD
 
 Set `DTC_HEADLESS=true` in automated builds to skip interactive prompts (e.g., theme installation).
+
+=== Source
+
+:param_source_file: scripts/generateSite.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_installBausteinsicht.adoc
+++ b/src/docs/015_tasks/03_task_installBausteinsicht.adoc
@@ -48,3 +48,8 @@ If neither file exists, the task installs the tool and skips the hint (it never 
 
 * https://doctoolchain.org/Bausteinsicht/[Bausteinsicht documentation]
 * https://github.com/docToolchain/Bausteinsicht[Bausteinsicht on GitHub]
+
+=== Source
+
+:param_source_file: scripts/installBausteinsicht.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_installDacli.adoc
+++ b/src/docs/015_tasks/03_task_installDacli.adoc
@@ -59,3 +59,8 @@ If neither file exists, the hint is skipped and no agent file is created.
 * https://doctoolchain.org/dacli[daCLI documentation]
 * https://github.com/docToolchain/dacli[daCLI on GitHub]
 * https://docs.astral.sh/uv/[uv — the Python tool installer]
+
+=== Source
+
+:param_source_file: scripts/installDacli.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_lintAsciiDoc.adoc
+++ b/src/docs/015_tasks/03_task_lintAsciiDoc.adoc
@@ -66,3 +66,8 @@ lintAsciiDoc = [
 
 * https://doctoolchain.org/asciidoc-linter[AsciiDoc Linter documentation]
 * https://github.com/docToolchain/asciidoc-linter[AsciiDoc Linter on GitHub]
+
+=== Source
+
+:param_source_file: scripts/lintAsciiDoc.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_publishToConfluence.adoc
+++ b/src/docs/015_tasks/03_task_publishToConfluence.adoc
@@ -291,3 +291,8 @@ The following style definitions are Confluence-compatible, and will enable the u
 .yellow-background{background-color:#fafa00}
 ----
 
+
+=== Source
+
+:param_source_file: scripts/publishToConfluence.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/_viewTaskSource.adoc
+++ b/src/docs/015_tasks/_viewTaskSource.adoc
@@ -1,0 +1,14 @@
+// Reusable snippet: link to a task's source on GitHub.
+// Usage in a task doc:
+//   === Source
+//   :param_source_file: scripts/<task>.groovy
+//   include::_viewTaskSource.adoc[]
+
+ifndef::param_source_file[#please specify :param_source_file#]
+
+ifdef::param_source_file[]
+View the source of this task: https://github.com/docToolchain/docToolchain/blob/main-4.x/{param_source_file}[`{param_source_file}` on GitHub^]
+endif::[]
+
+// clear the parameter so it doesn't leak into the next include
+:param_source_file!:


### PR DESCRIPTION
v3 task docs had a **Source** section linking to each task's source (via a shared `_viewTaskSource.adoc`). v4 dropped it. This restores it.

## What this does
- Adds `src/docs/015_tasks/_viewTaskSource.adoc` — a reusable snippet that renders a GitHub link to a task's source on `main-4.x`.
- Adds a `=== Source` section to all 12 v4 task docs, each pointing to `scripts/<task>.groovy`.

## Link-only, by design
The v3 version *also* embedded the source inline via `include::{projectRootDir}/<file>[]` inside a `[source]----…----` block. That's deliberately omitted because:
- An embedded script containing a line that is exactly `----` would prematurely close the listing block (broken render / SEVERE).
- Including a file outside the rendered doc tree is exactly the failure mode that just broke the microsite build (the `027_arc42/dtcw.puml` include, fixed in #1633).

A GitHub link is robust and is what was requested. If you want the collapsible inline source back too, I can add it guarded by `ifdef::projectRootDir[]` — say the word.

## Verified
`./dtcw4 local generateSite` completes (134 pages); all 12 task pages render the link (`View the source of this task` → `…/blob/main-4.x/scripts/<task>.groovy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)