### PR TITLE
docs(site): drop stale jBake/Docsy credits from the v4 footer

### DIFF
--- a/docToolchainConfig.groovy
+++ b/docToolchainConfig.groovy
@@ -110,7 +110,7 @@ microsite.with {
     // Slack Channel
     footerSlack = ''
     // general text for the footer
-    footerText = '<small class="text-white">built with <a href="https://doctoolchain.org">docToolchain</a> and <a href="https://jbake.org">jBake</a> <br /> theme: <a href="https://www.docsy.dev/">docsy</a></small>'
+    footerText = '<small class="text-white">built with <a href="https://doctoolchain.org">docToolchain</a> &middot; powered by <a href="https://asciidoctor.org">AsciiDoctor</a> &amp; <a href="https://getbootstrap.com/">Bootstrap</a></small>'
     // site title if no other title is given
     title = 'docToolchain'
     //

--- a/src/site/templates/footer.gsp
+++ b/src/site/templates/footer.gsp
@@ -1,10 +1,4 @@
 
-    <!--footer class="footer mt-auto py-3 bg-light">
-        <div class="container">
-            <span class="text-muted">&copy; 2020 | based on <a href="https://arc42.org">arc42 7.0</a> | mixed with <a href="http://getbootstrap.com/">Bootstrap v5.0.0-beta</a> | Baked with <a href="http://jbake.org">JBake ${version}</a></span>
-        </div>
-    </footer-->
-
     <footer class="bg-dark py-5 row d-print-none">
         <div class="container-fluid mx-sm-5">
             <div class="row">

--- a/template_config/Config.groovy
+++ b/template_config/Config.groovy
@@ -110,8 +110,8 @@ microsite.with {
     footerSlack = '##Slack-url##'
     //
     // Footer Text
-    // example: <small class="text-white">built with docToolchain and jBake <br /> theme: docsy</small>
-    footerText = '<small class="text-white">built with <a href="https://doctoolchain.org">docToolchain</a> and <a href="https://jbake.org">jBake</a> <br /> theme: <a href="https://www.docsy.dev/">docsy</a></small>'
+    // example: <small class="text-white">built with docToolchain &middot; powered by AsciiDoctor &amp; Bootstrap</small>
+    footerText = '<small class="text-white">built with <a href="https://doctoolchain.org">docToolchain</a> &middot; powered by <a href="https://asciidoctor.org">AsciiDoctor</a> &amp; <a href="https://getbootstrap.com/">Bootstrap</a></small>'
     //
     // site title if no other title is given
     title = 'docToolchain'


### PR DESCRIPTION
The v4 site footer still credited **jBake** and **Docsy** — v4 uses neither (jBake → built-in `MicrositeBaker`, ADR-4; Docsy → custom Bootstrap 5 GSP templates).

## Changes
- `docToolchainConfig.groovy` + `template_config/Config.groovy`: `footerText` → *"built with docToolchain · powered by AsciiDoctor & Bootstrap"* (honest — those are what v4 actually uses).
- `src/site/templates/footer.gsp`: removed the dead commented-out *"Baked with JBake"* footer block.

## Verified
`generateSite` → **0 jBake / 0 Docsy** references in the rendered output (137 pages, no fatal errors).

Note: the remaining `jbake` mentions elsewhere in `docToolchainConfig.groovy` are the backward-compat metadata-header config (`:jbake-*:`) — tracked separately in #1651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)