### PR TITLE
docs(adr): ADRs for the docToolchain v4 Docker image (#1643)

### DIFF
--- a/src/docs/050_ADRs/ADR-3-v4-docker-image-build-model.adoc
+++ b/src/docs/050_ADRs/ADR-3-v4-docker-image-build-model.adoc
@@ -1,0 +1,87 @@
+:filename: 050_ADRs/ADR-3-v4-docker-image-build-model.adoc
+:icons: font
+:jbake-menu: ADRs
+:jbake-order: 3
+:jbake-status: published
+:jbake-title: ADR-03: Docker image build model for docToolchain v4
+
+:issue-1643: https://github.com/docToolchain/docToolchain/issues/1643
+:docker-image-repo: https://github.com/docToolchain/docker-image
+
+== ADR-03: Docker image build model for docToolchain v4
+
+=== Status
+
+*Proposed.*
+
+This ADR opens the discussion for the v4 Docker image (see {issue-1643}[issue #1643]).
+Cells marked `?` in the Pugh matrix need team judgement before this moves to _Accepted_.
+
+=== Problem and Context
+
+The docToolchain v3 images in {docker-image-repo}[docToolchain/docker-image] are built by
+downloading the release ZIP and running `./gradlew downloadDependencies` at build time.
+At runtime, every task still goes through Gradle.
+
+docToolchain v4 changes this fundamentally.
+The `dtcw4` wrapper (repository root) installs v4 by cloning the `main-4.x` branch, running the
+Gradle task `packageLibs` *once*, and then executing all tasks *directly on the JVM without
+Gradle*.
+There is also no v4 release ZIP yet -- the latest published release is v3.5.0.
+
+The existing Dockerfiles therefore do not produce a working v4 image, and the build model has to
+be reconsidered. This decision is a prerequisite for ADR-04, ADR-05 and ADR-06.
+
+=== Decision Drivers
+
+* Alignment with the v4 runtime model (`packageLibs` + direct JVM execution).
+* Final image size and runtime startup time.
+* Build reproducibility (no v4 release artifact exists yet).
+* Maintenance effort and overlap with the v3 image definitions.
+
+=== Considered Options
+
+* *Option A (datum):* Keep the v3 approach -- download a release ZIP and run
+  `./gradlew downloadDependencies`. Requires a v4 release artifact and keeps Gradle at runtime.
+* *Option B:* Single-stage build -- `git clone --branch main-4.x` + `./gradlew packageLibs`, copy
+  the built JARs into `lib/`, mirror what `dtcw4` does. Gradle present only at build time.
+* *Option C:* Multi-stage build -- a builder stage clones and runs `packageLibs`, the final stage
+  contains only the packaged `lib/` JARs plus a JRE and the runtime tooling.
+
+=== Pugh Matrix
+
+Scores are relative to the datum (Option A), on a 3-point scale (`+1` better, `0` equal,
+`-1` worse).
+
+[cols="3,^1,^1,^1",options="header"]
+|===
+| Criterion (datum: Option A) | A | B | C
+
+| Alignment with v4 runtime (dtcw4) | 0 | +1 | +1
+| Final image size              | 0 |  0 | +1
+| Runtime startup time          | 0 | +1 | +1
+| Build reproducibility w/o release ZIP | 0 | +1 | +1
+| Build time / complexity       | 0 |  0 | -1
+| Maintenance effort            | 0 |  0 | ?
+
+| *Sum*                         | *0* | *+3* | *?*
+|===
+
+=== Decision
+
+*Proposed:* build the v4 image from source with `git clone` + `packageLibs`, mirroring `dtcw4`,
+and prefer a *multi-stage build* (Option C) so the final image ships only the runtime libraries
+and a JRE instead of a full JDK plus Gradle caches.
+
+The choice between Option B and Option C, and the pinning strategy (build from the `main-4.x`
+branch HEAD vs. a tagged v4 pre-release once it exists) are left open (`?`) for the team.
+
+=== Consequences
+
+* The Dockerfiles in `docToolchain/docker-image` must be rewritten for v4; they cannot be reused
+  as-is. The `DTC_VERSION` build-arg semantics change from "release tag" to "git ref".
+* Building from a moving branch makes images non-reproducible until a v4 tag exists
+  -- *risk R-401* (to be added to arc42 chapter 11): pin to a commit/tag once available.
+* A JRE-only final image may miss tools that some tasks shell out to (Graphviz, Ruby/pygments)
+  -- handled in ADR-04; *risk R-402*: verify the runtime tool set during the smoke test.
+* This ADR concretises the direction of ADR-02 (decoupling the core logic from Gradle).

--- a/src/docs/050_ADRs/ADR-4-v4-image-diagram-rendering.adoc
+++ b/src/docs/050_ADRs/ADR-4-v4-image-diagram-rendering.adoc
@@ -1,0 +1,85 @@
+:filename: 050_ADRs/ADR-4-v4-image-diagram-rendering.adoc
+:icons: font
+:jbake-menu: ADRs
+:jbake-order: 4
+:jbake-status: published
+:jbake-title: ADR-04: Diagram rendering in the docToolchain v4 image
+
+:issue-1643: https://github.com/docToolchain/docToolchain/issues/1643
+:kroki: https://kroki.io
+
+== ADR-04: Diagram rendering in the docToolchain v4 image
+
+=== Status
+
+*Proposed.* Depends on ADR-03. Cells marked `?` need team judgement.
+
+=== Problem and Context
+
+The image is also used in CI/CD pipelines, where diagrams must render reliably and ideally
+without external network access.
+
+The current state in the v3 images:
+
+* *PlantUML* is available as a Java library through `asciidoctorj-diagram` (2.3.2 in
+  `libs.versions.toml`); no separate binary is needed.
+* *Graphviz* is installed as a binary via `apk add graphviz`; it is required both by PlantUML for
+  some diagram types and by `structurizr-graphviz`.
+* *Structurizr* support is present as libraries (`structurizr-dsl`, `-export`, `-graphviz`,
+  `-d2`). The `structurizr-d2` exporter additionally needs the external *D2* binary, which is
+  *not* in the image today.
+* {kroki}[*Kroki*] is supported only as a *remote* rendering path (asciidoctor-diagram
+  `:diagram-server-url:` / asciidoctor-kroki). docToolchain does not bundle a Kroki server.
+
+For v4 we must decide which of these the image guarantees out of the box.
+
+=== Decision Drivers
+
+* Offline / air-gapped capability (no call to a third-party server).
+* CI determinism and reproducibility.
+* Diagram-format coverage (PlantUML, Graphviz, Structurizr incl. D2, others).
+* Image size and the cost of an external service dependency.
+
+=== Considered Options
+
+* *Option A (datum):* Keep today's set -- PlantUML (lib) + Graphviz (binary), no D2, no Kroki.
+* *Option B:* Option A plus the *D2 binary* so `structurizr-d2` works out of the box.
+* *Option C:* Rely on a *remote Kroki* server (`kroki.io` or a self-hosted URL); document the
+  configuration, ship less locally.
+* *Option D:* Provide a *local Kroki* server alongside the image (separate image /
+  docker-compose example) for offline rendering of many formats.
+
+=== Pugh Matrix
+
+[cols="3,^1,^1,^1,^1",options="header"]
+|===
+| Criterion (datum: Option A) | A | B | C | D
+
+| Offline / air-gapped capability | 0 |  0 | -1 |  0
+| CI determinism                  | 0 |  0 | -1 | +1
+| Diagram-format coverage         | 0 | +1 | +1 | +1
+| No external network dependency  | 0 |  0 | -1 | +1
+| Image size                      | 0 | -1 |  0 | -1
+| Operational/maintenance effort  | 0 |  0 | -1 | -1
+
+| *Sum*                           | *0* | *0* | *?* | *?*
+|===
+
+=== Decision
+
+*Proposed:* keep local rendering as the default and *add the D2 binary* (Option B) so the
+Structurizr/C4 building-block path -- the arc42 "Bausteinsicht" -- works without extra setup.
+
+Kroki should be *documented and configurable* (Option C as an opt-in), not the default, because a
+mandatory remote call breaks air-gapped CI. Whether to additionally publish a *local Kroki*
+compose example (Option D) is left open (`?`).
+
+=== Consequences
+
+* The v4 Dockerfile keeps `graphviz` and adds the `d2` binary; the smoke test must cover a
+  PlantUML, a Graphviz and a Structurizr-D2 diagram.
+* Adding D2 increases image size -- *risk R-411* (arc42 ch.11): keep it in the default image only
+  if the size cost is acceptable, otherwise move to a variant (see ADR-05).
+* Documenting Kroki as opt-in creates a *supply-chain/availability* dependency when users enable
+  it -- *risk R-412*: recommend a self-hosted Kroki URL for sensitive environments.
+* Confirms that PlantUML + Graphviz remain first-class in v4 (answers a recurring user question).

--- a/src/docs/050_ADRs/ADR-5-v4-image-ci-tooling.adoc
+++ b/src/docs/050_ADRs/ADR-5-v4-image-ci-tooling.adoc
@@ -1,0 +1,78 @@
+:filename: 050_ADRs/ADR-5-v4-image-ci-tooling.adoc
+:icons: font
+:jbake-menu: ADRs
+:jbake-order: 5
+:jbake-status: published
+:jbake-title: ADR-05: Docs-as-code CI tooling in the v4 image
+
+:issue-1643: https://github.com/docToolchain/docToolchain/issues/1643
+:asciidoc-linter: https://github.com/docToolchain/asciidoc-linter
+:dacli: https://github.com/docToolchain/dacli
+
+== ADR-05: Docs-as-code CI tooling in the v4 image
+
+=== Status
+
+*Proposed.* Depends on ADR-03. Cells marked `?` need team judgement.
+
+=== Problem and Context
+
+The image is used in CI/CD pipelines, so it is tempting to ship the surrounding docs-as-code
+tooling in the same image instead of installing it in every pipeline:
+
+* {asciidoc-linter}[*asciidoc-linter*] -- a Python tool, already wired into
+  `.pre-commit-config.yaml` via `asciidoc-linter@git+https://github.com/docToolchain/asciidoc-linter`.
+  `python3` is already present in the base image.
+* {dacli}[*dacli*] -- a Python 3.12+ CLI (managed with `uv`) to navigate and query large
+  documentation projects (AsciiDoc + Markdown), part of the docToolchain ecosystem.
+
+Both pull in a Python toolchain (`dacli` specifically needs Python 3.12+ and `uv`), which adds
+weight and a second runtime to an otherwise JVM-centric image.
+
+=== Decision Drivers
+
+* CI convenience -- one image instead of per-pipeline installs.
+* Image size and the cost of carrying a second (Python/uv) runtime.
+* Separation of concerns -- a lean default image vs. a batteries-included CI image.
+* Coupling the release cadence of the image to that of `asciidoc-linter` / `dacli`.
+
+=== Considered Options
+
+* *Option A (datum):* Ship neither tool; pipelines install them on demand.
+* *Option B:* Add *asciidoc-linter* only (lightweight, `pip`/pre-commit, Python already present).
+* *Option C:* Add *both* asciidoc-linter and dacli to the default image (adds Python 3.12 + `uv`).
+* *Option D:* Keep the default image lean and publish a dedicated *`-ci` image variant* that adds
+  asciidoc-linter and dacli on top of the base.
+
+=== Pugh Matrix
+
+[cols="3,^1,^1,^1,^1",options="header"]
+|===
+| Criterion (datum: Option A) | A | B | C | D
+
+| CI convenience (no per-pipeline installs) | 0 | +1 | +1 | +1
+| Lean default image / size      | 0 |  0 | -1 |  0
+| Avoids a second (Python) runtime | 0 | 0 | -1 |  0
+| Separation of concerns         | 0 |  0 | -1 | +1
+| Release-coupling / maintenance | 0 | -1 | -1 | ?
+
+| *Sum*                          | *0* | *+1* | *-3* | *?*
+|===
+
+=== Decision
+
+*Proposed:* do *not* bloat the default image. Add `asciidoc-linter` where it is cheap, and offer
+the heavier combination (asciidoc-linter + dacli) through a dedicated *`-ci` image variant*
+(Option D) so users who want a one-stop CI image get it, while the base image stays lean.
+
+Whether dacli belongs in the same `-ci` variant or its own image (it has its own `uv`-based
+release cycle) is left open (`?`).
+
+=== Consequences
+
+* A new `-ci` image variant has to be defined and built in `docToolchain/docker-image` (see
+  ADR-06 for how it is tagged).
+* Bundling Python tools couples image releases to upstream tool releases -- *risk R-421*
+  (arc42 ch.11): pin tool versions and rebuild on upstream releases.
+* Adding `uv` + Python 3.12 to an Alpine/Temurin base may need extra packages -- *risk R-422*:
+  validate the build on the chosen base image.

--- a/src/docs/050_ADRs/ADR-6-v4-image-tagging-strategy.adoc
+++ b/src/docs/050_ADRs/ADR-6-v4-image-tagging-strategy.adoc
@@ -1,0 +1,69 @@
+:filename: 050_ADRs/ADR-6-v4-image-tagging-strategy.adoc
+:icons: font
+:jbake-menu: ADRs
+:jbake-order: 6
+:jbake-status: published
+:jbake-title: ADR-06: Image tagging strategy for 4.x / 3.x coexistence
+
+:issue-1643: https://github.com/docToolchain/docToolchain/issues/1643
+:dockerhub: https://hub.docker.com/r/doctoolchain/doctoolchain/tags
+
+== ADR-06: Image tagging strategy for 4.x / 3.x coexistence
+
+=== Status
+
+*Proposed.* Depends on ADR-03. Cells marked `?` need team judgement.
+
+=== Problem and Context
+
+v4 should run independently from v3 for now. The {dockerhub}[Docker Hub repository] currently
+serves the 3.x line, including a floating `latest` tag that many users and the `dtcw` wrapper
+rely on. Publishing 4.x images must not silently move 3.x users onto an incompatible image
+before v4 is generally available.
+
+=== Decision Drivers
+
+* Do not break existing 3.x users (especially consumers of `latest`).
+* Clarity and discoverability of the v4 images.
+* CI/publishing complexity.
+* A clean switch-over path once v4 reaches GA.
+
+=== Considered Options
+
+* *Option A (datum):* Reuse the existing tag scheme, including `latest`, for v4 too.
+* *Option B:* Version-pinned tags (`v4.0.0`, ...) plus a floating `4` / `4-latest` tag; keep
+  `latest` pointing at the newest 3.x until v4 GA, then flip it deliberately.
+* *Option C:* Publish v4 under a *separate image name / namespace* (e.g. a `...-v4` repository).
+
+=== Pugh Matrix
+
+[cols="3,^1,^1,^1",options="header"]
+|===
+| Criterion (datum: Option A) | A | B | C
+
+| Does not break 3.x `latest` users | 0 | +1 | +1
+| Clarity / discoverability        | 0 | +1 |  0
+| CI / publishing complexity        | 0 |  0 | -1
+| Clean GA switch-over path          | 0 | +1 |  0
+| Reuses existing tooling/conventions | 0 | +1 | -1
+
+| *Sum*                             | *0* | *+4* | *-2*
+|===
+
+=== Decision
+
+*Proposed:* adopt Option B -- publish version-pinned `v4.x.y` tags plus a floating `4` /
+`4-latest` tag, and *leave `latest` on the 3.x line* until v4 is declared GA, then move it in a
+deliberate, announced step.
+
+The exact name of the floating tag (`4` vs. `4-latest`) and whether pre-GA images get a `next` /
+`beta` tag are left open (`?`).
+
+=== Consequences
+
+* The publishing workflow in `docToolchain/docker-image` needs explicit tag mapping per branch /
+  release rather than an implicit `latest`.
+* `dtcw` / `dtcw4` must select the right image tag for v4 -- *risk R-431* (arc42 ch.11): verify
+  the wrapper's docker mode picks the v4 tag.
+* Until v4 GA, a user explicitly opting into `4` / `4-latest` may hit an unstable image
+  -- *accepted consequence* (opt-in, documented), no separate tracked risk.


### PR DESCRIPTION
## Was

Vier neue ADRs unter `src/docs/050_ADRs/` (Nygard-Stil wie ADR-1/ADR-2, ergänzt um eine 3-Punkt-Pugh-Matrix gemäß Semantic-Contract). Sie halten die offenen Architektur-Entscheidungen rund um das **docToolchain-v4-Docker-Image** fest (Kontext: #1643).

| ADR | Thema | Vorschlag |
|-----|-------|-----------|
| **ADR-03** | v4-Image-Build-Modell | `git clone` + `packageLibs` + direkte JVM-Ausführung (Multi-Stage), **nicht** mehr Zip+Gradle |
| **ADR-04** | Diagramm-Rendering im Image | Lokal PlantUML+Graphviz beibehalten, **D2-Binary ergänzen** (Bausteinsicht/Structurizr), Kroki als opt-in dokumentieren |
| **ADR-05** | CI-Tools im Image | Default schlank halten; `asciidoc-linter` günstig ergänzen, `asciidoc-linter`+`dacli` über separate **`-ci`-Variante** |
| **ADR-06** | Tagging / 3.x-Koexistenz | `v4.x.y` + floatendes `4`/`4-latest`; `latest` bleibt bis v4-GA auf 3.x |

## Status

Alle vier ADRs stehen auf **Status: Proposed**. Zellen der Pugh-Matrix, die echtes Team-Urteil brauchen, sind bewusst mit `?` markiert statt geraten (so vom Contract gefordert).

## Hintergrund / Befunde

- v4 läuft laut `dtcw4` **ohne Gradle zur Laufzeit** → bestehende Dockerfiles (Release-Zip → `gradlew downloadDependencies`) sind nicht wiederverwendbar.
- **PlantUML** ist über `asciidoctorj-diagram` als Java-Lib vorhanden (kein Binary nötig); **Graphviz** wird per `apk` installiert. **D2** (für `structurizr-d2`) fehlt aktuell.
- **Kroki** ist nur ein *Remote*-Renderingweg; kein gebündelter Server.
- **dacli** = `docToolchain/dacli` (Python 3.12+/`uv`), **asciidoc-linter** = `docToolchain/asciidoc-linter` (bereits in `.pre-commit-config.yaml`).

## Offene Punkte

- Risiken `R-401/402/411/412/421/422/431` sind in den ADR-Consequences benannt und sollten in **arc42 Kapitel 11** (Risiko-Register) übernommen werden.
- Die eigentliche Umsetzung erfolgt im Repo `docToolchain/docker-image` (dort sind Issues deaktiviert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPJcqxcmptZyM4uVSnx6TT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPJcqxcmptZyM4uVSnx6TT)_