### PR TITLE
fix(site): reveal the sub-navigation on mobile (<768px)

### DIFF
--- a/src/site/assets/css/doctoolchain-v4.css
+++ b/src/site/assets/css/doctoolchain-v4.css
@@ -128,6 +128,23 @@ body::before {
 [data-theme="dark"] .td-sidebar-link__section.active { color:var(--g-300) !important; }
 summary { color:var(--dtc-ink); }
 
+/* ---- mobile: keep the sub-navigation reachable --------------------- */
+/* This microsite's navbar never collapses to a hamburger, and Docsy marks the
+   section nav as a Bootstrap `collapse` (display:none) until the md breakpoint
+   with no toggle of its own — so below 768px the sub-navigation was hidden and
+   unreachable. Reveal it inline above the page content; it stays collapsible
+   per section via the <details> elements. Pure CSS, no JavaScript. */
+@media (max-width: 767.98px) {
+  #td-section-nav.td-sidebar-nav,
+  nav.td-sidebar-nav.collapse,
+  .td-sidebar-nav.collapse { display:block !important; }
+  .td-sidebar {
+    border-right:0; border-bottom:1px solid var(--dtc-border);
+    padding:.5rem 0 .75rem; margin-bottom:1rem;
+  }
+  .td-sidebar__inner { position:static; height:auto; }
+}
+
 /* arc42 chapter numbering — mono, accent */
 .arc42-num { font-family:var(--dtc-mono); font-weight:600; font-size:.78em; color:var(--g-600); margin-right:6px; opacity:.95; letter-spacing:.02em; }
 [data-theme="dark"] .arc42-num { color:var(--g-300); }


### PR DESCRIPTION
## Problem
On phones the **sub-navigation (left section nav) is not visible**.

## Cause
This microsite's navbar is `navbar-expand` — it never collapses to a hamburger. Docsy marks the section nav (`#td-section-nav`) as a Bootstrap `collapse` (`display:none`) and only un-hides it at the md breakpoint:
```css
@media (min-width:768px){ .td-sidebar-nav{ display:block !important } }
```
…with **no toggle of its own**. So below 768px the section nav stays `display:none` and is unreachable. (This is independent of the colour theme — it was latent; the redesign just made it noticeable.)

## Fix
A `@media (max-width:767.98px)` rule that reveals the section nav **inline** above the content (full-width, bottom hairline). It stays collapsible per section via the existing `<details>` elements. **Pure CSS — no JavaScript.**

## Verified
`generateSite` → 137 pages; the rule is in the built CSS.

If the full list above the content feels too long on phones, a follow-up could wrap it in a CSS-only `<details>` "Menu" toggle — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)