### PR TITLE
test(v4): PR render smoke-test + DtcConfig regression spec

### DIFF
--- a/.github/workflows/smoke-test-v4.yaml
+++ b/.github/workflows/smoke-test-v4.yaml
@@ -1,0 +1,71 @@
+name: Smoke Test (v4 render)
+
+# Renders documentation from THIS PR's sources on every pull request, so a
+# fatal render break (e.g. an `include::`/`plantuml::` to a file outside the
+# rendered tree) is caught at PR time — not after merge on the gh-pages deploy.
+# Unlike `.ci.sh create_doc` (which only renders on the main-4.x branch and uses
+# the installed release), this builds lib/ from the PR and runs the PR's scripts,
+# so it guards both doc changes and script/engine changes.
+
+on:
+  pull_request:
+    branches: [ main-4.x ]
+    paths:
+      - 'core/**'
+      - 'scripts/**'
+      - 'src/**'
+      - 'build.gradle'
+      - 'libs.versions.toml'
+      - '.github/workflows/smoke-test-v4.yaml'
+      - '!**/README.*'
+  workflow_dispatch: {}
+
+jobs:
+  smoke:
+    name: Render smoke test (generateHTML + generateSite)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install diagram tools
+        run: sudo apt-get install -y graphviz
+
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: adopt
+          java-version: 17
+          cache: 'gradle'
+
+      - name: Build v4 lib/ from this PR's sources
+        run: |
+          set -euo pipefail
+          ./gradlew packageLibs --no-daemon
+          mkdir -p lib
+          cp build/lib/*.jar lib/
+          echo "lib/ contains $(ls lib/*.jar | wc -l) JARs"
+
+      - name: generateHTML smoke (minimal fixture)
+        run: |
+          set -euo pipefail
+          mkdir -p .smoke/src/docs
+          cat > .smoke/docToolchainConfig.groovy <<'EOF'
+          outputPath = 'build'
+          inputPath  = 'src/docs'
+          inputFiles = [[file: 'smoke.adoc', formats: ['html']]]
+          imageDirs  = []
+          EOF
+          printf '= Smoke Test\n\nHello *world*.\n\n== Section\n\nSome text.\n' > .smoke/src/docs/smoke.adoc
+          java -cp "lib/*" -DdocDir="$PWD/.smoke" groovy.ui.GroovyMain scripts/generateHTML.groovy
+          test -s .smoke/build/html5/smoke.html
+
+      - name: generateSite smoke (this repo's docs)
+        # Renders the full microsite from the PR's docs through the microsite
+        # tmp-tree copy — the path that exposes file-outside-tree includes. A
+        # fatal AsciidoctorCoreException aborts the build and fails the job;
+        # non-fatal warnings (missing diagram tools, optional includes) do not.
+        run: |
+          set -euo pipefail
+          java -cp "lib/*" -DdocDir="$PWD" groovy.ui.GroovyMain scripts/generateSite.groovy
+          test -s build/microsite/output/index.html

--- a/core/src/test/groovy/org/docToolchain/configuration/DtcConfigSpec.groovy
+++ b/core/src/test/groovy/org/docToolchain/configuration/DtcConfigSpec.groovy
@@ -1,0 +1,102 @@
+package org.docToolchain.configuration
+
+import spock.lang.Specification
+
+/**
+ * Locks in the behaviour of the v4 config helper {@code scripts/lib/DtcConfig.groovy}.
+ *
+ * DtcConfig is a script-loaded class (no package, no compilation) — it is parsed at
+ * runtime by every v4 task exactly as done here via GroovyClassLoader, so this spec
+ * exercises it the same way production does. Regression guard for the get()/getSubTree()
+ * hardening (PR #1638): falsy config values must be returned as themselves, and a
+ * subtree lookup must not leak sibling keys that merely share a prefix.
+ */
+class DtcConfigSpec extends Specification {
+
+    File tmpDir
+    def dtcConfig
+
+    private static File locateDtcConfigScript() {
+        ['../scripts/lib/DtcConfig.groovy', 'scripts/lib/DtcConfig.groovy', '../../scripts/lib/DtcConfig.groovy']
+            .collect { new File(it) }
+            .find { it.exists() }
+    }
+
+    private def loadConfig(String text) {
+        new File(tmpDir, 'docToolchainConfig.groovy').setText(text, 'UTF-8')
+        def scriptFile = locateDtcConfigScript()
+        assert scriptFile != null : 'could not locate scripts/lib/DtcConfig.groovy relative to the test working dir'
+        def cls = new GroovyClassLoader(getClass().classLoader).parseClass(scriptFile)
+        return cls.load(tmpDir.absolutePath, 'docToolchainConfig.groovy')
+    }
+
+    def setup() {
+        tmpDir = File.createTempDir()
+        dtcConfig = loadConfig('''
+            failOnError = false
+            port = 0
+            emptyText = ''
+            emptyList = []
+            confluence {
+                api = 'https://example.com'
+                enabled = false
+                retries = 0
+            }
+        ''')
+    }
+
+    def cleanup() {
+        tmpDir?.deleteDir()
+    }
+
+    def "get() returns falsy leaf values as themselves, not as 'missing'"() {
+        expect:
+            dtcConfig.get(path) == expected
+
+        where:
+            path                 || expected
+            'failOnError'        || false
+            'port'               || 0
+            'emptyText'          || ''
+            'confluence.enabled' || false
+            'confluence.retries' || 0
+            'confluence.api'     || 'https://example.com'
+    }
+
+    def "get() returns an empty-list leaf as an empty list"() {
+        expect:
+            dtcConfig.get('emptyList') == []
+    }
+
+    def "get() returns null for a missing key"() {
+        expect:
+            dtcConfig.get('does.not.exist') == null
+    }
+
+    def "get() returns the full subtree for a first-level key"() {
+        when:
+            def subtree = dtcConfig.get('confluence')
+
+        then:
+            subtree instanceof Map
+            subtree.api == 'https://example.com'
+            subtree.enabled == false
+            subtree.retries == 0
+    }
+
+    def "getSubTree() flattens a subtree and strips the dotted prefix"() {
+        expect:
+            dtcConfig.getSubTree('confluence') == [api: 'https://example.com', enabled: false, retries: 0]
+    }
+
+    def "getSubTree() does not leak sibling keys that share a prefix"() {
+        given: 'two top-level keys, one a prefix of the other'
+            def cfg = loadConfig('''
+                confluence { api = 'a' }
+                confluenceExtra { api = 'b' }
+            ''')
+
+        expect: 'only the exact-prefix subtree is returned'
+            cfg.getSubTree('confluence') == [api: 'a']
+    }
+}


