### PR TITLE
Fix navbar logo contrast on the dark navbar

### DIFF
--- a/src/site/assets/css/theme-v4.css
+++ b/src/site/assets/css/theme-v4.css
@@ -14,6 +14,18 @@ body {
     background: #064e3b;
 }
 
+/* The logo is a light document with a black chain — both vanish on the dark
+   navbar. Sit it on a light rounded "chip" so it keeps its colours and
+   contrasts well against the dark green background. */
+.td-navbar .navbar-logo {
+    background: #ffffff;
+    border-radius: 6px;
+    padding: 3px 5px;
+    display: inline-flex;
+    align-items: center;
+    margin-right: 0.5rem;
+}
+
 .td-navbar .nav-link:hover,
 .td-navbar .nav-link:focus {
     background: rgba(255, 255, 255, 0.12);


### PR DESCRIPTION
The logo had poor contrast against the dark emerald navbar (`#064e3b`). The logo is a light-blue document with a **black** chain — the black part in particular disappears on the dark background.

## Fix
Sit the logo on a light rounded "chip" (`.td-navbar .navbar-logo { background: #fff; border-radius: 6px; padding: 3px 5px; }`). This keeps the logo's real brand colours and gives it strong contrast on any navbar — better than flattening it to a white silhouette (`brightness(0) invert(1)`), which would lose the document/chain detail.

CSS-only change in `theme-v4.css`. Higher specificity than the existing inline `span.navbar-logo` padding rule, so it overrides cleanly.

## Verified
`./dtcw4 local generateSite` completes (134 pages); the rule lands in the published `theme-v4.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)