### PR TITLE
perf(dtcw): default v4 JVM to short-lived startup flags (~2x faster)

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -763,7 +763,13 @@ build_command() {
             # v4 Docker: direct Groovy invocation inside container
             local task=${1}
             shift
-            local java_opts="-Xmx2048m -Dfile.encoding=UTF-8"
+            # Short-lived JVM: cap JIT at C1 (skip the C2 compiler, which never
+            # pays off in a seconds-long run) and use SerialGC. Roughly halves
+            # startup + render for typical docs. Override or disable via
+            # DTC_JAVA_STARTUP_OPTS (set it empty for very large docs where C2
+            # eventually amortises).
+            local startup_opts="${DTC_JAVA_STARTUP_OPTS--XX:TieredStopAtLevel=1 -XX:+UseSerialGC}"
+            local java_opts="-Xmx2048m -Dfile.encoding=UTF-8 ${startup_opts}"
             java_opts="${java_opts} -DdocDir=. -DmainConfigFile=\"${DTC_CONFIG_FILE}\""
             java_opts="${java_opts} -DDTC_HEADLESS=true -DDTC_PROJECT_BRANCH=\"${DTC_PROJECT_BRANCH}\""
             # Expansion must happen inside container, not locally
@@ -792,7 +798,13 @@ build_command() {
                 exit ${ERR_DTCW}
             fi
 
-            local java_opts="-Xmx2048m -Dfile.encoding=UTF-8"
+            # Short-lived JVM: cap JIT at C1 (skip the C2 compiler, which never
+            # pays off in a seconds-long run) and use SerialGC. Roughly halves
+            # startup + render for typical docs. Override or disable via
+            # DTC_JAVA_STARTUP_OPTS (set it empty for very large docs where C2
+            # eventually amortises).
+            local startup_opts="${DTC_JAVA_STARTUP_OPTS--XX:TieredStopAtLevel=1 -XX:+UseSerialGC}"
+            local java_opts="-Xmx2048m -Dfile.encoding=UTF-8 ${startup_opts}"
             java_opts="${java_opts} -DdocDir=. -DmainConfigFile=\"${DTC_CONFIG_FILE}\""
             java_opts="${java_opts} -DDTC_HEADLESS=${DTC_HEADLESS}"
             java_opts="${java_opts} -DDTC_PROJECT_BRANCH=\"${DTC_PROJECT_BRANCH}\""

--- a/src/docs/010_manual/50_Frequently_asked_Questions.adoc
+++ b/src/docs/010_manual/50_Frequently_asked_Questions.adoc
@@ -96,3 +96,34 @@ Pass proxy settings as system properties:
 ./dtcw4 local generateSite -Dhttp.proxyHost=proxy.example.com -Dhttp.proxyPort=3128
 ----
 ====
+
+=== Q: Can I tune the JVM startup for faster v4 builds?
+
+.Answer
+[%collapsible]
+====
+docToolchain v4 runs every task in a fresh, short-lived JVM (no Gradle daemon).
+To make that startup cheap, the `dtcw` wrapper launches the v4 JVM with these
+flags by default: `-XX:TieredStopAtLevel=1 -XX:+UseSerialGC`.
+
+A run that lasts only seconds never recoups the cost of the C2 JIT compiler
+optimising hot methods it abandons moments later. Capping the JIT at level 1
+(C1) removes that wasted compilation, and `SerialGC` skips parallel-GC thread
+setup. On a typical site this roughly halves the wall-clock time.
+
+The flags are a default, not a hard-coded value. Override them with the
+`DTC_JAVA_STARTUP_OPTS` environment variable:
+
+[source,bash]
+----
+# Disable the defaults entirely:
+DTC_JAVA_STARTUP_OPTS= ./dtcw4 local generateSite
+
+# Replace them with your own choice:
+DTC_JAVA_STARTUP_OPTS="-XX:+UseParallelGC" ./dtcw4 local generateSite
+----
+
+TIP: For a *very* large documentation set whose render runs for minutes, the C2
+JIT does eventually pay off. There, disabling the defaults
+(`DTC_JAVA_STARTUP_OPTS=`) can be faster — measure both and keep the winner.
+====


### PR DESCRIPTION
## Why

v4 runs each task (`generateSite`, …) in a **fresh, short-lived JVM** — no daemon. Benchmarking `generateSite` on a small site (23 pages) showed that ~53% of the warm wall-clock is fixed JVM startup the document never benefits from:

| phase | warm |
|---|---|
| JVM + classpath boot | ~6.0s |
| AsciidoctorJ/JRuby load | ~10.2s |
| render + diagrams | ~13.2s |

## What

Add `-XX:TieredStopAtLevel=1 -XX:+UseSerialGC` to the v4 `java_opts` (both **local** and **docker** paths).

**Result: ~30s → ~15.5s warm — every phase roughly halves.** A seconds-long process never recoups the cost of the C2 JIT optimizing hot methods it abandons moments later; capping the JIT at C1 removes that wasted compilation, and SerialGC skips parallel-GC thread setup. The same flags halve the v3/Gradle path too (~39s → ~22.5s), which confirms the win is the flags and not disk cache.

## Tradeoff & escape hatch

For **very large docs** rendering over minutes, C2 eventually amortises and `TieredStopAtLevel=1` would become a drag. The flags are therefore overridable:

```bash
# disable entirely
DTC_JAVA_STARTUP_OPTS= ./dtcw generateSite
# or override with your own
DTC_JAVA_STARTUP_OPTS="-XX:+UseParallelGC" ./dtcw generateSite
```

`${DTC_JAVA_STARTUP_OPTS-…}` (no colon) means: unset → defaults applied; set empty → disabled.

## Validation

- `bash -n dtcw` passes.
- Measured with a phase-resolved benchmark (forces a full render on both v3 and v4, wall-clock `real` only).
- Robust, not a caching artifact: the cold first run was already fast, every phase dropped uniformly, and v3 dropped identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017tuych8KhL8ErHvAA5nGE7

---
_Generated by [Claude Code](https://claude.ai/code/session_017tuych8KhL8ErHvAA5nGE7)_