### PR TITLE
docs(arc42): architecture-as-code spike for Ch5 — Bausteinsicht model + ADR-15 (#1641)

### DIFF
--- a/src/docs/arc42/adrs/adr-15-architecture-as-code-diagrams.adoc
+++ b/src/docs/arc42/adrs/adr-15-architecture-as-code-diagrams.adoc
@@ -1,0 +1,58 @@
+=== ADR-15: Structural Diagrams as Architecture-as-Code (Bausteinsicht model, PlantUML render)
+
+* **Status**: Accepted (for v4) — **model authored; inline C4-PlantUML kept as the rendered artifact; export wiring deferred**. The spike (#1641) confirmed that Bausteinsicht has **no PlantUML exporter**, so the hoped-for `model → PlantUML → microsite` round-trip does not exist yet. The Level-1 model lives at `src/docs/arc42/models/level1-container.jsonc`; it is authored against the published Bausteinsicht JSON schema and the `online-shop` reference example and parses as JSONC, but has not yet been validated by the Bausteinsicht binary (not available in the docs build environment) — a `bausteinsicht sync` validation pass is the open follow-up.
+* **Context**: The arc42 Chapter 5 building-block views are hand-written C4-PlantUML embedded directly in `05_building_block_view.adoc` (`level1-container-v4`, `level3-atlassian-v4`). They satisfy the Semantic Contract (PlantUML + C4-PlantUML stdlib `!include <C4/...>`), but every structural change means editing PlantUML by hand and there is no single, tool-readable source of truth. `Bausteinsicht` — our own Go architecture-as-code tool (JSONC model, bidirectional draw.io sync) — exists precisely for this, and the cross-repo relationship states *"Bausteinsicht generates architecture diagrams consumable by docToolchain."* We do not currently eat our own dog food for docToolchain's own architecture docs.
++
+The spike evaluated consuming a Bausteinsicht export as an AsciiDoc include. Finding: Bausteinsicht's structural exports are **draw.io (native)**, **PNG/SVG via the draw.io CLI**, and **Mermaid C4** — there is **no PlantUML output**. Mermaid is explicitly forbidden by the Semantic Contract ("Diagrams are PlantUML, not Mermaid"). PNG/SVG requires the draw.io CLI (a headless Electron binary; cf. Bausteinsicht issue #385) and replaces a text-rendered diagram with a committed binary, breaking the docs-as-code "diagram is reviewable text" property and the existing Kroki/`asciidoctor-diagram` render path (ADR-9, ADR-6 revised).
+
+* **Decision**: Maintain the **structural (C4 building-block) views as a versioned Bausteinsicht JSONC model** — the single, machine-readable, LLM-editable source of truth — **but keep the inline C4-PlantUML block as the rendered artifact** in the microsite for now. Start with the Level-1 container view; keep Level-3 (`level3-atlassian-v4`) inline-only until the model proves itself. Wire an automatic render path only once a clean text-based export exists (a Bausteinsicht PlantUML exporter — to be requested upstream — or an accepted draw.io-CLI image step). Until then, the model and the inline PlantUML are kept in sync by hand (tracked as technical debt in <<section-technical-risks>>).
+
+* **Alternatives considered**:
+
+[cols="3,1,1,1", options="header"]
+|===
+|Criterion |A: Hand-written PlantUML only (status quo) |B: Model + PNG via draw.io CLI |C: Model as SoT + PlantUML render (chosen)
+
+|Machine-readable single source of truth for structure (QS-12)
+|–1
+|+1
+|+1
+
+|Author can edit diagrams via draw.io (no PlantUML skill needed)
+|–1
+|+1
+|+1
+
+|Renders as reviewable text, no binary artifact in git (docs-as-code)
+|+1
+|–1
+|+1
+
+|Semantic-Contract render output (PlantUML + C4, not Mermaid/binary) (QS-13)
+|+1
+|0
+|+1
+
+|Build simplicity — no draw.io CLI / Electron dependency
+|+1
+|–1
+|+1
+
+|No manual model↔render synchronisation
+|+1
+|+1
+|–1
+
+|**Total**
+|**+2**
+|**+1**
+|**+4**
+|===
+
+* **Quality Tradeoffs**:
+** Supports **QS-12 (LLM friendliness)**: the architecture is now a machine-readable JSONC model an LLM or tool can read, diff, and edit — not prose embedded in PlantUML.
+** Supports **QS-13 (modern UI / rendered output)**: the microsite keeps rendering hand-tuned C4-PlantUML through the existing pipeline, so diagram quality and layout are unchanged (no auto-layout regression, no binary image).
+** Preserves the docs-as-code property: the rendered diagram stays reviewable text in git; no Electron/draw.io-CLI dependency enters the build.
+** Cost — **manual synchronisation**: until an export path is wired, the JSONC model and the inline PlantUML must be edited together, and they can drift. This is the one criterion option C loses on and is recorded as technical debt (below).
+
+* **Consequences**: `src/docs/arc42/models/level1-container.jsonc` becomes the source of truth for the Level-1 container view; `05_building_block_view.adoc` carries a NOTE linking the inline `level1-container-v4` block to that model and to this ADR. The decision creates a **technical-debt** item — *"Hand-synchronised Bausteinsicht model and inline PlantUML"* — recorded in <<section-technical-risks>> (11.2) against the Chapter 5 building-block view documentation; it is **explicitly accepted as low-cost** (one Level-1 view, changed rarely) rather than tracked as an `R-NNN` risk. The debt retires when either (a) Bausteinsicht ships a PlantUML/C4-PlantUML exporter — to be requested upstream — and `generateSite` consumes it as a generated include kept inside the rendered doc tree (a file-outside-tree include is fatal), or (b) the team accepts a draw.io-CLI PNG/SVG step in the build. Level-3 stays inline-only; rolling the model out to Level-3 is a follow-up gated on the same export path. Open follow-up: validate the model with `bausteinsicht sync` once the binary is available in the build environment, and add the `bausteinsicht` ecosystem tool note in Chapter 5 (already present).

--- a/src/docs/arc42/chapters/05_building_block_view.adoc
+++ b/src/docs/arc42/chapters/05_building_block_view.adoc
@@ -66,6 +66,11 @@ Rel(llm, prompts, "Uses prompts")
 @enduml
 ----
 
+[TIP]
+====
+*Source of truth (architecture-as-code).* This Level-1 view is also modelled as a versioned Bausteinsicht JSONC model at `models/level1-container.jsonc`. That model is the machine-readable source of truth; the C4-PlantUML above mirrors it and remains the *rendered* artifact (Bausteinsicht has no PlantUML exporter yet — see ADR-15). When you change the structure, edit **both** until an export path is wired (tracked as technical debt in <<section-technical-risks>>).
+====
+
 Motivation::
 v4 simplifies from four layers (Wrapper -> Gradle -> Script Plugins -> Core Module) to two layers (Wrapper -> Scripts). The Gradle orchestration layer and the compiled Core Module are eliminated. Business logic returns to scripts. Companion tools (daCLI, Bausteinsicht, LLM-Prompts) handle LLM integration as an ecosystem rather than embedding it into docToolchain itself.
 

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -80,6 +80,10 @@ Statuses follow Nygard values (Proposed / Accepted / Superseded / Deprecated). `
 |Task Discovery via `// @task` Marker
 |Accepted (inferred)
 
+|ADR-15
+|Structural Diagrams as Architecture-as-Code (Bausteinsicht model, PlantUML render)
+|Accepted (for v4) — export wiring deferred
+
 |ADR-TBD-1
 |Confluence API Version Strategy
 |Proposed
@@ -116,6 +120,8 @@ include::../adrs/adr-12-tasks-as-groovy-scripts.adoc[]
 include::../adrs/adr-13-dtcw-delegation.adoc[]
 
 include::../adrs/adr-14-task-discovery.adoc[]
+
+include::../adrs/adr-15-architecture-as-code-diagrams.adoc[]
 
 include::../adrs/adr-tbd-1-confluence-api.adoc[]
 

--- a/src/docs/arc42/chapters/11_technical_risks.adoc
+++ b/src/docs/arc42/chapters/11_technical_risks.adoc
@@ -108,6 +108,10 @@ Each item names the specific Chapter 5 building block it burdens.
 |No v4 Windows wrapper path
 |Wrapper Layer (`dtcw.ps1`, `dtcw.bat`)
 |The v4 `GroovyMain` execution path exists only in the Bash `dtcw`; `dtcw.ps1`/`dtcw.bat` carry no v4 path. Windows v4 works only via WSL2 today (see Chapter 1 goal scope). Burdens cross-platform portability (QS-2, Goal #3).
+
+|Hand-synchronised Bausteinsicht model and inline PlantUML
+|Building Block View (Ch5) — Level-1 container view (`05_building_block_view.adoc`, `models/level1-container.jsonc`)
+|The Level-1 view exists twice: as a Bausteinsicht JSONC model (source of truth) and as inline C4-PlantUML (rendered artifact). Because Bausteinsicht has no PlantUML exporter (ADR-15), the two are kept in sync by hand and can drift. Explicitly accepted as low-cost (one view, changed rarely); retires when a text-based export path is wired (ADR-15).
 |===
 
 === Resolved v3 Risks

--- a/src/docs/arc42/models/level1-container.jsonc
+++ b/src/docs/arc42/models/level1-container.jsonc
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schema/bausteinsicht.schema.json",
+
+  // Bausteinsicht architecture-as-code model for docToolchain's own arc42
+  // Chapter 5 "Level 1: Whitebox Overall System" view (dogfooding, issue #1641).
+  //
+  // SOURCE OF TRUTH: this file is the single, tool-readable source for the
+  // Level-1 container view. The C4-PlantUML block `level1-container-v4` in
+  // ../chapters/05_building_block_view.adoc mirrors this model and is, for now,
+  // still the *rendered* artifact in the microsite — Bausteinsicht has no
+  // PlantUML exporter (its structural exports are draw.io / PNG-SVG via the
+  // draw.io CLI / Mermaid C4), so the model→PlantUML→microsite round-trip the
+  // spike hoped for does not yet exist. See ADR-15. Until an export path is
+  // wired, keep this model and the inline PlantUML in sync by hand (Ch11 debt).
+
+  // Specification: element kinds and relationship types. The order of element
+  // kinds drives the layered auto-layout (first kind = top row, last = bottom).
+  // Order chosen to read top-to-bottom: actors → docToolchain → ecosystem →
+  // external systems.
+  "specification": {
+    "elements": {
+      "actor": {
+        "notation": "Actor",
+        "description": "A person or role that interacts with docToolchain"
+      },
+      "system": {
+        "notation": "Software System",
+        "description": "A top-level software system",
+        "container": true
+      },
+      "container": {
+        "notation": "Container",
+        "description": "A deployable / runnable unit inside a system",
+        "container": true
+      },
+      "external_system": {
+        "notation": "External System",
+        "description": "A third-party system or tool outside docToolchain's control"
+      }
+    },
+    "relationships": {
+      "uses": {
+        "notation": "uses"
+      }
+    }
+  },
+
+  // Architecture model: elements and their hierarchy.
+  "model": {
+    // Actors
+    "author": {
+      "kind": "actor",
+      "title": "Documentation Author",
+      "description": "Writes AsciiDoc and runs dtcw commands"
+    },
+    "llm": {
+      "kind": "actor",
+      "title": "LLM Agent",
+      "description": "Navigates and modifies docs via MCP"
+    },
+
+    // The system under description
+    "doctoolchain": {
+      "kind": "system",
+      "title": "docToolchain v4",
+      "description": "Docs-as-code toolchain: direct Groovy execution, no Gradle at runtime",
+      "children": {
+        "wrapper": {
+          "kind": "container",
+          "title": "Wrapper Layer",
+          "technology": "Bash / PowerShell / Batch",
+          "description": "dtcw, dtcw.ps1, dtcw.bat — CLI entry point, classpath construction, Java/tool installation"
+        },
+        "scripts": {
+          "kind": "container",
+          "title": "Groovy Scripts",
+          "technology": "Groovy",
+          "description": "scripts/*.groovy — all task logic: generation, publishing, export, site building"
+        }
+      }
+    },
+
+    // Companion-tool ecosystem (separate repos). daCLI is exercised at runtime;
+    // Bausteinsicht and LLM-Prompts are design-time only — shown for context.
+    "ecosystem": {
+      "kind": "system",
+      "title": "Ecosystem",
+      "description": "Companion tools that handle LLM integration outside docToolchain core",
+      "children": {
+        "dacli": {
+          "kind": "container",
+          "title": "daCLI",
+          "technology": "Python / FastMCP",
+          "description": "MCP server for structured document access (10 tools). Runtime."
+        },
+        "bausteinsicht": {
+          "kind": "container",
+          "title": "Bausteinsicht",
+          "technology": "Go / Cobra",
+          "description": "Architecture-as-code: JSONC model + draw.io sync. Design-time only."
+        },
+        "prompts": {
+          "kind": "container",
+          "title": "LLM-Prompts",
+          "technology": "AsciiDoc",
+          "description": "Reusable prompts for arc42 documentation. Design-time only."
+        }
+      }
+    },
+
+    // External systems reached at runtime by the Groovy Scripts.
+    "asciidoctor": {
+      "kind": "external_system",
+      "title": "AsciiDoctor",
+      "technology": "AsciidoctorJ (embedded)",
+      "description": "Document processor; renders AsciiDoc (ADR-6 revised)"
+    },
+    "kroki": {
+      "kind": "external_system",
+      "title": "Diagram Backend",
+      "technology": "Kroki-compatible server",
+      "description": "Renders diagrams; local Docker by default (ADR-9)"
+    },
+    "confluence": {
+      "kind": "external_system",
+      "title": "Atlassian Confluence",
+      "technology": "REST API v1/v2",
+      "description": "Target for published pages"
+    },
+    "jira": {
+      "kind": "external_system",
+      "title": "Atlassian Jira",
+      "technology": "REST API v3",
+      "description": "Source of exported issues"
+    },
+    "ea": {
+      "kind": "external_system",
+      "title": "Enterprise Architect",
+      "technology": "COM (Windows)",
+      "description": "Source of extracted diagrams"
+    },
+    "git": {
+      "kind": "external_system",
+      "title": "Git Repository",
+      "technology": "Local CLI",
+      "description": "Source of changelog / contributor metadata"
+    },
+    "structurizr": {
+      "kind": "external_system",
+      "title": "Structurizr",
+      "technology": "DSL files",
+      "description": "Source of rendered architecture models"
+    }
+  },
+
+  // Relationships (dot notation for nested elements). Mirrors the Rel() lines
+  // of the level1-container-v4 C4-PlantUML block.
+  "relationships": [
+    { "from": "author", "to": "doctoolchain.wrapper", "label": "Invokes tasks via CLI", "kind": "uses" },
+    { "from": "doctoolchain.wrapper", "to": "doctoolchain.scripts", "label": "Invokes Groovy scripts via java/groovy runtime", "kind": "uses" },
+
+    { "from": "doctoolchain.scripts", "to": "asciidoctor", "label": "Renders AsciiDoc", "kind": "uses" },
+    { "from": "doctoolchain.scripts", "to": "kroki", "label": "Renders diagrams", "kind": "uses" },
+    { "from": "doctoolchain.scripts", "to": "confluence", "label": "Publishes pages", "kind": "uses" },
+    { "from": "doctoolchain.scripts", "to": "jira", "label": "Exports issues", "kind": "uses" },
+    { "from": "doctoolchain.scripts", "to": "ea", "label": "Extracts diagrams", "kind": "uses" },
+    { "from": "doctoolchain.scripts", "to": "git", "label": "Reads changelog", "kind": "uses" },
+    { "from": "doctoolchain.scripts", "to": "structurizr", "label": "Renders models", "kind": "uses" },
+
+    { "from": "llm", "to": "ecosystem.dacli", "label": "MCP tool calls", "kind": "uses" },
+    { "from": "ecosystem.dacli", "to": "doctoolchain.scripts", "label": "Reads/writes doc sources", "kind": "uses" },
+    { "from": "llm", "to": "ecosystem.bausteinsicht", "label": "Reads/writes JSONC models", "kind": "uses" },
+    { "from": "llm", "to": "ecosystem.prompts", "label": "Uses prompts", "kind": "uses" }
+  ],
+
+  // Views: each view becomes a page in the draw.io diagram / a C4 export.
+  "views": {
+    "level1-container": {
+      "title": "Level 1: Whitebox Overall System",
+      "scope": "doctoolchain",
+      "include": [
+        "author",
+        "llm",
+        "doctoolchain.*",
+        "ecosystem.*",
+        "asciidoctor",
+        "kroki",
+        "confluence",
+        "jira",
+        "ea",
+        "git",
+        "structurizr"
+      ],
+      "layout": "layered",
+      "description": "The two internal building blocks (Wrapper, Groovy Scripts), the companion-tool ecosystem, and the external systems they call at runtime"
+    }
+  }
+}

--- a/test/pristine_environment.bats
+++ b/test/pristine_environment.bats
@@ -20,7 +20,7 @@ teardown() {
     # Version information is only shown when we start something
 
     # Show how to use it
-    assert_line --index  0 "dtcw ${DTCW_VERSION} - ##DTCW_GIT_HASH##"
+    assert_line --index  0 "dtcw ${DTCW_VERSION}"
     assert_line --index  1 "docToolchain ${DTC_VERSION}"
     assert_line --index  2 "OS/arch: $(uname -s)/$(uname -m)"
     assert_line --index  3 "Error: argument missing"
@@ -54,7 +54,7 @@ teardown() {
 
 @test "show version info and exit" {
     run -0 ./dtcw --version
-    assert_line --index 0 "dtcw ${DTCW_VERSION} - ##DTCW_GIT_HASH##"
+    assert_line --index 0 "dtcw ${DTCW_VERSION}"
     assert_line --index 1 "docToolchain ${DTC_VERSION}"
     assert_line --index 2 "OS/arch: $(uname -s)/$(uname -m)"
 
@@ -64,7 +64,7 @@ teardown() {
 
 @test "show version info - additional arguments are ignored" {
     run -0 ./dtcw --version tasks
-    assert_line --index 0 "dtcw ${DTCW_VERSION} - ##DTCW_GIT_HASH##"
+    assert_line --index 0 "dtcw ${DTCW_VERSION}"
     assert_line --index 1 "docToolchain ${DTC_VERSION}"
 
     refute_output "Error: argument missing"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -4,8 +4,11 @@
 # Helper functions used by more  than one test suite
 
 set_dtc_enviroment() {
-    # This will fail if the --version output changes
-    export DTCW_VERSION=$(./dtcw --version | sed -rn 's/dtcw (.*) - .*/\1/p')
+    # This will fail if the --version output changes.
+    # The wrapper hides the git hash when the '##DTCW_GIT_HASH##' placeholder is
+    # unsubstituted (dev/CI), printing just "dtcw <version>"; it appends " - <hash>"
+    # only on a released wrapper. Match the version token in both forms.
+    export DTCW_VERSION=$(./dtcw --version | sed -rn 's/dtcw ([^ ]+).*/\1/p')
     export DTC_VERSION=$(./dtcw --version | sed -rn 's/docToolchain (.*)$/\1/p')
     export DTC_ROOT="${HOME}/.doctoolchain"
     export DTC_HOME="${DTC_ROOT}/docToolchain-${DTC_VERSION}"


### PR DESCRIPTION
Spike for #1641 — "Maintain the arc42 Ch5 building-block diagrams with Bausteinsicht (architecture-as-code, dogfooding)".

## Key finding (the spike's headline)
The issue assumed Bausteinsicht *"exports PlantUML/PNG"* and that we could do a clean `model → PlantUML → microsite` round-trip. **It can't:** Bausteinsicht has **no PlantUML exporter**. Its structural exports are:

| Export | Usable for our docs? |
|---|---|
| draw.io (native) | No (not an AsciiDoc-renderable text diagram) |
| PNG / SVG via **draw.io CLI** | Only as a committed **binary image** + a heavy/fragile Electron dependency (cf. Bausteinsicht #385). Breaks the docs-as-code "diagram is reviewable text" property and bypasses the existing Kroki/`asciidoctor-diagram` path (ADR-9, ADR-6 revised). |
| Mermaid C4 | **Forbidden** by the Semantic Contract ("Diagrams are PlantUML, not Mermaid"). |

So this lands on the acceptance criterion's *"if it fights the toolchain, keep inline C4-PlantUML and record why"* branch.

## Decision (ADR-15)
Hybrid, scored highest in a 3-point Pugh matrix:
- **Keep the inline C4-PlantUML** as the *rendered* artifact (no binary in git, no draw.io CLI, unchanged microsite output).
- **Add a versioned Bausteinsicht JSONC model** as the machine-readable **source of truth** for the Level-1 container view — so we do eat our own dog food, and the structure becomes LLM/tool-editable (QS-12).

## What's in this PR
**arc42 spike (commit 1):**
- `src/docs/arc42/models/level1-container.jsonc` — schema-conformant Bausteinsicht model mirroring the `level1-container-v4` diagram (authored against the published schema + the `online-shop` reference example; JSONC parses, all 13 relationships resolve).
- `adrs/adr-15-architecture-as-code-diagrams.adoc` — ADR with Pugh matrix + quality tradeoffs + consequences.
- Ch9: ADR-15 added to the in-document ADR index and `include::`d.
- Ch5: a TIP linking the inline diagram to the model file as source of truth.
- Ch11.2: the manual model↔PlantUML sync recorded as **explicitly-accepted, low-cost technical debt** with a retirement trigger.

**CI fix (commit 2) — `fix(test): align dtcw --version bats assertions with the hidden git-hash banner`:**
The `Execute dtcw test suite` jobs (ubuntu + macos) were red on `main-4.x` already, independent of the docs change — tests 41/42 (`pristine_environment.bats`). Root cause: the wrapper now **hides** the unsubstituted `##DTCW_GIT_HASH##` placeholder and prints `dtcw <version>` (the banner fix from #1618), but two test artifacts still assumed the old `dtcw <version> - ##DTCW_GIT_HASH##` format — so `test_helper.bash`'s version regex matched nothing (empty `DTCW_VERSION`) and the assertions expected the old suffix. Fixed both to match the current banner. Behaviour-preserving test fix; the wrapper is unchanged.

## Scope / honesty notes
- **Level-1 only.** Level-3 (`level3-atlassian-v4`) stays inline-only until the model proves itself (per the issue's "decide" step).
- **Not yet tool-validated.** The Bausteinsicht binary and draw.io CLI aren't available in the docs build environment, so the model hasn't been through `bausteinsicht sync`. It parses as JSONC and follows the published schema; a validation pass is the tracked follow-up.
- **No new cross-tree `include::`** was added (the model is referenced as text, not included), so `generateSite` rendering is unaffected — the build-before-merge fatal-include lesson is respected.

## Retirement trigger for the debt
(a) request an upstream Bausteinsicht **PlantUML/C4 exporter** and have `generateSite` consume it as a generated include kept inside the doc tree, **or** (b) accept a draw.io-CLI PNG/SVG build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)