### PR TITLE
fix(scripts): harden v4 task-script robustness (#1627)

### DIFF
--- a/scripts/copyThemes.groovy
+++ b/scripts/copyThemes.groovy
@@ -55,7 +55,7 @@ switch (whatArg) {
             System.exit(1)
         }
         def pdfThemeDir = config.pdfThemeDir ?: './src/docs/pdfTheme'
-        def target = pdfThemeDir.startsWith('/') ? new File(pdfThemeDir) : new File(docDir, pdfThemeDir)
+        def target = new File(pdfThemeDir).isAbsolute() ? new File(pdfThemeDir) : new File(docDir, pdfThemeDir)
         copyDir(source, target)
         println "pdfTheme copied into ${target.canonicalPath}"
         if (!config.pdfThemeDir) {

--- a/scripts/downloadTemplate.groovy
+++ b/scripts/downloadTemplate.groovy
@@ -106,9 +106,17 @@ outputDir.mkdirs()
 
 def zipFile = new File(outputDir, 'template.zip')
 println "Downloading ${url}"
-def conn = new URL(url).openConnection()
+def conn = (HttpURLConnection) new URL(url).openConnection()
 conn.connectTimeout = 15000
 conn.readTimeout = 60000
+conn.instanceFollowRedirects = true
+int status = conn.responseCode
+if (status != HttpURLConnection.HTTP_OK) {
+    throw new RuntimeException(
+        "Download failed: HTTP ${status} for ${url}\n" +
+        "The server did not return a template archive. Check the template name and " +
+        "language — an unknown language yields a 404 whose HTML error page is not a valid zip.")
+}
 conn.inputStream.withCloseable { zipFile.bytes = it.bytes }
 
 // Unzip

--- a/scripts/exportExcel.groovy
+++ b/scripts/exportExcel.groovy
@@ -59,7 +59,10 @@ def exportSheet = { sheet, evaluator, targetFileName ->
             def width = []
             numCols = row.lastCellNum
             numCols.times { width << sheet.getColumnWidth((int) it) }
-            width = width.collect { Math.round(100 * it / width.sum()) }
+            // Guard against an empty/zero-width header row: a sum of 0 would
+            // divide-by-zero. Fall back to equal column weights.
+            def widthSum = (width.sum() ?: 0) as int
+            width = widthSum > 0 ? width.collect { Math.round(100 * it / widthSum) } : width.collect { 1 }
             targetFileAD.append('[options="header",cols="' + width.join(',') + '"]' + nl, 'UTF-8')
             targetFileAD.append('|===' + nl, 'UTF-8')
         }

--- a/scripts/lib/DtcConfig.groovy
+++ b/scripts/lib/DtcConfig.groovy
@@ -115,11 +115,22 @@ imageDirs  = []
      * Returns null if not found.
      */
     Object get(String propertyPath) {
-        def property = configObject.get(propertyPath)
-        if (!property) {
-            property = configObject.flatten().get(propertyPath)
+        // Prefer an exact leaf match so falsy values (false, 0, '', []) are
+        // returned as themselves rather than being mistaken for "missing"
+        // by Groovy-truth. flatten() exposes dotted leaf keys like
+        // 'confluence.api'; a first-level key like 'confluence' is not a leaf
+        // and falls through to the subtree lookup below.
+        def flat = configObject.flatten()
+        if (flat.containsKey(propertyPath)) {
+            return flat.get(propertyPath)
         }
-        return property
+        def nested = configObject.get(propertyPath)
+        // ConfigObject auto-vivifies a missing key to an empty ConfigObject;
+        // treat that as genuinely absent rather than returning an empty tree.
+        if (nested instanceof ConfigObject && nested.isEmpty()) {
+            return null
+        }
+        return nested
     }
 
     /**
@@ -128,9 +139,13 @@ imageDirs  = []
      * Returns empty map if path not found.
      */
     Map getSubTree(String propertyPath) {
+        // Match on a literal dotted prefix and strip it with substring, not a
+        // regex: propertyPath may contain regex metacharacters, and requiring
+        // the trailing '.' avoids matching sibling keys like 'confluenceX'.
+        def prefix = propertyPath + "."
         return configObject.flatten().inject([:]) { result, key, value ->
-            if (key.startsWith(propertyPath)) {
-                result.put(key.replaceFirst("${propertyPath}.", ""), value)
+            if (key.startsWith(prefix)) {
+                result.put(key.substring(prefix.length()), value)
             }
             return result
         }

--- a/scripts/lib/DtcRestClient.groovy
+++ b/scripts/lib/DtcRestClient.groovy
@@ -33,7 +33,7 @@ class DtcRequestFailedException extends RuntimeException {
         String reasonLog = reason != null ? reason.message : "<none>"
         String possibleSolution
 
-        switch (response.code) {
+        switch (response?.code) {
             case 401:
                 possibleSolution = "please check your credentials in config file or passed parameters"
                 break


### PR DESCRIPTION
Addresses the **contained, individually-tested** findings from the round-2 code review (#1627). Each fix was verified against the real `lib/` jars, and `generateHTML` still runs end-to-end (exit 0).

## What changed
| Finding | Fix | Risk |
|---|---|---|
| `DtcConfig.get()` Groovy-truth smell | match the exact flattened leaf via `containsKey`; empty subtree → `null` | none — scalar + subtree behaviour verified identical |
| `getSubTree()` uses path as unescaped regex | strip dotted prefix with `substring`, require trailing `.` | none |
| `DtcRestClient` `switch(response.code)` NPE on null | `response?.code` | none |
| `downloadTemplate` slurps a 404 HTML body into `template.zip` | check HTTP status before unzip | none — additive guard |
| `copyThemes` `startsWith('/')` is POSIX-only | `new File(path).isAbsolute()` | none |
| `exportExcel` div-by-zero on zero-width header row | equal-weight fallback | none |

## Important note on the HIGH finding
The reported `DtcConfig.get()` *"returns null instead of the real value"* bug **does not reproduce** — the existing `flatten()` fallback recovers every falsy value (verified: `false`, `0`, `''`, `[]` all return correctly). This PR still hardens the method (clarity + the genuine empty-subtree edge) **without changing observed behaviour**.

## Deliberately deferred (larger / higher-risk — kept in #1627)
- Systemic `System.exit()` → `DtcException` migration across ~16 scripts (the future-proof keystone; needs its own carefully-tested PR so a working v4 isn't destabilised).
- `generateSite` converter-subprocess stdout drain + `bash -c` interpolation (touches the render path).
- `exportExcel` per-file error isolation (converge on the `exportPPT` model).

Closes none yet; #1627 stays open for the deferred systemic items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)