### PR TITLE
Quick wins: STEM math rendering, AGENTS.md bootstrap, .rst docs (#1675, #1676, #1678)

### DIFF
--- a/core/src/test/groovy/org/docToolchain/scripts/AgentHintsSpec.groovy
+++ b/core/src/test/groovy/org/docToolchain/scripts/AgentHintsSpec.groovy
@@ -1,0 +1,88 @@
+package org.docToolchain.scripts
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.TempDir
+
+/**
+ * Locks in {@code scripts/lib/AgentHints.groovy}: the heading-anchored, idempotent
+ * upsert of an agent-contract block into AGENTS.md / CLAUDE.md, and the ensure()
+ * bootstrap that seeds a fresh AGENTS.md when a project has no agent file yet
+ * (issue #1676). Loaded via GroovyClassLoader exactly as the install task scripts
+ * load it at runtime.
+ */
+class AgentHintsSpec extends Specification {
+
+    @Shared Class agentHints
+
+    @TempDir
+    File projectDir
+
+    private static final String BLOCK = '''\
+## Diagrams — use Bausteinsicht
+**Only when you change diagrams:** use Bausteinsicht.'''
+
+    def setupSpec() {
+        def scriptFile = ['../scripts/lib/AgentHints.groovy', 'scripts/lib/AgentHints.groovy']
+            .collect { new File(it) }.find { it.exists() }
+        assert scriptFile != null : 'could not locate scripts/lib/AgentHints.groovy'
+        def gcl = new GroovyClassLoader(getClass().classLoader)
+        agentHints = gcl.parseClass(scriptFile)
+    }
+
+    def "upsert returns null and writes nothing when no agent file exists"() {
+        when:
+            def result = agentHints.upsert(projectDir, BLOCK)
+
+        then:
+            result == null
+            !new File(projectDir, 'AGENTS.md').exists()
+            !new File(projectDir, 'CLAUDE.md').exists()
+    }
+
+    def "ensure creates AGENTS.md with the block when no agent file exists"() {
+        when:
+            def written = agentHints.ensure(projectDir, BLOCK)
+
+        then:
+            written.name == 'AGENTS.md'
+            written.exists()
+            written.text.contains('## Diagrams — use Bausteinsicht')
+            !new File(projectDir, 'CLAUDE.md').exists()
+    }
+
+    def "ensure updates an existing AGENTS.md in place without clobbering other content"() {
+        given: 'an AGENTS.md the user already maintains'
+            def agents = new File(projectDir, 'AGENTS.md')
+            agents.text = '# My project\n\nSome existing guidance.\n'
+
+        when:
+            def written = agentHints.ensure(projectDir, BLOCK)
+
+        then:
+            written == agents
+            agents.text.contains('Some existing guidance.')
+            agents.text.contains('## Diagrams — use Bausteinsicht')
+    }
+
+    def "ensure prefers an existing CLAUDE.md over creating AGENTS.md"() {
+        given:
+            new File(projectDir, 'CLAUDE.md').text = '# Claude\n'
+
+        when:
+            def written = agentHints.ensure(projectDir, BLOCK)
+
+        then:
+            written.name == 'CLAUDE.md'
+            !new File(projectDir, 'AGENTS.md').exists()
+    }
+
+    def "ensure is idempotent — re-running does not duplicate the block"() {
+        when: 'ensure runs twice'
+            agentHints.ensure(projectDir, BLOCK)
+            def written = agentHints.ensure(projectDir, BLOCK)
+
+        then: 'the heading appears exactly once'
+            written.text.count('## Diagrams — use Bausteinsicht') == 1
+    }
+}

--- a/scripts/AsciiDocBasics.gradle
+++ b/scripts/AsciiDocBasics.gradle
@@ -176,6 +176,11 @@ asciidoctorj {
         'imagesdir': 'images@',
         'toc': 'left@',
         'icons': 'font@',
+        // Enable STEM (math) so stem:[…], [stem]/[asciimath]/[latexmath] render:
+        // MathJax in HTML, native rendering in asciidoctor-pdf. latexmath is the
+        // default notation for unqualified stem; asciimath still works explicitly.
+        // Soft-set (@) so a document can override the default notation.
+        'stem': 'latexmath@',
         'javaVersion'         : "$javaVersion",
         'currentDate'         : "$currentDate",
         'allow-uri-read'      : 'true@',

--- a/scripts/installBausteinsicht.groovy
+++ b/scripts/installBausteinsicht.groovy
@@ -100,7 +100,7 @@ if (alreadyInstalled && !pinned) {
     println "${color('green', "Installed Bausteinsicht to ${binary.absolutePath}")}"
 }
 
-// --- 4. Hint agents to use it (only if the project has an agent file) --------
+// --- 4. Hint agents to use it (create an agent file if none exists yet) ------
 def block = """\
 ## Diagrams — use Bausteinsicht
 **Only when you are creating or changing architecture diagrams:** use Bausteinsicht
@@ -109,12 +109,13 @@ def block = """\
 Not installed? Run `./dtcw installBausteinsicht`.
 Docs: https://doctoolchain.org/Bausteinsicht/"""
 
-def updated = AgentHints.upsert(new File(docDir), block)
-if (updated) {
-    println "${color('green', "Added a Bausteinsicht hint for agents to ${updated.name}")}"
+def cliArgs = binding.hasVariable('args') ? (args as List) : []
+def noAgentHints = cliArgs.contains('--no-agent-hints') || (System.getenv('DTC_NO_AGENT_HINTS') ?: '') != ''
+if (noAgentHints) {
+    println "${color('yellow', 'Skipped the agent hint (--no-agent-hints / DTC_NO_AGENT_HINTS).')}"
 } else {
-    println "${color('yellow', 'No AGENTS.md or CLAUDE.md found — skipped the agent hint.')}"
-    println "  (Create one of them and re-run to let LLM agents know about Bausteinsicht.)"
+    def updated = AgentHints.ensure(new File(docDir), block)
+    println "${color('green', "Added a Bausteinsicht hint for agents to ${updated.name}")}"
 }
 
 // --- 5. PATH guidance -------------------------------------------------------

--- a/scripts/installDacli.groovy
+++ b/scripts/installDacli.groovy
@@ -58,7 +58,7 @@ if (proc.exitValue() != 0) {
 }
 println "${color('green', 'daCLI installed (dacli, dacli-mcp).')}"
 
-// --- 3. Hint agents to use it (only if the project has an agent file) --------
+// --- 3. Hint agents to use it (create an agent file if none exists yet) ------
 def block = """\
 ## Working with these docs — use daCLI
 **Only when you are reading or editing this project's documentation:** use daCLI for
@@ -67,12 +67,13 @@ Run `dacli --help` first to discover the current commands.
 Not installed? Run `./dtcw installDacli`.
 Docs: https://doctoolchain.org/dacli"""
 
-def updated = AgentHints.upsert(new File(docDir), block)
-if (updated) {
-    println "${color('green', "Added a daCLI hint for agents to ${updated.name}")}"
+def cliArgs = binding.hasVariable('args') ? (args as List) : []
+def noAgentHints = cliArgs.contains('--no-agent-hints') || (System.getenv('DTC_NO_AGENT_HINTS') ?: '') != ''
+if (noAgentHints) {
+    println "${color('yellow', 'Skipped the agent hint (--no-agent-hints / DTC_NO_AGENT_HINTS).')}"
 } else {
-    println "${color('yellow', 'No AGENTS.md or CLAUDE.md found — skipped the agent hint.')}"
-    println "  (Create one of them and re-run to let LLM agents know about daCLI.)"
+    def updated = AgentHints.ensure(new File(docDir), block)
+    println "${color('green', "Added a daCLI hint for agents to ${updated.name}")}"
 }
 
 println ""

--- a/scripts/lib/AgentHints.groovy
+++ b/scripts/lib/AgentHints.groovy
@@ -13,18 +13,38 @@
 
 class AgentHints {
 
-    // Targeted in this order; the first that exists is updated. Neither is
-    // created if absent — we never add an agent file a project didn't ask for.
+    // Targeted in this order; the first that exists is updated.
     static final List<String> AGENT_FILES = ['AGENTS.md', 'CLAUDE.md']
+
+    // When no agent file exists yet, ensure() seeds this vendor-neutral one.
+    static final String DEFAULT_AGENT_FILE = 'AGENTS.md'
 
     /**
      * Upsert {@code block} into the project's agent file under {@code docDir}.
+     * Does not create a file: returns {@code null} when none exists, leaving the
+     * decision to bootstrap one to the caller (see {@link #ensure}).
      * @return the file written, or {@code null} if no agent file exists.
      */
     static File upsert(File docDir, String block) {
         def target = AGENT_FILES.collect { new File(docDir, it) }.find { it.exists() }
         if (!target) return null
         target.setText(merge(target.getText('UTF-8'), block), 'UTF-8')
+        return target
+    }
+
+    /**
+     * Like {@link #upsert}, but bootstraps a fresh {@value #DEFAULT_AGENT_FILE}
+     * seeded with {@code block} when the project has neither agent file yet.
+     * An existing file is updated in place, idempotently. So after install the
+     * project always carries the contract, whether or not it had an agent file.
+     * @return the file written (never {@code null}).
+     */
+    static File ensure(File docDir, String block) {
+        def target = AGENT_FILES.collect { new File(docDir, it) }.find { it.exists() }
+        boolean created = target == null
+        if (created) target = new File(docDir, DEFAULT_AGENT_FILE)
+        def existing = target.exists() ? target.getText('UTF-8') : ''
+        target.setText(merge(existing, block), 'UTF-8')
         return target
     }
 

--- a/src/docs/010_manual/40_features.adoc
+++ b/src/docs/010_manual/40_features.adoc
@@ -23,10 +23,54 @@ No Ruby gems, no external `asciidoctor` CLI needed.
 Generate HTML, PDF, or a full microsite from the same AsciiDoc sources.
 See the xref:../015_tasks/03_tasks.adoc[Tasks] section for all available output formats.
 
+=== Multiple Markup Formats
+
+The microsite renders more than AsciiDoc: Markdown and plain HTML work out of the
+box, and reStructuredText (`.rst`) is supported via a one-line converter entry.
+See xref:../020_tutorial/040_microsite/043_multi-markup.adoc[Multi-Markup] for the
+full list and how to enable `.rst`.
+
 === Diagram Support
 
 Built-in support for text-based diagrams via https://asciidoctor.org/docs/asciidoctor-diagram/[asciidoctor-diagram]:
 PlantUML, ditaa, Mermaid, and more.
+
+=== Math & Formulas (STEM)
+
+docToolchain renders mathematical and scientific formulas (AsciiDoc
+https://docs.asciidoctor.org/asciidoc/latest/stem/[STEM] content).
+STEM is enabled out of the box — no configuration needed.
+
+Use it inline or as a block, in either the `latexmath` or the `asciimath` notation:
+
+[source,asciidoc]
+----
+A square root inline: stem:[sqrt(4) = 2].
+
+[latexmath]
+++++
+\sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+++++
+
+[asciimath]
+++++
+sum_(i=1)^n i = (n(n+1))/2
+++++
+----
+
+The default notation for an unqualified `stem:[…]` / `[stem]` is `latexmath`.
+Override it per document with `:stem: asciimath`, or pin a single expression with
+the explicit `[asciimath]` / `[latexmath]` block forms shown above.
+
+Formulas render in all main output formats:
+
+* **HTML** — rendered in the browser via MathJax.
+* **PDF** — rendered natively by asciidoctor-pdf.
+
+NOTE: In the microsite, MathJax is loaded the same way as in standalone HTML.
+For fully offline / self-contained sites you can bundle MathJax locally instead
+of loading it from a CDN — see the
+https://github.com/docToolchain/docToolchain/issues/1675[tracking issue].
 
 === Confluence Publishing
 

--- a/src/docs/020_tutorial/040_microsite/043_multi-markup.adoc
+++ b/src/docs/020_tutorial/040_microsite/043_multi-markup.adoc
@@ -8,6 +8,35 @@ AsciiDoc is the default (and preferred) markup language for documentation writte
 
 But because docToolchain is designed to be used by larger teams and organisations, its built-in site generator can render AsciiDoc, Markdown, and plain HTML.
 
+=== Supported Markup Formats
+
+The microsite (`generateSite`) accepts these input formats:
+
+[cols="1,1,3", options="header"]
+|===
+| Format | Status | Notes
+
+| AsciiDoc (`.adoc`)
+| Built-in (default)
+| The preferred markup for docToolchain.
+
+| Markdown (`.md`)
+| Built-in
+| Rendered out of the box via flexmark; flavour configurable.
+
+| HTML (`.html`)
+| Built-in
+| The body is shown in the content area.
+
+| reStructuredText (`.rst`)
+| Supported, opt-in
+| Enabled with one `additionalConverters` entry (see below). Requires Python + docutils on the build host.
+|===
+
+IMPORTANT: These formats are supported by the *microsite* pipeline (`generateSite`) only.
+The standalone `generateHTML` / `generatePDF` tasks process AsciiDoc.
+reStructuredText in particular is *not* available in `generateHTML` / `generatePDF`.
+
 === Meta-Data Header
 
 In AsciiDoc, metadata is defined as attributes beginning with `jbake-`, such as `:jbake-header:`.
@@ -41,23 +70,56 @@ Refer to https://github.com/docToolchain/multi-markup-demo/blob/main/src/docs/de
 
 === restructuredText (.rst)
 
-Since the built-in generator doesn't render reStructuredText directly, docToolchain uses a different mechanism:
+reStructuredText is *already supported* — you just have to switch it on.
+Since the built-in generator doesn't render `.rst` directly, docToolchain ships a
+converter (`scripts/rstToHtml.py`) and runs it through the `additionalConverters`
+mechanism.
 
-ifndef::projectRootDir[:projectRootDir: ../../..]
+.Prerequisite
+[NOTE]
+====
+The converter is a https://docutils.sourceforge.io/[docutils] script, so the build host needs:
+
+* `python3`
+* the `docutils` package (`pip install docutils`)
+====
+
+Enable `.rst` by adding this one entry to the `microsite` section of your
+`docToolchainConfig.groovy` (copy-paste ready):
 
 .docToolchainConfig.groovy
 [source, groovy]
 ----
-include::{projectRootDir}/template_config/Config.groovy[tags=additionalConverters]
+additionalConverters = [
+    '.rst': [command: 'dtcw:rstToHtml.py', type: 'bash'],
+]
 ----
+
+`dtcw:rstToHtml.py` is the internal converter shipped with docToolchain; the
+`dtcw:` prefix tells docToolchain to resolve it from its own `scripts/` folder.
 
 Once an additional converter is configured, docToolchain will traverse all doc-files, check the extension, and invoke the configured script if the extension matches.
 
-
 The script's task is to convert the file to a markup format the site generator recognises (AsciiDoc, Markdown, or HTML).
 Afterwards, the built-in generator processes everything as usual.
+In this case, the Python docutils convert reStructuredText to HTML.
 
-In this case, the Python docutils will convert restructuredText to HTML.
+[NOTE]
+====
+This applies to the microsite (`generateSite`) only — `.rst` is not processed by
+the standalone `generateHTML` / `generatePDF` tasks.
+====
+
+For reference, the full `additionalConverters` configuration block (with all
+supported converter types) looks like this:
+
+ifndef::projectRootDir[:projectRootDir: ../../..]
+
+.template_config/Config.groovy
+[source, groovy]
+----
+include::{projectRootDir}/template_config/Config.groovy[tags=additionalConverters]
+----
 
 === Additional Markup Languages
 


### PR DESCRIPTION
## Summary

Implements the three quick-win backlog items identified from the next-gen issues. Each is small, self-contained, and shipped together.

### #1676 — `installBausteinsicht`/`installDacli` create an agent file when missing
- `AgentHints.upsert()` only updated an **existing** `AGENTS.md`/`CLAUDE.md` and silently did nothing otherwise, so a fresh project got no contract even right after installing the tool.
- New `AgentHints.ensure()` seeds a vendor-neutral `AGENTS.md` when no agent file exists, and otherwise upserts in place idempotently.
- Wired into both install tasks, with a `--no-agent-hints` / `DTC_NO_AGENT_HINTS` opt-out.
- Covered by new `AgentHintsSpec` (create, update-in-place, `CLAUDE.md` preference, idempotency, unchanged `upsert` null contract).

### #1675 — Enable STEM (math) rendering
- The `stem` attribute was never set, so `stem:[…]` / `[stem]` / `[asciimath]` / `[latexmath]` were not rendered.
- Set `stem: latexmath@` in the `asciidoctorj` attribute block → MathJax in HTML, native rendering in asciidoctor-pdf; both notations work.
- Documented with worked examples in the manual.
- **Follow-up (left in #1675):** microsite-local MathJax bundling (offline, no CDN).

### #1678 — Surface the existing reStructuredText (`.rst`) support (docs only)
- `.rst` already works in the microsite via `rstToHtml.py` + `additionalConverters`, but was barely discoverable.
- Added a **Supported Markup Formats** overview, a copy-pasteable enable snippet, the Python/docutils prerequisite, and an explicit **microsite-only** scope note; cross-linked from the manual.

## Testing
- `./gradlew core:test` — green (incl. new `AgentHintsSpec`).
- STEM/`.rst` rendering not exercised end-to-end here (requires a full `generateHTML`/`generateSite` run); the STEM change is a single asciidoctorj attribute and the `.rst` change is documentation only.

## Notes
These three were chosen as the genuine quick-wins from the seven next-gen issues (#1673–#1679); the remaining four (install naming, pan & zoom, draw.io interactivity, multi-repo federation) are larger and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQzThZwKHsA886pXJUTfVS)_