### PR TITLE
docs(site): subtle v4-preview notice on the landing page

### DIFF
--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -4,9 +4,8 @@
         <!-- v4 preview notice — see docToolchain/docToolchain#1599 -->
         <div class="alert alert-info d-flex flex-wrap align-items-center justify-content-between" role="alert" style="gap:.75rem;">
             <span>
-                <strong>docToolchain v4 is in the works</strong> &mdash; a ground-up, LLM-native rewrite:
-                no Gradle, faster startup, and docs-as-code built for the GenAI age.
-                It is still in development &mdash; <strong>v3 (this site) remains the stable release</strong>.
+                <strong>docToolchain v4 is in the works</strong> &mdash; a ground-up, LLM-native rewrite
+                for the GenAI age. Still in development &mdash; <strong>v3 (this site) remains the stable release</strong>.
             </span>
             <a class="btn btn-sm btn-outline-primary text-nowrap" href="https://github.com/docToolchain/docToolchain/discussions/1599" target="_blank" rel="noopener">
                 See the v4 vision &amp; give feedback &rarr;

--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -1,5 +1,18 @@
 <div class="row flex-xl-nowrap">
     <main class="col-12 col-md-12 col-xl-12 pl-md-12" role="main">
+
+        <!-- v4 preview notice — see docToolchain/docToolchain#1599 -->
+        <div class="alert alert-info d-flex flex-wrap align-items-center justify-content-between" role="alert" style="gap:.75rem;">
+            <span>
+                <strong>docToolchain v4 is in the works</strong> &mdash; a ground-up, LLM-native rewrite:
+                no Gradle, faster startup, and docs-as-code built for the GenAI age.
+                It is still in development &mdash; <strong>v3 (this site) remains the stable release</strong>.
+            </span>
+            <a class="btn btn-sm btn-outline-primary text-nowrap" href="https://github.com/docToolchain/docToolchain/discussions/1599" target="_blank" rel="noopener">
+                See the v4 vision &amp; give feedback &rarr;
+            </a>
+        </div>
+
         <div class="bg-light p-5 rounded jumbotron">
             <img src="images/doctoolchain-logo-blue.png" alt="docToolchain" style="float: left" />
             <h1>docToolchain</h1>


### PR DESCRIPTION
Adds a **slim, honest preview banner** above the hero on the doctoolchain.org landing page (`src/docs/landingpage.gsp`).

## Rendered text
> **docToolchain v4 is in the works** — a ground-up, LLM-native rewrite: no Gradle, faster startup, and docs-as-code built for the GenAI age. It is still in development — **v3 (this site) remains the stable release**.
>
> [ See the v4 vision & give feedback → ] (links to discussion #1599)

## Design choices
- **Preview, not CTA:** explicitly says v3 is the stable release — no "upgrade to v4" push onto an unreleased version.
- **Feedback funnel:** the button points at the v4 vision discussion (#1599), not a download.
- **Subtle:** a single Bootstrap `alert-info` above the hero, no layout changes.
- Pure static markup — no GSP expressions or includes.

## ⚠️ Before merge
- Merging to `ng` **deploys to doctoolchain.org** (live). Please eyeball the rendered banner first — I could not build the v3/jBake microsite locally (only the v4 toolchain is available here).
- Tonality is easy to dial: say the word for more sober ("a ground-up rewrite is underway") or more inviting ("the next generation of docs-as-code is coming").

No rush — this is a soft notice; the louder announcement (blog/hero) fits better once v4 is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)