### PR TITLE
Jira: support non-standard server context paths (e.g. /jira/rest) — rebased #1538

### DIFF
--- a/changelog.adoc
+++ b/changelog.adoc
@@ -28,6 +28,7 @@ and this project tries to adhere to https://semver.org/spec/v2.0.0.html[Semantic
 === changed
 
 * https://github.com/docToolchain/docToolchain/pull/1511[exportEA: close application after export with ShutdownEA interface]
+* https://github.com/docToolchain/docToolchain/pull/1538[exportJiraIssues: support for onPrem Jira serving e.g. from /jira/rest than /rest (std)]
 
 == 3.4.2 - 2025-04-05
 

--- a/core/src/main/groovy/org/docToolchain/atlassian/jira/clients/JiraServerClient.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/jira/clients/JiraServerClient.groovy
@@ -52,8 +52,13 @@ class JiraServerClient extends JiraClient {
     }
 
     private static String buildOrigin(URI u) {
-        String port = (u.port > -1) ? ":${u.port}" : ""
-        return "${u.scheme}://${u.host}${port}"
+        // Prefer rawAuthority to preserve IPv6 brackets, userinfo, and port
+        String authority = u.rawAuthority
+        if (!authority) {
+            String port = (u.port > -1) ? ":${u.port}" : ""
+            authority = "${u.host}${port}"
+        }
+        return "${u.scheme}://${authority}"
     }
 
     String api(String route) {

--- a/core/src/main/groovy/org/docToolchain/atlassian/jira/clients/JiraServerClient.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/jira/clients/JiraServerClient.groovy
@@ -82,7 +82,6 @@ class JiraServerClient extends JiraClient {
 
     @Override
     def getIssuesByJql(String jql, String selectedFields) {
-        println("getIssuesByJql: " + apiAbs("/api/2/search"))
         URI uri = new URIBuilder(apiAbs("/api/2/search"))
             .addParameter("jql", jql)
             .addParameter("maxResults", "1000")

--- a/core/src/main/groovy/org/docToolchain/atlassian/jira/clients/JiraServerClient.groovy
+++ b/core/src/main/groovy/org/docToolchain/atlassian/jira/clients/JiraServerClient.groovy
@@ -1,24 +1,87 @@
 package org.docToolchain.atlassian.jira.clients
 
-import org.apache.hc.client5.http.classic.methods.HttpGet
-import org.apache.hc.core5.http.HttpRequest
-import org.apache.hc.core5.net.URIBuilder
 import org.docToolchain.configuration.ConfigService
+import java.net.URI
+import org.apache.hc.core5.net.URIBuilder
+import org.apache.hc.core5.http.HttpRequest
+import org.apache.hc.client5.http.classic.methods.HttpGet
 
 class JiraServerClient extends JiraClient {
 
-    protected final String API_PATH = "/rest"
+    /** Legacy relative path (always present) */
+    protected final String API_PATH
+
+    /** Absolute URL, only when jira.api includes scheme+host */
+    protected final String API_URL
 
     JiraServerClient(ConfigService configService) {
         super(configService)
+        String base = (configService.getConfigProperty("jira.api") as String)?.trim()
+        def built = buildApiFromBase(base)
+        this.API_PATH = built.apiPath
+        this.API_URL  = built.apiUrl
     }
 
+    private static Map<String, String> buildApiFromBase(String base) {
+        if (!base) return [apiPath: "/rest", apiUrl: null]
+
+        URI uri
+        try {
+            uri = URI.create(base.trim())
+        } catch (IllegalArgumentException ignored) {
+            String ctx = normalizeContext(base)
+            return [apiPath: (ctx ?: "") + "/rest", apiUrl: null]
+        }
+
+        String ctx = normalizeContext(uri.path ?: "")
+        if (uri.scheme == null) {
+            return [apiPath: (ctx ?: "") + "/rest", apiUrl: null]
+        }
+
+        String origin = buildOrigin(uri)
+        String path = (ctx ?: "") + "/rest"
+        return [apiPath: path, apiUrl: origin + path]
+    }
+
+    private static String normalizeContext(String ctx) {
+        if (!ctx) return ""
+        String c = ctx.trim()
+        if (!c.startsWith("/")) c = "/" + c
+        if (c.endsWith("/")) c = c[0..-2]
+        return c
+    }
+
+    private static String buildOrigin(URI u) {
+        String port = (u.port > -1) ? ":${u.port}" : ""
+        return "${u.scheme}://${u.host}${port}"
+    }
+
+    String api(String route) {
+        return joinPath(API_PATH, route)
+    }
+
+    String apiAbs(String route) {
+        String base = API_URL ?: API_PATH
+        return joinPath(base, route)
+    }
+
+    private static String joinPath(String base, String route) {
+        String b = (base ?: "").trim()
+        String r = (route ?: "").trim()
+        if (r && !r.startsWith("/")) r = "/" + r
+        if (b.endsWith("/")) b = b[0..-2]
+        return b + r
+    }
+
+    // ---------------- Original REST methods adapted ----------------
+
     @Override
-    def getIssuesByJql(String jql, String selectedFields){
-        URI uri = new URIBuilder(API_PATH + '/api/2/search')
-            .addParameter('jql', jql)
-            .addParameter('maxResults', '1000')
-            .addParameter('fields', selectedFields)
+    def getIssuesByJql(String jql, String selectedFields) {
+        println("getIssuesByJql: " + apiAbs("/api/2/search"))
+        URI uri = new URIBuilder(apiAbs("/api/2/search"))
+            .addParameter("jql", jql)
+            .addParameter("maxResults", "1000")
+            .addParameter("fields", selectedFields)
             .build()
         HttpRequest get = new HttpGet(uri)
         return callApiAndFailIfNot20x(get)
@@ -26,8 +89,8 @@ class JiraServerClient extends JiraClient {
 
     @Override
     def getSprintsByBoardAndState(String boardId, String sprintState) {
-        URI uri = new URIBuilder(API_PATH + "/agile/latest/board/${boardId}/sprint")
-            .addParameter('state', sprintState)
+        URI uri = new URIBuilder(apiAbs("/agile/latest/board/${boardId}/sprint"))
+            .addParameter("state", sprintState)
             .build()
         HttpRequest get = new HttpGet(uri)
         return callApiAndFailIfNot20x(get)
@@ -35,10 +98,10 @@ class JiraServerClient extends JiraClient {
 
     @Override
     def getIssuesForSprint(String boardId, Integer sprintId, String issueStatus, String ticketFields) {
-        URI uri = new URIBuilder(API_PATH + "/agile/latest/board/${boardId}/sprint/${sprintId}/issue")
-            .addParameter('jql', "status in (${issueStatus}) ORDER BY type DESC, status ASC")
-            .addParameter('maxResults', '1000')
-            .addParameter('fields', ticketFields)
+        URI uri = new URIBuilder(apiAbs("/agile/latest/board/${boardId}/sprint/${sprintId}/issue"))
+            .addParameter("jql", "status in (${issueStatus}) ORDER BY type DESC, status ASC")
+            .addParameter("maxResults", "1000")
+            .addParameter("fields", ticketFields)
             .build()
         HttpRequest get = new HttpGet(uri)
         return callApiAndFailIfNot20x(get)

--- a/src/docs/10_about/30_community.adoc
+++ b/src/docs/10_about/30_community.adoc
@@ -100,5 +100,6 @@ Please get in touch to update your entry or let us know if you have contributed 
 - https://github.com/jgenssler-GiN[Jakob Genßler]
 - https://github.com/tkleiber[Torsten Kleiber]
 - https://github.com/davidmpaz[David Paz]
+- https://github.com/stefan-baron[Stefan Baron]
 
 image::https://img.shields.io/github/contributors/doctoolchain/doctoolchain.svg[link=https://github.com/docToolchain/docToolchain/graphs/contributors]


### PR DESCRIPTION
## What this is

This is a **rebase of #1538** by @stefan-baron onto the current `ng` branch. The original PR had developed merge conflicts (in `changelog.adoc` / `30_community.adoc`) and had been sitting since Feb 2026, so as part of the backlog cleanup the commits were rebased onto `ng` and the conflicts resolved. **Stefan Baron's authorship on the original commits is preserved.**

Supersedes #1538.

## What it does

Adds support for Jira Server / Data Center instances that are served from a **non-standard context path** (e.g. `/jira/rest` instead of the standard `/rest`). `JiraServerClient` now derives the API base from the configured `jira.api` value:

- relative path or context prefix → builds `<context>/rest`
- full URL with scheme+host → builds an absolute API URL while preserving authority (IPv6 brackets, userinfo, port)

## Conflict resolution

- `src/docs/10_about/30_community.adoc` — kept all contributor entries (Torsten Kleiber, David Paz **and** Stefan Baron).
- `changelog.adoc` — auto-merged, entry for #1538 retained.

## Follow-up cleanup

The rebased code contained a leftover debug line in `getIssuesByJql` (`println("getIssuesByJql: ...")`), which has now been **removed** in a separate commit on top of the author's work.

## Status before merge

- [x] Remove/adjust the `println` debug statement
- [x] CI green (Java build, dtcw test suites on Linux/macOS/Windows, Spock, CodeQL, SonarCloud, ShellCheck)
- [ ] Quick functional check against a real Jira instance with a non-standard context path
- [ ] Mark ready for review (currently draft)

---

cc @stefan-baron — thank you for the original contribution! 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019r5o91RTxhTCGzquupaupv