### PR TITLE
docs(site): move v4 notice below the hero, link straight to the v4 site

### DIFF
--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -1,17 +1,6 @@
 <div class="row flex-xl-nowrap">
     <main class="col-12 col-md-12 col-xl-12 pl-md-12" role="main">
 
-        <!-- v4 preview notice — see docToolchain/docToolchain#1599 -->
-        <div class="alert alert-info d-flex flex-wrap align-items-center justify-content-between" role="alert" style="gap:.75rem;">
-            <span>
-                <strong>docToolchain v4 is in the works</strong> &mdash; a ground-up, LLM-native rewrite
-                for the GenAI age. Still in development &mdash; <strong>v3 (this site) remains the stable release</strong>.
-            </span>
-            <a class="btn btn-sm btn-outline-primary text-nowrap" href="https://github.com/docToolchain/docToolchain/discussions/1599" target="_blank" rel="noopener">
-                See the v4 vision &amp; give feedback &rarr;
-            </a>
-        </div>
-
         <div class="bg-light p-5 rounded jumbotron">
             <img src="images/doctoolchain-logo-blue.png" alt="docToolchain" style="float: left" />
             <h1>docToolchain</h1>
@@ -21,6 +10,18 @@
             <p>docToolchain is a collection of scripts that makes it easy to create and maintain powerful technical documentation. Built on best-of-breed open source technologies, we deliver the best docs toolchain so you don’t have to.
             </p>
         </div>
+
+        <!-- v4 preview notice -->
+        <div class="alert alert-info d-flex flex-wrap align-items-center justify-content-between" role="alert" style="gap:.75rem;">
+            <span>
+                <strong>docToolchain v4 is in the works</strong> &mdash; a ground-up, LLM-native rewrite
+                for the GenAI age. Still in development &mdash; <strong>v3 (this site) remains the stable release</strong>.
+            </span>
+            <a class="btn btn-sm btn-outline-primary text-nowrap" href="https://doctoolchain.org/docToolchain/v4.0.x/" target="_blank" rel="noopener">
+                Explore docToolchain v4 &rarr;
+            </a>
+        </div>
+
         <div class="row row-cols-1 row-cols-md-3 mb-3 text-center">
             <div class="col">
                 <div class="card mb-12 shadow-sm">


### PR DESCRIPTION
Follow-up to #1655, per feedback:
- **Placement:** banner now sits **below the hero jumbotron** (was above it).
- **Link:** the button points **directly to the v4 site** (https://doctoolchain.org/docToolchain/v4.0.x/) instead of the discussion; label changed to *Explore docToolchain v4 →*.

Still a slim, single `alert-info`; text unchanged (v3 = stable, v4 = in development).

⚠️ Merge to `ng` deploys to doctoolchain.org — the previous banner build was green, this is a small markup move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)