### PR DESCRIPTION
Two **additive** test improvements from the round-2 test assessment. Neither touches runtime code, so a working v4 is unaffected.

## 1. PR render smoke-test (`.github/workflows/smoke-test-v4.yaml`)
Renders documentation from **this PR's sources** on every PR to `main-4.x`:
- `packageLibs` → build `lib/` from the PR (so it also catches **script/engine** breakage, not just docs)
- `generateHTML` on a minimal fixture
- `generateSite` on the repo's own docs — through the microsite tmp-tree copy, the path that exposes file-outside-tree includes

A fatal `AsciidoctorCoreException` aborts the build and fails the job; non-fatal warnings (missing diagram tools, optional includes) don't.

**Why:** `.ci.sh create_doc` renders only on the `main-4.x` branch (post-merge) and against the *installed* release, so PRs were never render-checked — that's how #1623's bad `plantuml::` include reached the live site. 

**Verified locally:** good docs → `generateHTML`+`generateSite` exit 0; a bad `plantuml::../outside/missing.puml` → exit 1 (the exact #1623 `ENOENT` class). The gate works.

## 2. `DtcConfigSpec` (regression guard for #1638)
The v4 config helper `scripts/lib/DtcConfig.groovy` had **no test** (`ConfigServiceSpec` covers the old v3 `ConfigService`). This spec loads it via `GroovyClassLoader` exactly as v4 tasks do and locks in:
- falsy leaf values (`false`, `0`, `''`, `[]`) returned as themselves
- empty subtree → `null`; first-level key → its subtree
- `getSubTree()` does not leak sibling keys sharing a prefix (`confluenceExtra` vs `confluence`)

Data-driven (`where:`) — the suite had none before. **11 tests, all green under `core:test` (BUILD SUCCESSFUL).**

Relates to the test-assessment items #1 (PR smoke-test) and #2 (DtcConfig spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)