### PR TITLE
feat(dtcw): project-local custom tasks and monkey-patching (v4)

### DIFF
--- a/dtcw
+++ b/dtcw
@@ -122,6 +122,17 @@ main() {
             exit 0
         fi
         assert_v4_task_exists "${1}" "${DTC_HOME}"
+
+        # Docker mounts the project at /project, so a project-local task can only
+        # be reached via a path *relative* to the project root. An absolute
+        # DTC_PROJECT_SCRIPTS_DIR would yield an invalid in-container path
+        # (e.g. /project//abs/path); fail fast with guidance instead.
+        if [ "${environment}" = docker ] && [ -n "$(project_task_script "${1}")" ] \
+                && [[ "${DTC_PROJECT_SCRIPTS_DIR}" = /* ]]; then
+            error "DTC_PROJECT_SCRIPTS_DIR must be a relative path in docker mode (got '${DTC_PROJECT_SCRIPTS_DIR}')."
+            echo "The project is mounted at /project inside the container; set a path relative to the project root." >&2
+            exit ${ERR_ARG}
+        fi
     fi
 
     docker_image_name=""
@@ -727,8 +738,10 @@ list_v4_tasks() {
         is_v4_task_script "$script" || continue
         local name
         name=$(basename "$script" .groovy)
-        # Skip overrides — they were already listed next to the installed task
-        [ -f "${scripts_dir}/${name}.groovy" ] && continue
+        # Skip overrides — they were already listed next to the installed task.
+        # Use the marker check so a project task is still listed when the
+        # installation only has a non-task helper of the same name.
+        is_v4_task_script "${scripts_dir}/${name}.groovy" && continue
         if [ "$printed_header" = false ]; then
             echo ""
             echo "Project-local custom tasks (${DTC_PROJECT_SCRIPTS_DIR}/):"
@@ -834,7 +847,7 @@ build_command() {
             project_script=$(project_task_script "${task}")
             if [ -n "$project_script" ]; then
                 container_script="/project/${DTC_PROJECT_SCRIPTS_DIR}/${task}.groovy"
-                if [ -f "${DTC_HOME}/scripts/${task}.groovy" ]; then
+                if is_v4_task_script "${DTC_HOME}/scripts/${task}.groovy"; then
                     echo "Note: running project-local override of task '${task}' from '${project_script}' (shadows the installed task)." >&2
                 else
                     echo "Note: running project-local custom task '${task}' from '${project_script}'." >&2
@@ -874,7 +887,7 @@ build_command() {
             project_script=$(project_task_script "${task}")
             if [ -n "$project_script" ]; then
                 script_path="$project_script"
-                if [ -f "${dtc_home}/scripts/${task}.groovy" ]; then
+                if is_v4_task_script "${dtc_home}/scripts/${task}.groovy"; then
                     echo "Note: running project-local override of task '${task}' from '${project_script}' (shadows the installed task)." >&2
                 else
                     echo "Note: running project-local custom task '${task}' from '${project_script}'." >&2

--- a/dtcw
+++ b/dtcw
@@ -843,7 +843,7 @@ build_command() {
             # Expansion must happen inside container, not locally
             # shellcheck disable=SC2016
             local docker_cp='$(for f in /opt/docToolchain/lib/*.jar; do [ -f "$f" ] && printf "%s:" "$f"; done)'
-            cmd="docker ${docker_args} -c \"java ${java_opts} -cp ${docker_cp} groovy.ui.GroovyMain ${container_script} ${*} && exit\""
+            cmd="docker ${docker_args} -c \"java ${java_opts} -cp ${docker_cp} groovy.ui.GroovyMain ${container_script} ${*:-} && exit\""
         else
             # v3 Docker: Gradle via doctoolchain
             cmd="docker ${docker_args} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
@@ -896,7 +896,7 @@ build_command() {
             # installation rather than next to themselves (ADR-17).
             java_opts="${java_opts} -Ddtc.scriptsHome=\"${dtc_home}/scripts\""
             # Pass remaining arguments as system properties or script args
-            cmd="${JAVA_CMD:-java} ${java_opts} -cp \"${classpath}\" groovy.ui.GroovyMain \"${script_path}\" ${*}"
+            cmd="${JAVA_CMD:-java} ${java_opts} -cp \"${classpath}\" groovy.ui.GroovyMain \"${script_path}\" ${*:-}"
         else
             # v3: Gradle-based execution
             if [[ "${DTC_HEADLESS}" = false ]]; then

--- a/dtcw
+++ b/dtcw
@@ -823,6 +823,7 @@ build_command() {
 
         docker_args="run --rm -i --platform linux/amd64 -u $(id -u):$(id -g) --name ${container_name} \
             -e DTC_HEADLESS=true -e DTC_SITETHEME -e DTC_PROJECT_BRANCH=${DTC_PROJECT_BRANCH} \
+            -e DTC_PROJECT_SCRIPTS_DIR \
             ${docker_extra_arguments} ${env_file_option} \
             --entrypoint /bin/bash -v '${pwd}:/project' ${DTC_DOCKER_PREFIX}${docker_image}:v${version}"
 
@@ -856,7 +857,9 @@ build_command() {
             # Expansion must happen inside container, not locally
             # shellcheck disable=SC2016
             local docker_cp='$(for f in /opt/docToolchain/lib/*.jar; do [ -f "$f" ] && printf "%s:" "$f"; done)'
-            cmd="docker ${docker_args} -c \"java ${java_opts} -cp ${docker_cp} groovy.ui.GroovyMain ${container_script} ${*:-} && exit\""
+            # Single-quote the script path so it survives word splitting / glob
+            # expansion in the container shell even if it contains spaces.
+            cmd="docker ${docker_args} -c \"java ${java_opts} -cp ${docker_cp} groovy.ui.GroovyMain '${container_script}' ${*:-} && exit\""
         else
             # v3 Docker: Gradle via doctoolchain
             cmd="docker ${docker_args} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""

--- a/dtcw
+++ b/dtcw
@@ -28,6 +28,16 @@ set -o pipefail
 # docToolchain configuration file may be overruled by the user
 : "${DTC_CONFIG_FILE:=docToolchainConfig.groovy}"
 
+# Directory (relative to the project / current working directory) in which
+# docToolchain looks for project-local tasks. A *.groovy file there carrying the
+# '// @task' marker (see ADR-14) is a runnable task. Such a project task either
+# adds a new task (custom tasks) or, when it shares a name with an installed
+# task, overrides it (monkey-patching). See ADR-16.
+: "${DTC_PROJECT_SCRIPTS_DIR:=scripts}"
+# Exported so the createTask/copyTask helper scripts write to the same directory
+# that dtcw resolves project tasks from.
+export DTC_PROJECT_SCRIPTS_DIR
+
 # Contains the current project git branch, "-" if not available
 : "${DTC_PROJECT_BRANCH:=$(git branch --show-current 2> /dev/null || echo -)}"
 export DTC_PROJECT_BRANCH
@@ -672,6 +682,23 @@ build_classpath() {
     echo "$cp"
 }
 
+# Is the given file a runnable v4 task? (carries '// @task' in its first 5 lines)
+is_v4_task_script() {
+    local script=${1}
+    [ -f "$script" ] && head -5 "$script" | grep -q '// @task'
+}
+
+# Echo the path to a project-local task script for <task> if one exists and is
+# marked as a task, otherwise echo nothing. The project scripts directory is
+# resolved relative to the current working directory (the project root).
+project_task_script() {
+    local task=${1}
+    local script="${DTC_PROJECT_SCRIPTS_DIR}/${task}.groovy"
+    if is_v4_task_script "$script"; then
+        echo "$script"
+    fi
+}
+
 # List available v4 tasks (only scripts with '// @task' marker in first 5 lines)
 list_v4_tasks() {
     local home=${1:-${DTC_HOME}}
@@ -685,8 +712,30 @@ list_v4_tasks() {
         if head -5 "$script" | grep -q '// @task'; then
             local name
             name=$(basename "$script" .groovy)
-            echo "  ${name}"
+            # Flag tasks that a project-local script overrides (monkey-patching)
+            if is_v4_task_script "${DTC_PROJECT_SCRIPTS_DIR}/${name}.groovy"; then
+                echo "  ${name} (overridden by ${DTC_PROJECT_SCRIPTS_DIR}/${name}.groovy)"
+            else
+                echo "  ${name}"
+            fi
         fi
+    done
+    # Append project-local custom tasks that do not shadow an installed task
+    local printed_header=false
+    for script in "${DTC_PROJECT_SCRIPTS_DIR}/"*.groovy; do
+        [ -f "$script" ] || continue
+        is_v4_task_script "$script" || continue
+        local name
+        name=$(basename "$script" .groovy)
+        # Skip overrides — they were already listed next to the installed task
+        [ -f "${scripts_dir}/${name}.groovy" ] && continue
+        if [ "$printed_header" = false ]; then
+            echo ""
+            echo "Project-local custom tasks (${DTC_PROJECT_SCRIPTS_DIR}/):"
+            echo ""
+            printed_header=true
+        fi
+        echo "  ${name}"
     done
     echo ""
     echo "Usage: ./dtcw [environment] <task>"
@@ -698,6 +747,11 @@ assert_v4_task_exists() {
     local task=${1}
     local home=${2:-${DTC_HOME}}
     local script="${home}/scripts/${task}.groovy"
+
+    # A project-local task (custom or override) is always accepted
+    if [ -n "$(project_task_script "${task}")" ]; then
+        return 0
+    fi
 
     if [ -f "$script" ] && head -5 "$script" | grep -q '// @task'; then
         return 0
@@ -772,10 +826,24 @@ build_command() {
             local java_opts="-Xmx2048m -Dfile.encoding=UTF-8 ${startup_opts}"
             java_opts="${java_opts} -DdocDir=. -DmainConfigFile=\"${DTC_CONFIG_FILE}\""
             java_opts="${java_opts} -DDTC_HEADLESS=true -DDTC_PROJECT_BRANCH=\"${DTC_PROJECT_BRANCH}\""
+            # Project-local scripts (custom or override) live under the mounted
+            # /project; installed scripts and their lib/ live under /opt/docToolchain.
+            java_opts="${java_opts} -Ddtc.scriptsHome=/opt/docToolchain/scripts"
+            local container_script="/opt/docToolchain/scripts/${task}.groovy"
+            local project_script
+            project_script=$(project_task_script "${task}")
+            if [ -n "$project_script" ]; then
+                container_script="/project/${DTC_PROJECT_SCRIPTS_DIR}/${task}.groovy"
+                if [ -f "${DTC_HOME}/scripts/${task}.groovy" ]; then
+                    echo "Note: running project-local override of task '${task}' from '${project_script}' (shadows the installed task)." >&2
+                else
+                    echo "Note: running project-local custom task '${task}' from '${project_script}'." >&2
+                fi
+            fi
             # Expansion must happen inside container, not locally
             # shellcheck disable=SC2016
             local docker_cp='$(for f in /opt/docToolchain/lib/*.jar; do [ -f "$f" ] && printf "%s:" "$f"; done)'
-            cmd="docker ${docker_args} -c \"java ${java_opts} -cp ${docker_cp} groovy.ui.GroovyMain /opt/docToolchain/scripts/${task}.groovy ${*} && exit\""
+            cmd="docker ${docker_args} -c \"java ${java_opts} -cp ${docker_cp} groovy.ui.GroovyMain ${container_script} ${*} && exit\""
         else
             # v3 Docker: Gradle via doctoolchain
             cmd="docker ${docker_args} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
@@ -798,6 +866,21 @@ build_command() {
                 exit ${ERR_DTCW}
             fi
 
+            # Resolve the script to run: a project-local task (custom or override)
+            # takes precedence over the installed one (ADR-16). Warnings go to
+            # stderr so they do not pollute the captured command on stdout.
+            local script_path="${dtc_home}/scripts/${task}.groovy"
+            local project_script
+            project_script=$(project_task_script "${task}")
+            if [ -n "$project_script" ]; then
+                script_path="$project_script"
+                if [ -f "${dtc_home}/scripts/${task}.groovy" ]; then
+                    echo "Note: running project-local override of task '${task}' from '${project_script}' (shadows the installed task)." >&2
+                else
+                    echo "Note: running project-local custom task '${task}' from '${project_script}'." >&2
+                fi
+            fi
+
             # Short-lived JVM: cap JIT at C1 (skip the C2 compiler, which never
             # pays off in a seconds-long run) and use SerialGC. Roughly halves
             # startup + render for typical docs. Override or disable via
@@ -808,8 +891,12 @@ build_command() {
             java_opts="${java_opts} -DdocDir=. -DmainConfigFile=\"${DTC_CONFIG_FILE}\""
             java_opts="${java_opts} -DDTC_HEADLESS=${DTC_HEADLESS}"
             java_opts="${java_opts} -DDTC_PROJECT_BRANCH=\"${DTC_PROJECT_BRANCH}\""
+            # Tell scripts where the installed scripts/ (and its lib/ helpers and
+            # resources) live, so project-local scripts resolve them from the
+            # installation rather than next to themselves (ADR-17).
+            java_opts="${java_opts} -Ddtc.scriptsHome=\"${dtc_home}/scripts\""
             # Pass remaining arguments as system properties or script args
-            cmd="${JAVA_CMD:-java} ${java_opts} -cp \"${classpath}\" groovy.ui.GroovyMain \"${dtc_home}/scripts/${task}.groovy\" ${*}"
+            cmd="${JAVA_CMD:-java} ${java_opts} -cp \"${classpath}\" groovy.ui.GroovyMain \"${script_path}\" ${*}"
         else
             # v3: Gradle-based execution
             if [[ "${DTC_HEADLESS}" = false ]]; then

--- a/scripts/copyLandingPage.groovy
+++ b/scripts/copyLandingPage.groovy
@@ -5,8 +5,8 @@
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 
-def dtcHome = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile.parentFile
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def dtcHome = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')).parentFile : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile.parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def gcl = new GroovyClassLoader(this.class.classLoader)
 def DtcConfig = gcl.parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 gcl.parseClass(new File(scriptDir, 'lib/DtcException.groovy'))

--- a/scripts/copyTask.groovy
+++ b/scripts/copyTask.groovy
@@ -1,0 +1,66 @@
+#!/usr/bin/env groovy
+// @task
+// v4: Copy an installed task script into the current project so it can be
+// modified (monkey-patching, see ADR-16). The project copy shadows the
+// installed task of the same name; dtcw warns when it runs the override.
+// Usage: ./dtcw copyTask <installedTaskName>
+
+def docDir = System.getProperty('docDir', '.')
+def scriptsDirName = System.getenv('DTC_PROJECT_SCRIPTS_DIR') ?: 'scripts'
+def scriptsHome = System.getProperty('dtc.scriptsHome')
+
+if (!args || args.length == 0) {
+    System.err.println """
+Error: no task name given.
+Usage: ./dtcw copyTask <installedTaskName>
+Run './dtcw tasks' to see which tasks you can copy.
+"""
+    System.exit 2
+}
+def taskName = args[0]
+
+if (!scriptsHome) {
+    System.err.println """
+Error: cannot locate the docToolchain installation (dtc.scriptsHome is unset).
+Run this task via ./dtcw so the installation directory is known.
+"""
+    System.exit 1
+}
+
+def source = new File(scriptsHome, "${taskName}.groovy")
+if (!source.exists()) {
+    System.err.println """
+Error: installed task '${taskName}' not found at:
+  ${source.path}
+Run './dtcw tasks' to see the available tasks.
+"""
+    System.exit 1
+}
+
+def scriptsDir = new File(docDir, scriptsDirName)
+scriptsDir.mkdirs()
+def target = new File(scriptsDir, "${taskName}.groovy")
+if (target.exists()) {
+    System.err.println """
+Error: '${target.path}' already exists.
+Refusing to overwrite your local copy. Edit it directly, or remove it first.
+"""
+    System.exit 1
+}
+
+target.bytes = source.bytes
+
+println """
+Copied installed task '${taskName}' to:
+
+  ${target.canonicalPath}
+
+This project-local copy now overrides the installed task. Edit it freely —
+its bundled helpers (lib/) and resources still resolve from the installation,
+so the copy keeps working. When you run
+
+  ./dtcw ${taskName}
+
+dtcw runs your copy and prints a note that the installed task is being
+overridden. Delete the file to fall back to the installed task.
+"""

--- a/scripts/copyTask.groovy
+++ b/scripts/copyTask.groovy
@@ -19,6 +19,18 @@ Run './dtcw tasks' to see which tasks you can copy.
 }
 def taskName = args[0]
 
+// Validate the name before using it to build a path. This is both a usability
+// check and a path-traversal guard: without it, '../foo' could copy files from
+// outside the installed scripts directory.
+if (!(taskName ==~ /^[a-zA-Z][a-zA-Z0-9_-]*$/)) {
+    System.err.println """
+Error: invalid task name '${taskName}'.
+Task names must start with a letter and contain only letters, digits,
+hyphens or underscores. Run './dtcw tasks' to see the available tasks.
+"""
+    System.exit 2
+}
+
 if (!scriptsHome) {
     System.err.println """
 Error: cannot locate the docToolchain installation (dtc.scriptsHome is unset).
@@ -33,6 +45,20 @@ if (!source.exists()) {
 Error: installed task '${taskName}' not found at:
   ${source.path}
 Run './dtcw tasks' to see the available tasks.
+"""
+    System.exit 1
+}
+
+// Only runnable tasks (carrying the '// @task' marker in the first 5 lines,
+// see ADR-14) may be copied — not the non-task Groovy helpers that also live in
+// the installed scripts/ directory.
+def isTask = source.withReader { r ->
+    (1..5).any { (r.readLine() ?: '').contains('// @task') }
+}
+if (!isTask) {
+    System.err.println """
+Error: '${taskName}' is not a runnable task (no '// @task' marker), so it cannot
+be copied and overridden. Run './dtcw tasks' to see the available tasks.
 """
     System.exit 1
 }

--- a/scripts/copyThemes.groovy
+++ b/scripts/copyThemes.groovy
@@ -6,8 +6,8 @@ def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 def isHeadless = System.getProperty('DTC_HEADLESS', System.getenv('DTC_HEADLESS') ?: 'false') == 'true'
 
-def dtcHome = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile.parentFile
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def dtcHome = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')).parentFile : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile.parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def gcl = new GroovyClassLoader(this.class.classLoader)
 def DtcConfig = gcl.parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 gcl.parseClass(new File(scriptDir, 'lib/DtcException.groovy'))

--- a/scripts/createTask.groovy
+++ b/scripts/createTask.groovy
@@ -1,0 +1,74 @@
+#!/usr/bin/env groovy
+// @task
+// v4: Scaffold a new project-local custom task (see ADR-16).
+// Usage: ./dtcw createTask [taskName]
+// Creates <projectScriptsDir>/<taskName>.groovy in the current project with a
+// ready-to-edit skeleton that already carries the '// @task' marker, so dtcw
+// discovers and runs it. No edit to any config or registry is required.
+
+def docDir = System.getProperty('docDir', '.')
+// dtcw exports the project scripts directory name; default mirrors the wrapper.
+def scriptsDirName = System.getenv('DTC_PROJECT_SCRIPTS_DIR') ?: 'scripts'
+
+def taskName = (args && args.length > 0) ? args[0] : 'customTask'
+
+// Validate the name: it becomes a file name and a dtcw task argument.
+if (!(taskName ==~ /^[a-zA-Z][a-zA-Z0-9_-]*$/)) {
+    System.err.println """
+Error: invalid task name '${taskName}'.
+Task names must start with a letter and contain only letters, digits,
+hyphens or underscores. Example: ./dtcw createTask exportFoo
+"""
+    System.exit 2
+}
+
+def scriptsDir = new File(docDir, scriptsDirName)
+scriptsDir.mkdirs()
+def target = new File(scriptsDir, "${taskName}.groovy")
+
+if (target.exists()) {
+    System.err.println """
+Error: '${target.path}' already exists.
+Pick another name, or edit the existing file directly.
+"""
+    System.exit 1
+}
+
+target.text = """\
+#!/usr/bin/env groovy
+// @task
+// Custom task '${taskName}' — created by 'dtcw createTask'.
+// This file lives in your project and is discovered automatically by dtcw.
+
+// docDir is your project root; mainConfigFile is your docToolchainConfig.groovy.
+def docDir = System.getProperty('docDir', '.')
+def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
+
+// Optional: reuse docToolchain's bundled helpers from the installation.
+// 'dtc.scriptsHome' points at the installed scripts/ directory, so this works
+// even though this script lives in your project (see ADR-17).
+def scriptsHome = System.getProperty('dtc.scriptsHome')
+if (scriptsHome) {
+    def gcl = new GroovyClassLoader(this.class.classLoader)
+    def DtcConfig = gcl.parseClass(new File(scriptsHome, 'lib/DtcConfig.groovy'))
+    def config = DtcConfig.load(docDir, configFile).getRaw()
+    println "Custom task '${taskName}' — inputPath = \${config.inputPath}"
+}
+
+println "Hello from your custom task '${taskName}'!"
+// TODO: add your own logic here.
+"""
+
+println """
+Custom task created:
+
+  ${target.canonicalPath}
+
+Run it with:
+
+  ./dtcw ${taskName}
+
+List it together with the built-in tasks:
+
+  ./dtcw tasks
+"""

--- a/scripts/downloadTemplate.groovy
+++ b/scripts/downloadTemplate.groovy
@@ -10,7 +10,7 @@ def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 def isHeadless = System.getProperty('DTC_HEADLESS', System.getenv('DTC_HEADLESS') ?: 'false') == 'true'
 
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def gcl = new GroovyClassLoader(this.class.classLoader)
 def DtcConfig = gcl.parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 gcl.parseClass(new File(scriptDir, 'lib/DtcException.groovy'))

--- a/scripts/exportExcel.groovy
+++ b/scripts/exportExcel.groovy
@@ -8,7 +8,7 @@ import org.apache.poi.ss.usermodel.DataFormatter
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def DtcConfig = new GroovyClassLoader(this.class.classLoader).parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 def dtcConfig = DtcConfig.load(docDir, configFile)
 def config = dtcConfig.getRaw()

--- a/scripts/exportPPT.groovy
+++ b/scripts/exportPPT.groovy
@@ -13,7 +13,7 @@ import javax.imageio.ImageIO
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def DtcConfig = new GroovyClassLoader(this.class.classLoader).parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 def dtcConfig = DtcConfig.load(docDir, configFile)
 def config = dtcConfig.getRaw()

--- a/scripts/generateCICD.groovy
+++ b/scripts/generateCICD.groovy
@@ -3,7 +3,7 @@
 // v4: Scaffold a docToolchain CI/CD pipeline (dtcw4-based) for GitHub or GitLab
 
 def docDir = System.getProperty('docDir', '.')
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def gcl = new GroovyClassLoader(this.class.classLoader)
 gcl.parseClass(new File(scriptDir, 'lib/DtcException.groovy'))
 def DtcError = gcl.loadClass('DtcError')

--- a/scripts/generateHTML.groovy
+++ b/scripts/generateHTML.groovy
@@ -10,7 +10,7 @@ import org.asciidoctor.SafeMode
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def gcl = new GroovyClassLoader(this.class.classLoader)
 def DtcConfig = gcl.parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 gcl.parseClass(new File(scriptDir, 'lib/DtcException.groovy'))

--- a/scripts/generatePDF.groovy
+++ b/scripts/generatePDF.groovy
@@ -10,7 +10,7 @@ import org.asciidoctor.SafeMode
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def gcl = new GroovyClassLoader(this.class.classLoader)
 def DtcConfig = gcl.parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 gcl.parseClass(new File(scriptDir, 'lib/DtcException.groovy'))

--- a/scripts/generateSite.groovy
+++ b/scripts/generateSite.groovy
@@ -7,9 +7,9 @@ import groovy.io.FileType
 
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
-def dtcHome = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile.parentFile
+def dtcHome = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')).parentFile : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile.parentFile
 
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def DtcConfig = new GroovyClassLoader(this.class.classLoader).parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 def dtcConfig = DtcConfig.load(docDir, configFile)
 def config = dtcConfig.getRaw()

--- a/scripts/installBausteinsicht.groovy
+++ b/scripts/installBausteinsicht.groovy
@@ -3,7 +3,7 @@
 // v4: Install the Bausteinsicht CLI (architecture-as-code) and hint agents to use it
 
 def docDir = System.getProperty('docDir', '.')
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 def AgentHints = new GroovyClassLoader(this.class.classLoader)
     .parseClass(new File(scriptDir, 'lib/AgentHints.groovy'))
 

--- a/scripts/installDacli.groovy
+++ b/scripts/installDacli.groovy
@@ -4,7 +4,7 @@
 
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 
 def DtcConfig = new GroovyClassLoader(this.class.classLoader).parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))
 def config = DtcConfig.load(docDir, configFile).getRaw()

--- a/scripts/lintAsciiDoc.groovy
+++ b/scripts/lintAsciiDoc.groovy
@@ -4,7 +4,7 @@
 
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 
 def gcl = new GroovyClassLoader(this.class.classLoader)
 def DtcConfig = gcl.parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))

--- a/scripts/publishToConfluence.groovy
+++ b/scripts/publishToConfluence.groovy
@@ -15,9 +15,11 @@
 def docDir = System.getProperty('docDir', '.')
 def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
 
-// scriptDir = the directory this script lives in (…/scripts). For a script run
-// via groovy.ui.GroovyMain the codeSource location is the script file itself.
-def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+// scriptDir = the installed scripts/ directory that holds lib/ (ADR-17). dtcw
+// passes it via -Ddtc.scriptsHome so a project-local copy of this script still
+// finds the bundled helpers; the fallback (codeSource location, i.e. the script
+// file itself) applies when run directly via groovy.ui.GroovyMain without dtcw.
+def scriptDir = System.getProperty('dtc.scriptsHome') ? new File(System.getProperty('dtc.scriptsHome')) : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
 
 def libGcl = new GroovyClassLoader(this.class.classLoader)
 def DtcConfig = libGcl.parseClass(new File(scriptDir, 'lib/DtcConfig.groovy'))

--- a/src/docs/010_manual/45_custom_tasks.adoc
+++ b/src/docs/010_manual/45_custom_tasks.adoc
@@ -28,6 +28,11 @@ project script can be discovered without you registering it anywhere.
 The project scripts directory defaults to `scripts/` under your project root.
 Override it with the environment variable `DTC_PROJECT_SCRIPTS_DIR`.
 
+NOTE: In the `docker` environment the project is mounted at a fixed location
+inside the container, so `DTC_PROJECT_SCRIPTS_DIR` must be a path *relative* to
+the project root. `dtcw` rejects an absolute value with an actionable error when
+running a project-local task in Docker.
+
 == Adding a custom task
 
 Create a skeleton with `createTask` and edit it:

--- a/src/docs/010_manual/45_custom_tasks.adoc
+++ b/src/docs/010_manual/45_custom_tasks.adoc
@@ -1,0 +1,111 @@
+:filename: 010_manual/45_custom_tasks.adoc
+ifndef::imagesdir[:imagesdir: images]
+
+[[custom-tasks]]
+= Extending docToolchain: Custom Tasks and Monkey-Patching
+
+docToolchain ships every task as a self-contained Groovy script. You can use the
+same mechanism in your own project — to *add* a task or to *change* one that
+docToolchain already provides. Neither needs a fork, a build step, or an edit to
+a registry.
+
+NOTE: This is a v4 feature (the Gradle-free runtime driven by `dtcw`/`dtcw4`).
+The older v3 `customTasks` config entry belongs to the Gradle build and does not
+apply here.
+
+== How task resolution works
+
+When you run `./dtcw <task>`, the wrapper looks for the task script in two
+places, **the project first, the installation second**:
+
+. `scripts/<task>.groovy` in your project (the *project scripts directory*)
+. `<task>.groovy` in the installed docToolchain (`~/.doctoolchain/docToolchain-<version>/scripts/`)
+
+A file counts as a task only if it carries the marker `// @task` within its
+first five lines — exactly the rule used by the built-in tasks. This is how a
+project script can be discovered without you registering it anywhere.
+
+The project scripts directory defaults to `scripts/` under your project root.
+Override it with the environment variable `DTC_PROJECT_SCRIPTS_DIR`.
+
+== Adding a custom task
+
+Create a skeleton with `createTask` and edit it:
+
+[source,bash]
+----
+./dtcw createTask exportNotion
+----
+
+This writes `scripts/exportNotion.groovy` with the `// @task` marker already in
+place. Add your logic, then run it:
+
+[source,bash]
+----
+./dtcw exportNotion
+----
+
+It also shows up in the task list, under its own heading:
+
+[source,bash]
+----
+./dtcw tasks
+----
+
+You can of course create the file by hand instead — the only requirement is the
+`// @task` marker near the top.
+
+=== Reusing docToolchain's helpers
+
+A custom task can reuse the bundled helpers (for example `DtcConfig` to read
+`docToolchainConfig.groovy`). They live in the installation, not your project,
+and `dtcw` tells your script where via the `dtc.scriptsHome` system property:
+
+[source,groovy]
+----
+def docDir = System.getProperty('docDir', '.')
+def configFile = System.getProperty('mainConfigFile', 'docToolchainConfig.groovy')
+
+def scriptsHome = System.getProperty('dtc.scriptsHome')
+def gcl = new GroovyClassLoader(this.class.classLoader)
+def DtcConfig = gcl.parseClass(new File(scriptsHome, 'lib/DtcConfig.groovy'))
+def config = DtcConfig.load(docDir, configFile).getRaw()
+
+println "inputPath is ${config.inputPath}"
+----
+
+The skeleton created by `createTask` already contains this pattern.
+
+== Monkey-patching an installed task
+
+To change what a shipped task does, copy it into your project and edit the copy:
+
+[source,bash]
+----
+./dtcw copyTask generateHTML
+----
+
+This copies the installed `generateHTML.groovy` to `scripts/generateHTML.groovy`
+in your project. Because the project copy has the same name as an installed
+task, it *overrides* it: from now on `./dtcw generateHTML` runs **your** copy.
+
+docToolchain makes the override visible so you never patch by accident:
+
+* `./dtcw generateHTML` prints a note to stderr that the installed task is being
+  overridden by your project file.
+* `./dtcw tasks` lists `generateHTML` as `overridden by scripts/generateHTML.groovy`.
+
+The copy keeps working even though it now lives in your project: its bundled
+helpers and resources still resolve from the installation via `dtc.scriptsHome`.
+
+To return to the shipped behaviour, simply delete your copy.
+
+WARNING: A monkey-patched task is pinned to the version you copied. After
+upgrading docToolchain, re-copy the task if you want to pick up upstream changes.
+
+== Security note
+
+Project tasks are Groovy code that runs with your privileges — the same trust
+level that `docToolchainConfig.groovy` already has, since it too is executable
+Groovy. Opening someone else's project and running `dtcw` runs their scripts.
+Treat a project's `scripts/` directory with the same care as its config.

--- a/src/docs/010_manual/single-page.adoc
+++ b/src/docs/010_manual/single-page.adoc
@@ -45,6 +45,12 @@ include::40_features.adoc[leveloffset=+1]
 
 '''
 
+<<<
+
+include::45_custom_tasks.adoc[leveloffset=+1]
+
+'''
+
 = docToolchain Tasks
 
 :leveloffset: +0
@@ -88,6 +94,18 @@ include::../015_tasks/03_task_exportExcel.adoc[]
 <<<
 
 include::../015_tasks/03_task_downloadTemplate.adoc[]
+
+'''
+
+<<<
+
+include::../015_tasks/03_task_createTask.adoc[]
+
+'''
+
+<<<
+
+include::../015_tasks/03_task_copyTask.adoc[]
 
 '''
 

--- a/src/docs/015_tasks/03_task_copyTask.adoc
+++ b/src/docs/015_tasks/03_task_copyTask.adoc
@@ -1,0 +1,51 @@
+:filename: 015_tasks/03_task_copyTask.adoc
+include::_config.adoc[]
+
+[[task_copyTask]]
+== copyTask
+
+include::../_feedback.adoc[]
+
+=== About This Task
+
+`copyTask` copies an installed task script into your project so you can modify it
+— *monkey-patching*. The project copy has the same name as the installed task and
+therefore overrides it: `dtcw` runs your copy instead of the shipped one.
+
+[source,bash]
+----
+./dtcw copyTask generateHTML
+----
+
+This copies the installed `generateHTML.groovy` to `scripts/generateHTML.groovy`
+in your project. Edit it, then run `./dtcw generateHTML` as usual.
+
+=== Setup and Configuration
+
+* Pass the name of an existing installed task. Run `./dtcw tasks` to see the
+  available names.
+* The copy is placed in `scripts/` by default; override with
+  `DTC_PROJECT_SCRIPTS_DIR`.
+* `copyTask` refuses to overwrite an existing project copy.
+
+=== How the Override Behaves
+
+* `./dtcw generateHTML` prints a note to stderr that the installed task is being
+  overridden by your project file.
+* `./dtcw tasks` flags the task as `overridden by scripts/generateHTML.groovy`.
+* The copy still loads its bundled helpers and resources from the installation
+  via `dtc.scriptsHome`, so it keeps working unchanged.
+* Delete the copy to fall back to the shipped task.
+
+WARNING: A copied task is pinned to the version you copied. After upgrading
+docToolchain, re-copy it if you want upstream changes.
+
+=== Further Reading and Resources
+
+* xref:../010_manual/45_custom_tasks.adoc[Extending docToolchain: Custom Tasks and Monkey-Patching]
+* <<task_createTask,createTask>> — scaffold a brand-new custom task
+
+=== Source
+
+:param_source_file: scripts/copyTask.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/015_tasks/03_task_createTask.adoc
+++ b/src/docs/015_tasks/03_task_createTask.adoc
@@ -1,0 +1,43 @@
+:filename: 015_tasks/03_task_createTask.adoc
+include::_config.adoc[]
+
+[[task_createTask]]
+== createTask
+
+include::../_feedback.adoc[]
+
+=== About This Task
+
+`createTask` scaffolds a new *project-local custom task*. It writes a ready-to-edit
+Groovy script — with the `// @task` marker already in place — into your project's
+scripts directory, so `dtcw` discovers and runs it without any further wiring.
+
+[source,bash]
+----
+./dtcw createTask exportNotion
+----
+
+This creates `scripts/exportNotion.groovy`. Run it with `./dtcw exportNotion` and
+see it listed via `./dtcw tasks`.
+
+=== Setup and Configuration
+
+* The task name must start with a letter and contain only letters, digits,
+  hyphens or underscores. If omitted, the name defaults to `customTask`.
+* The target directory defaults to `scripts/`; override it with the
+  `DTC_PROJECT_SCRIPTS_DIR` environment variable.
+* `createTask` never overwrites an existing file — pick a new name or edit the
+  existing script directly.
+
+The generated skeleton shows how to read `docToolchainConfig.groovy` and reuse
+docToolchain's bundled helpers via the `dtc.scriptsHome` system property.
+
+=== Further Reading and Resources
+
+* xref:../010_manual/45_custom_tasks.adoc[Extending docToolchain: Custom Tasks and Monkey-Patching]
+* <<task_copyTask,copyTask>> — copy an installed task to modify it
+
+=== Source
+
+:param_source_file: scripts/createTask.groovy
+include::_viewTaskSource.adoc[]

--- a/src/docs/arc42/adrs/adr-16-project-local-tasks.adoc
+++ b/src/docs/arc42/adrs/adr-16-project-local-tasks.adoc
@@ -1,0 +1,55 @@
+=== ADR-16: Project-Local Tasks — Custom Tasks and Monkey-Patching via a Project `scripts/` Directory
+
+* **Status**: Accepted (for v4)
+* **Context**: v4 tasks are self-contained Groovy scripts (ADR-12) discovered by the `// @task` marker (ADR-14), but `dtcw` only ever resolves them from the *installed* runtime (`~/.doctoolchain/docToolchain-<version>/scripts/`). A project therefore could not (a) add its **own** task without forking docToolchain, nor (b) **modify** a shipped task short of editing the shared installation — which every other project on the machine then inherits. The v3 mechanism for this (`scripts/customTasks.gradle`, the `customTasks = [...]` config list, and a Gradle `createTask`) is Gradle-bound and dead under the Gradle-free v4 runtime (ADR-3). Quality goal QS-1 ("a contributor adds a task as one script, no build-system knowledge") is only half met: it holds for docToolchain's own repo, not for a *consuming* project. Two distinct user needs share one root cause — `dtcw` does not look in the project:
++
+. **Custom tasks** — a user drops a new task into their project and runs it.
+. **Monkey-patching** — a user copies an installed task into their project, edits it, and has their version run instead of the shipped one.
+
+* **Decision**: `dtcw` resolves a task from a **project-local scripts directory first, then the installation**. The directory defaults to `scripts/` under the project root and is overridable via `DTC_PROJECT_SCRIPTS_DIR`. The same ADR-14 rule applies: a file is a task **iff** it is a `*.groovy` with `// @task` in its first 5 lines — so discovery is uniform across installed and project tasks, with no registry and no config edit (extending QS-1 to consuming projects).
+** A project task whose name does **not** match an installed task is a **custom task** (need 1).
+** A project task whose name **matches** an installed task **overrides** it — monkey-patching (need 2). `dtcw` prints a `Note:` to stderr on every override run, so a shadowed task is never silent (transparency; relevant to T-005).
+** Two helper tasks make the workflow one command: `createTask <name>` scaffolds a marked skeleton in the project, and `copyTask <name>` copies an installed script into the project for editing.
+
+* **Alternatives considered**:
+
+[cols="3,1,1,1", options="header"]
+|===
+|Criterion |A: Config list (`customTasks=[…]`, v3-style) |B: Project `scripts/` + `// @task` auto-discovery (chosen) |C: Edit the shared installation directly
+
+|Adding a task (no central edit) — QS-1
+|–1 (must list every file in config)
+|+1 (drop one marked file, like installed tasks)
+|0 (no project file, but edits global state)
+
+|Consistency with ADR-14 (one discovery rule)
+|–1 (second, different mechanism)
+|+1 (same `// @task` rule everywhere)
+|+1 (it *is* the installation)
+
+|Override isolation (per project, not global)
+|0 (no override story)
+|+1 (override lives in the project repo)
+|–1 (every project on the box inherits the edit)
+
+|Transparency of an override (no silent shadowing) — T-005
+|0
+|+1 (`Note:` printed on each override run)
+|–1 (invisible global change)
+
+|Reproducibility (override travels with the repo)
+|0
+|+1 (committed alongside the docs)
+|–1 (lives outside version control)
+
+|**Total**
+|**–2**
+|**+5**
+|**–2**
+|===
+
+* **Quality Tradeoffs**:
+** Supports **QS-1 (Extensibility)**: a consuming project adds a task exactly the way docToolchain's own repo does — one marked script, no build-system knowledge, appears in `./dtcw tasks`.
+** Supports **QS-11 (Script-first)** and **QS-3 (Usability)**: one uniform task model; `createTask`/`copyTask` keep the first step to a single command.
+** Cost on **predictability**: a project file can now silently change what `generateHTML` does. Mitigated by the mandatory override `Note:` and by the override being flagged in `./dtcw tasks`.
+* **Consequences**: `dtcw` gains a project-first resolution step in `assert_v4_task_exists`, `list_v4_tasks`, and `build_command`; the listing flags overrides and groups custom tasks. Project tasks are executable Groovy authored by the project — the **same local-trust assumption already accepted for `docToolchainConfig.groovy`** (threat **T-005**, <<section-concepts>>): opening and running `dtcw` in a project already runs that project's Groovy, so project tasks add no new trust class, only more surface within it. The override `Note:` keeps shadowing visible. This decision depends on ADR-17 so that a copied or custom script can still load the bundled `lib/` helpers from the installation. No new Chapter 11 risk is created; the consequence is recorded as accepted under the existing T-005 local-trust model. The Windows wrappers (`dtcw.ps1`/`dtcw.bat`) do not yet carry the v4 path at all (Chapter 11 technical debt), so project-task resolution lands in the Bash `dtcw` first; Windows parity rides on the existing "no v4 Windows wrapper path" debt item.

--- a/src/docs/arc42/adrs/adr-17-script-home-lib-resolution.adoc
+++ b/src/docs/arc42/adrs/adr-17-script-home-lib-resolution.adoc
@@ -1,0 +1,57 @@
+=== ADR-17: `dtc.scriptsHome` — Resolve `lib/` Helpers and Resources from the Installation, Not the Script Location
+
+* **Status**: Accepted (for v4)
+* **Context**: Every v4 task script loads its shared helpers relative to *its own* file location: `def scriptDir = new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile` and then `new File(scriptDir, 'lib/DtcConfig.groovy')`. Three scripts likewise derive `dtcHome = scriptDir.parentFile` to find bundled resources (themes, landing page). This works only because installed scripts sit next to `lib/`. ADR-16 lets a script run from the *project* `scripts/` directory, where there is no `lib/` and no bundled resources — so a copied (monkey-patched) or custom script would fail to load `DtcConfig`/`DtcException` and break at startup. The helpers and resources it needs live in the installation, not the project.
+* **Decision**: `dtcw` passes the installed scripts directory to every run as a system property: `-Ddtc.scriptsHome="${dtc_home}/scripts"` (and `/opt/docToolchain/scripts` inside the Docker image). Scripts resolve their helper/resource base from that property, falling back to the on-disk script location when it is absent:
++
+[source,groovy]
+----
+def scriptDir = System.getProperty('dtc.scriptsHome')
+    ? new File(System.getProperty('dtc.scriptsHome'))
+    : new File(getClass().protectionDomain.codeSource.location.toURI()).parentFile
+----
++
+For an installed script `dtc.scriptsHome` equals its own directory, so behaviour is unchanged; for a project script it points back at the installation, so `lib/` and bundled resources resolve correctly regardless of where the script file lives.
+
+* **Alternatives considered**:
+
+[cols="3,1,1,1", options="header"]
+|===
+|Criterion |A: Copy `lib/` into the project too |B: `dtc.scriptsHome` system property (chosen) |C: Put `lib/` on the classpath and load helpers by class name
+
+|Project-script startup works (ADR-16) — QS-1
+|+1 (lib present locally)
+|+1 (resolves from install)
+|+1
+
+|Footprint / no duplication (QS-6)
+|–1 (copies ~MBs of helpers per project)
+|+1 (single installed copy)
+|+1
+
+|Determinism — copy can't drift from the runtime (QS-4)
+|–1 (project lib goes stale on upgrade)
+|+1 (always the installed helpers)
+|+1
+
+|Change size / risk across existing scripts
+|+1 (no script change)
+|0 (one mechanical line per script)
+|–1 (rework every helper-loading site + packaging)
+
+|Backward compatibility (installed scripts unchanged)
+|+1
+|+1 (property defaults to own dir)
+|0
+
+|**Total**
+|**+1**
+|**+4**
+|**+2**
+|===
+
+* **Quality Tradeoffs**:
+** Supports **QS-1 (Extensibility)**: custom and copied scripts load the same bundled helpers as installed tasks — the project extension point is fully functional, not a stub.
+** Supports **QS-4 (Determinism)** and **QS-6 (Footprint)**: helpers exist once, in the installation; a project copy can never drift from the runtime and adds no per-project megabytes.
+** Cost: a one-line convention every helper-loading script must follow; a script that hard-codes `scriptDir` from its own location instead of honouring `dtc.scriptsHome` silently breaks when run as a project override. Documented as the canonical idiom and demonstrated by the `createTask` skeleton.
+* **Consequences**: The `scriptDir`/`dtcHome` definition is updated to the property-first form across the v4 scripts that load `lib/` or bundled resources, and `dtcw` exports `dtc.scriptsHome` on every v4 invocation (local and Docker). This unblocks ADR-16: monkey-patched and custom scripts run against the installed helpers. It also contributes to **R-003 (script loading / classpath)** — helper resolution now hinges on a correctly-set property — mitigated by the safe fallback to the script's own directory when the property is unset (e.g. direct `groovy` invocation outside `dtcw`).

--- a/src/docs/arc42/adrs/adr-18-groovy-task-launcher.adoc
+++ b/src/docs/arc42/adrs/adr-18-groovy-task-launcher.adoc
@@ -1,0 +1,50 @@
+=== ADR-18: v4 Task Dispatch Moves into a Groovy Launcher — Bash Wrapper Reduced to JVM Bootstrap
+
+* **Status**: Proposed (target of the v4 quality rewrite; not yet implemented)
+* **Context**: v4 task *dispatch* logic currently lives in the Bash wrapper `dtcw`: task discovery (`list_v4_tasks`), validation (`assert_v4_task_exists`), and selection/invocation (the v4 branch of `build_command`), including the project-first resolution and override notes added for ADR-16. `dtcw4` only bootstraps and `exec`s the installed `dtcw` (ADR-13). Two forces make Bash the wrong long-term home for this logic:
+** **No cross-platform single source.** The v4 `GroovyMain` path exists only in the Bash `dtcw`; `dtcw.ps1`/`dtcw.bat` carry no v4 path at all (tracked as technical debt in <<section-technical-risks>>). Every piece of dispatch logic added in Bash must eventually be re-implemented twice more, in two more untyped shell dialects — exactly the drift the `// @task` marker (ADR-14) was meant to avoid for the task list.
+** **Untestable, against the v4 grain.** Dispatch logic in Bash is exercised only by bats integration tests; it cannot be unit-tested. v4's direction is script-first Groovy with logic out of the wrapper/build layer (ADR-3, ADR-5, ADR-12). Discovery, project-vs-install resolution, and override signalling are business logic, not JVM bootstrapping.
+* **Decision**: Extract v4 task discovery, resolution, and invocation into a single **Groovy launcher** (e.g. `scripts/Launcher.groovy`) executed inside the JVM the wrapper already starts. The platform wrappers (`dtcw`, `dtcw.ps1`, `dtcw.bat`) are reduced to what only they can do — detect the environment, locate Java, build the `lib/*` classpath, and hand **all** arguments to the launcher with the existing system properties (`docDir`, `dtc.scriptsHome`, `DTC_PROJECT_SCRIPTS_DIR`, …). The launcher owns: scanning the project and installed scripts directories, the `// @task` marker check, project-first selection with override/custom notes (ADR-16), unknown-task guidance, and dispatch to the chosen task script. This is the structural move; behaviour is preserved (the bats acceptance tests from ADR-16 stay green and are joined by Spock unit tests around the launcher).
+* **Alternatives considered**:
+
+[cols="3,1,1,1", options="header"]
+|===
+|Criterion |A: Keep dispatch in each wrapper (Bash + PS + BAT) |B: Groovy launcher, wrappers bootstrap only (chosen) |C: Compiled Java launcher in `lib/`
+
+|Single source across platforms (kills the Windows-parity debt) — QS-2
+|–1 (logic hand-ported into three shells)
+|+1 (one launcher for all wrappers)
+|+1
+
+|Testability (Spock unit tests vs bats/manual)
+|–1
+|+1
+|+1
+
+|Script-first, no compile step (ADR-3/ADR-12)
+|0
+|+1
+|–1 (reintroduces a build artifact)
+
+|Startup overhead (QS-9)
+|+1 (no extra step)
+|0 (runs in the JVM already started for the task)
+|+1
+
+|Change size / risk
+|0
+|0
+|–1 (build + packaging return)
+
+|**Total**
+|**–1**
+|**+3**
+|**+1**
+|===
+
+* **Quality Tradeoffs**:
+** Supports **QS-2 (Portability)** and retires the *"No v4 Windows wrapper path"* technical debt: one launcher gives `dtcw.ps1`/`dtcw.bat` the v4 path for free.
+** Supports **QS-1 (Extensibility)**, **QS-11 (Script-first)**, **QS-5 (Testability/maintainability)**: dispatch becomes Groovy, unit-tested, and consistent with how tasks themselves are written.
+** Neutral on **QS-9 (Fast startup)**: discovery moves into the JVM that is started for the task anyway — no second process.
+** Cost: a one-time refactor and the discipline of keeping the wrappers thin. Bash keeps only environment/JVM bootstrapping.
+* **Consequences**: The ~50 lines of v4 dispatch in `dtcw` (the ADR-16 resolution, listing, and notes) move into the launcher; the wrappers shrink to bootstrap + delegate. ADR-16's behaviour and bats acceptance tests are preserved, with Spock unit tests added around the launcher. This decision **does not change** ADR-13 (thin `dtcw4` → installed wrapper) or ADR-17 (`dtc.scriptsHome`), which already live in Groovy and are unaffected. Until this lands, the project-task logic from ADR-16 remains in the Bash `dtcw` as a deliberate tracer-bullet — correct and tested, but pending extraction. Tracked as an EPIC referencing the *"No v4 Windows wrapper path"* debt in <<section-technical-risks>>.

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -84,6 +84,14 @@ Statuses follow Nygard values (Proposed / Accepted / Superseded / Deprecated). `
 |Structural Diagrams as Architecture-as-Code (Bausteinsicht model, PlantUML render)
 |Accepted (for v4) — export wiring deferred
 
+|ADR-16
+|Project-Local Tasks — Custom Tasks and Monkey-Patching
+|Accepted (for v4)
+
+|ADR-17
+|`dtc.scriptsHome` — Resolve `lib/` Helpers from the Installation
+|Accepted (for v4)
+
 |ADR-TBD-1
 |Confluence API Version Strategy
 |Proposed
@@ -122,6 +130,10 @@ include::../adrs/adr-13-dtcw-delegation.adoc[]
 include::../adrs/adr-14-task-discovery.adoc[]
 
 include::../adrs/adr-15-architecture-as-code-diagrams.adoc[]
+
+include::../adrs/adr-16-project-local-tasks.adoc[]
+
+include::../adrs/adr-17-script-home-lib-resolution.adoc[]
 
 include::../adrs/adr-tbd-1-confluence-api.adoc[]
 

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -92,6 +92,10 @@ Statuses follow Nygard values (Proposed / Accepted / Superseded / Deprecated). `
 |`dtc.scriptsHome` — Resolve `lib/` Helpers from the Installation
 |Accepted (for v4)
 
+|ADR-18
+|v4 Task Dispatch Moves into a Groovy Launcher
+|Proposed
+
 |ADR-TBD-1
 |Confluence API Version Strategy
 |Proposed
@@ -134,6 +138,8 @@ include::../adrs/adr-15-architecture-as-code-diagrams.adoc[]
 include::../adrs/adr-16-project-local-tasks.adoc[]
 
 include::../adrs/adr-17-script-home-lib-resolution.adoc[]
+
+include::../adrs/adr-18-groovy-task-launcher.adoc[]
 
 include::../adrs/adr-tbd-1-confluence-api.adoc[]
 

--- a/src/docs/arc42/spec/02_project_local_tasks.adoc
+++ b/src/docs/arc42/spec/02_project_local_tasks.adoc
@@ -1,0 +1,256 @@
+= docToolchain v4 — Specification: Project-Local Tasks
+:toc:
+:toclevels: 3
+:sectnums:
+
+// This specification covers two related features: project-local *custom tasks*
+// and *monkey-patching* of installed tasks. Both rest on the same mechanism —
+// dtcw resolving tasks from the project before the installation (ADR-16) and
+// scripts loading their helpers from the installation (ADR-17).
+
+== Problem and Goals (PRD digest)
+
+*Problem.* A docToolchain v4 user can neither add their own task nor change a
+shipped task without forking docToolchain or editing the shared installation
+that every project on the machine inherits. The v3 mechanism
+(`customTasks.gradle`) is Gradle-bound and dead under the Gradle-free v4 runtime.
+
+*Goals.*
+
+* *G-1 Custom tasks* — a user adds a project-specific task and runs it via `dtcw`,
+  with no fork and no edit to a registry or config (concretises quality goal QS-1).
+* *G-2 Monkey-patching* — a user copies an installed task into their project,
+  edits it, and `dtcw` runs the project copy instead of the shipped one,
+  isolated to that project and committed alongside the docs.
+* *G-3 Transparency* — an override is never silent; the user always sees that a
+  patched task is running.
+
+*Personas.* Documentation Author (runs tasks), Build/Tooling Maintainer
+(authors custom tasks and patches), CI pipeline (non-interactive runner).
+
+*Success criteria.* A new marked script in the project appears in `./dtcw tasks`
+and runs; a same-named project script overrides the installed one and prints a
+note; both load the bundled `lib/` helpers without copying them into the project.
+
+== Domain Terms (Ubiquitous Language)
+
+[cols="1,3", options="header"]
+|===
+|Term |Meaning
+
+|Installed task
+|A `*.groovy` with `// @task` (first 5 lines, ADR-14) under the installation `scripts/`.
+
+|Project scripts directory
+|Directory under the project root scanned for project tasks. Default `scripts/`, overridable via `DTC_PROJECT_SCRIPTS_DIR`.
+
+|Custom task
+|A project task whose name matches no installed task — it *adds* a task.
+
+|Override (monkey-patch)
+|A project task whose name matches an installed task — it *replaces* it for this project.
+
+|`dtc.scriptsHome`
+|System property set by `dtcw` to the installed `scripts/` directory, so any script resolves `lib/` and bundled resources from the installation (ADR-17).
+|===
+
+== Use Cases (Cockburn, fully dressed)
+
+=== UC-CT-1: Add a Custom Task
+
+* *Primary Actor*: Build/Tooling Maintainer
+* *Level*: User goal
+* *Trigger*: The maintainer needs a project-specific automation step (e.g. `exportNotion`).
+* *Preconditions*: docToolchain v4 is installed; the project has a `docToolchainConfig.groovy`.
+* *Postconditions (success)*: A `*.groovy` task exists in the project scripts directory and runs via `./dtcw <name>`; it appears in `./dtcw tasks`.
+
+*Main Success Scenario*
+
+. Maintainer runs `./dtcw createTask exportNotion` (or hand-creates the file).
+. `dtcw` writes `scripts/exportNotion.groovy` with a `// @task` skeleton.
+. Maintainer edits the script's logic.
+. Maintainer runs `./dtcw exportNotion`.
+. `dtcw` discovers the project task, runs it, and prints a note that a project-local custom task is running.
+
+*Extensions*
+
+* 1a. Name invalid (BR-2): `createTask` aborts with an actionable message; no file written.
+* 1b. File already exists: `createTask` aborts and refuses to overwrite.
+* 4a. Marker missing or past line 5 (BR-1): the task is not discovered; `./dtcw tasks` does not list it and `./dtcw exportNotion` reports "Unknown task".
+
+*Business Rules*: BR-1, BR-2, BR-5.
+
+=== UC-CT-2: Monkey-Patch an Installed Task
+
+* *Primary Actor*: Build/Tooling Maintainer
+* *Level*: User goal
+* *Trigger*: A shipped task needs a project-specific change (e.g. tweak `generateHTML` attributes).
+* *Preconditions*: The task to patch exists in the installation.
+* *Postconditions (success)*: A project copy of the task runs instead of the installed one, for this project only; the installation is untouched.
+
+*Main Success Scenario*
+
+. Maintainer runs `./dtcw copyTask generateHTML`.
+. `dtcw` copies the installed `generateHTML.groovy` into the project scripts directory.
+. Maintainer edits the project copy.
+. Maintainer runs `./dtcw generateHTML`.
+. `dtcw` resolves the project copy first (BR-3), prints an override note to stderr (BR-4), and runs it; the copy loads `lib/` helpers from the installation (BR-6).
+
+*Extensions*
+
+* 1a. Installed task not found: `copyTask` aborts with the list of available tasks.
+* 2a. Project copy already exists: `copyTask` aborts and refuses to overwrite.
+* 4a. Maintainer deletes the project copy: `dtcw` falls back to the installed task, no note printed.
+
+*Business Rules*: BR-3, BR-4, BR-6.
+
+== System Use Cases (per CLI interface)
+
+=== SUC-1: `./dtcw <task>` resolution
+
+* *Input*: a task name matching `^[a-zA-Z][a-zA-Z0-9_-]*$`.
+* *Processing*:
+.. If `<projectScriptsDir>/<task>.groovy` exists and is marked, select it; else if the installed script exists and is marked, select that; else fail.
+.. If a project script was selected and an installed script of the same name exists, emit an override note to stderr; if no installed counterpart exists, emit a custom-task note.
+.. Invoke `java … groovy.ui.GroovyMain <selected script>` with `-DdocDir=.` and `-Ddtc.scriptsHome=<install>/scripts`.
+* *Output / status*: exit 0 on success; exit `ERR_ARG` for an invalid or unknown task name; the selected script's exit code otherwise.
+* *Error responses*: invalid name → "Invalid task name"; unknown task → "Unknown task '<task>'" plus near-name suggestions and "Run './dtcw tasks'".
+
+=== SUC-2: `./dtcw tasks` listing
+
+* *Input*: none (a trailing `--group …` is accepted and ignored with a note).
+* *Processing*: list installed tasks; annotate any that a project script overrides as `(overridden by …)`; then list project-only custom tasks under a separate heading.
+* *Output*: the task list; exit 0.
+
+=== SUC-3: `./dtcw createTask [name]`
+
+* *Input*: optional task name (default `customTask`), validated by BR-2.
+* *Processing*: create `<projectScriptsDir>/<name>.groovy` from a marked skeleton.
+* *Output / status*: path of the created file, exit 0; exit 2 on invalid name; exit 1 if the file exists.
+
+=== SUC-4: `./dtcw copyTask <name>`
+
+* *Input*: required name of an installed task.
+* *Processing*: copy `<install>/scripts/<name>.groovy` to `<projectScriptsDir>/<name>.groovy`.
+* *Output / status*: path of the copy plus an override hint, exit 0; exit 2 if no name; exit 1 if the installed task is missing or the copy already exists.
+
+== Activity Diagram — Task Resolution (SUC-1)
+
+[plantuml,suc1-task-resolution,svg]
+----
+@startuml
+start
+:user runs ./dtcw <task>;
+if (task name well-formed?) then (no)
+  :print "Invalid task name";
+  stop
+else (yes)
+endif
+if (project scripts dir has <task>.groovy with // @task ?) then (yes)
+  if (installed <task>.groovy exists ?) then (yes)
+    :print override Note to stderr (BR-4);
+  else (no)
+    :print custom-task Note to stderr;
+  endif
+  :select project script;
+else (no)
+  if (installed <task>.groovy with // @task ?) then (yes)
+    :select installed script;
+  else (no)
+    :print "Unknown task" + suggestions;
+    stop
+  endif
+endif
+:invoke GroovyMain with
+-DdocDir=. and -Ddtc.scriptsHome=<install>/scripts;
+stop
+@enduml
+----
+
+== Requirements (EARS)
+
+* *EARS-1 (ubiquitous)*: The dtcw wrapper shall treat a `*.groovy` file as a task only if it carries `// @task` within its first five lines.
+* *EARS-2 (event)*: When a task name is requested, dtcw shall resolve a project-local script in preference to an installed script of the same name.
+* *EARS-3 (event)*: When dtcw runs a project-local script that shadows an installed task, dtcw shall emit a note to stderr identifying the overriding file.
+* *EARS-4 (state)*: While running any v4 task, dtcw shall pass `-Ddtc.scriptsHome` set to the installed scripts directory.
+* *EARS-5 (event)*: When a requested task name matches neither a project nor an installed marked script, dtcw shall exit non-zero with an "Unknown task" message.
+* *EARS-6 (unwanted)*: If `createTask`/`copyTask` would overwrite an existing project file, then dtcw shall abort without modifying it.
+
+== Business Rules
+
+* *BR-1*: A task is discoverable iff it is a `*.groovy` with `// @task` in its first five lines (consistent with ADR-14).
+* *BR-2*: A task name must match `^[a-zA-Z][a-zA-Z0-9_-]*$`.
+* *BR-3*: Project scripts take precedence over installed scripts of the same name.
+* *BR-4*: Every override run prints a visible note; overrides are flagged in `./dtcw tasks`.
+* *BR-5*: Adding a custom task requires no edit to any config file or registry.
+* *BR-6*: A project script loads bundled `lib/` helpers and resources from the installation via `dtc.scriptsHome`, never from the project.
+
+== Acceptance Criteria (Gherkin)
+
+[source,gherkin]
+----
+Feature: Project-local custom tasks and monkey-patching
+
+  Scenario: Custom task is discovered (UC-CT-1, BR-1, BR-5)
+    Given a project scripts directory contains myCustomTask.groovy with a // @task marker
+    When the user runs ./dtcw tasks
+    Then "myCustomTask" appears under the project-local custom tasks heading
+
+  Scenario: Unmarked file is not a task (BR-1)
+    Given a project scripts directory contains justAHelper.groovy without a // @task marker
+    When the user runs ./dtcw tasks
+    Then "justAHelper" does not appear in the task list
+
+  Scenario: Custom task runs with the installation helpers (UC-CT-1, BR-6)
+    Given a project scripts directory contains myCustomTask.groovy with a // @task marker
+    When the user runs ./dtcw myCustomTask
+    Then dtcw runs the project script
+    And it passes -Ddtc.scriptsHome pointing at the installed scripts directory
+
+  Scenario: Override shadows the installed task and is announced (UC-CT-2, BR-3, BR-4)
+    Given an installed task generateHTML exists
+    And the project scripts directory contains generateHTML.groovy with a // @task marker
+    When the user runs ./dtcw generateHTML
+    Then dtcw runs the project copy, not the installed script
+    And dtcw prints a note that the installed task is being overridden
+
+  Scenario: Override is flagged in the task list (BR-4)
+    Given an installed task generateHTML exists
+    And the project scripts directory contains generateHTML.groovy with a // @task marker
+    When the user runs ./dtcw tasks
+    Then "generateHTML" is shown as overridden by the project script
+
+  Scenario: Unknown task is rejected (EARS-5)
+    Given no script named thisTaskDoesNotExist exists in the project or the installation
+    When the user runs ./dtcw thisTaskDoesNotExist
+    Then dtcw exits non-zero
+    And dtcw prints "Unknown task"
+
+  Scenario: copyTask refuses to overwrite (EARS-6, BR-3)
+    Given the project scripts directory already contains generateHTML.groovy
+    When the user runs ./dtcw copyTask generateHTML
+    Then dtcw aborts without modifying the existing file
+----
+
+== Traceability
+
+[cols="1,2,2", options="header"]
+|===
+|Item |Realised by |Verified by
+
+|UC-CT-1 / G-1
+|ADR-16, `createTask.groovy`, dtcw resolution
+|`test/custom_tasks.bats` (discovery, custom run)
+
+|UC-CT-2 / G-2
+|ADR-16, `copyTask.groovy`, dtcw override resolution
+|`test/custom_tasks.bats` (override run, listing)
+
+|G-3 / BR-4
+|dtcw override `Note:` + listing annotation
+|`test/custom_tasks.bats` (override note)
+
+|BR-6 / ADR-17
+|`dtc.scriptsHome` + script `scriptDir` idiom
+|`test/custom_tasks.bats` (scriptsHome passed)
+|===

--- a/test/custom_tasks.bats
+++ b/test/custom_tasks.bats
@@ -58,6 +58,18 @@ teardown() {
     assert_output --partial "generateHTML (overridden by"
 }
 
+@test "custom: a project task matching a non-task installed helper is custom, not an override" {
+    # The installation also holds non-task *.groovy helpers (no // @task marker).
+    # A project task sharing such a name must be a custom task, never an override.
+    printf '// a helper, not a task\nclass Foo {}\n' > "${DTC_HOME}/scripts/asciidoctorExtensions.groovy"
+    printf '// @task\n' > "${DTC_PROJECT_SCRIPTS_DIR}/asciidoctorExtensions.groovy"
+    run ./dtcw tasks
+    assert_success
+    assert_output --partial "Project-local custom tasks"
+    assert_output --partial "asciidoctorExtensions"
+    refute_output --partial "asciidoctorExtensions (overridden"
+}
+
 # --- Validation --------------------------------------------------------------
 
 @test "custom: an unknown task name is still rejected" {

--- a/test/custom_tasks.bats
+++ b/test/custom_tasks.bats
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2026, the docToolchain contributors
+
+# Tests for project-local custom tasks and monkey-patching (ADR-16, ADR-17).
+#
+# A *.groovy file with the '// @task' marker in a project-local scripts
+# directory is discovered by dtcw. It either adds a new task (custom task) or,
+# when it shares a name with an installed task, overrides it (monkey-patching).
+
+setup() {
+    load 'test_helper.bash'
+    setup_environment
+
+    export DTC_PROJECT_BRANCH=test
+
+    # Create a v4 installation (lib/ directory present)
+    mkdir -p "${DTC_HOME}/lib"
+    mkdir -p "${DTC_HOME}/scripts"
+    touch "${DTC_HOME}/lib/dummy.jar"
+
+    # An installed task
+    printf '// @task\n' > "${DTC_HOME}/scripts/generateHTML.groovy"
+
+    # Installed local java (so the v4 java invocation is captured, not real)
+    java_mock=$(mock_create_java "${DTC_ROOT}/jdk/bin/java" "17.0.14")
+
+    # Isolate the project scripts directory from the repository's own scripts/
+    export DTC_PROJECT_SCRIPTS_DIR="${BATS_TEST_TMPDIR}/project-scripts"
+    mkdir -p "${DTC_PROJECT_SCRIPTS_DIR}"
+}
+
+teardown() {
+    mock_teardown
+    rm -rf "${DTC_ROOT}"
+}
+
+# --- Discovery / listing -----------------------------------------------------
+
+@test "custom: a project-local task with @task marker is listed" {
+    printf '// @task\n' > "${DTC_PROJECT_SCRIPTS_DIR}/myCustomTask.groovy"
+    run ./dtcw tasks
+    assert_success
+    assert_output --partial "Project-local custom tasks"
+    assert_output --partial "myCustomTask"
+}
+
+@test "custom: a project-local *.groovy without the marker is NOT a task" {
+    printf '// not a task\n' > "${DTC_PROJECT_SCRIPTS_DIR}/justAHelper.groovy"
+    run ./dtcw tasks
+    assert_success
+    refute_output --partial "justAHelper"
+}
+
+@test "override: a project task shadowing an installed one is flagged in the listing" {
+    printf '// @task\n' > "${DTC_PROJECT_SCRIPTS_DIR}/generateHTML.groovy"
+    run ./dtcw tasks
+    assert_success
+    assert_output --partial "generateHTML (overridden by"
+}
+
+# --- Validation --------------------------------------------------------------
+
+@test "custom: an unknown task name is still rejected" {
+    run ./dtcw thisTaskDoesNotExist
+    assert_failure
+    assert_output --partial "Unknown task"
+}
+
+# --- Execution / resolution --------------------------------------------------
+
+@test "custom: running a project-local task invokes its script with dtc.scriptsHome" {
+    printf '// @task\n' > "${DTC_PROJECT_SCRIPTS_DIR}/myCustomTask.groovy"
+    run ./dtcw myCustomTask
+    assert_success
+    # Informational note that a project-local custom task is being run
+    assert_output --partial "project-local custom task 'myCustomTask'"
+    # The most recent java call runs GroovyMain on the project script and passes
+    # the installed scripts directory so lib/ resolves from the installation.
+    # (java is also called once for the -version check, hence no call-count assert.)
+    run mock_get_call_args "${java_mock}"
+    assert_output --partial "-Ddtc.scriptsHome=${DTC_HOME}/scripts"
+    assert_output --partial "${DTC_PROJECT_SCRIPTS_DIR}/myCustomTask.groovy"
+}
+
+@test "override: running an overridden task uses the project copy and warns" {
+    printf '// @task\n' > "${DTC_PROJECT_SCRIPTS_DIR}/generateHTML.groovy"
+    run ./dtcw generateHTML
+    assert_success
+    assert_output --partial "override of task 'generateHTML'"
+    run mock_get_call_args "${java_mock}"
+    # The project copy is executed, not the installed one
+    assert_output --partial "${DTC_PROJECT_SCRIPTS_DIR}/generateHTML.groovy"
+    refute_output --partial "${DTC_HOME}/scripts/generateHTML.groovy"
+}


### PR DESCRIPTION
EPIC #1666 · closes #1667 · closes #1668

## What

Let a v4 project **extend** docToolchain — add its own tasks (**custom tasks**) and modify shipped ones (**monkey-patching**) — without forking docToolchain or editing the shared installation.

`dtcw` now resolves a task **project-first, installation-second**, using the same `// @task` marker rule as installed tasks (ADR-14). No registry, no config list.

## How it works

- **Project scripts directory**: default `scripts/` under the project root, overridable via `DTC_PROJECT_SCRIPTS_DIR`.
- **Custom task** — a marked `*.groovy` in the project is discovered, runs via `./dtcw <name>`, and is listed under its own heading in `./dtcw tasks`. `createTask [name]` scaffolds a skeleton.
- **Monkey-patching** — a project script with the same name as an installed task **overrides** it. Every override run prints a `Note:` to stderr and the task is flagged `overridden by …` in `./dtcw tasks` (transparency). `copyTask <name>` copies an installed script into the project for editing.
- **Helper resolution (ADR-17)** — `dtcw` passes `-Ddtc.scriptsHome=<install>/scripts` on every v4 run (local + Docker). The `scriptDir`/`dtcHome` idiom in the 13 helper-loading scripts now prefers that property and falls back to the on-disk location, so a copied/custom script still loads the bundled `lib/` helpers and resources from the installation. Behaviour is unchanged for installed scripts (the property equals their own directory).

## Decisions

- **ADR-16** — Project-Local Tasks (resolution order, override transparency, helper commands).
- **ADR-17** — `dtc.scriptsHome` for lib/ resolution from the installation.

Both include a Pugh matrix and are wired into arc42 Chapter 9.

## Spec

`src/docs/arc42/spec/02_project_local_tasks.adoc` — Cockburn use cases (UC-CT-1/2), system use cases (SUC-1..4), EARS requirements, Business Rules (BR-1..6), Gherkin acceptance criteria, activity diagram, and a traceability matrix.

## Docs

- Manual guide: `010_manual/45_custom_tasks.adoc` (wired into `single-page.adoc`).
- Task pages: `015_tasks/03_task_createTask.adoc`, `03_task_copyTask.adoc`.

## Tests

`test/custom_tasks.bats` — discovery, unmarked-file exclusion, custom run (passes `dtc.scriptsHome`), override run + listing, unknown-task rejection. Also exercised end-to-end against a mock installation (listing, notes, java invocation) and `createTask`/`copyTask` run against a real Groovy runtime.

## Security

Project tasks are executable Groovy running with user privileges — the same local-trust model already accepted for `docToolchainConfig.groovy` (threat **T-005**). No new trust class; the mandatory override note keeps shadowing visible. Noted in the manual.

## Scope note

The v4 execution path lives only in the Bash `dtcw`; `dtcw.ps1`/`dtcw.bat` carry no v4 path yet (existing Chapter 11 tech debt), so project-task resolution lands in Bash first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQYPPp7ExNXXpmhN6YmBAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQYPPp7ExNXXpmhN6YmBAC)_