### PR TITLE
fix(landingpage): correct iSAQB template description and add trademark notice (ng)

### DIFF
--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -149,7 +149,7 @@
                         <h4 class="my-0 fw-normal">iSAQB Template</h4>
                     </div>
                     <div class="card-body">
-                        A ready-to-use documentation template following the iSAQB arc42 software architecture documentation standard.<br /><br />
+                        A ready-to-use template for writing your CPSA Advanced Level certification thesis, with a custom PDF theme for the required layout.<br /><br />
                         <a class="btn btn-primary" href="https://github.com/docToolchain/iSAQB-Template" role="button">learn more</a>
                     </div>
                 </div>
@@ -164,6 +164,11 @@
                         <a class="btn btn-primary" href="https://github.com/docToolchain/ci-cd-demo" role="button">learn more</a>
                     </div>
                 </div>
+            </div>
+        </div>
+        <div class="row row-cols-1 mb-3">
+            <div class="col">
+                <p class="text-muted small">iSAQB&reg; and CPSA&reg; are registered trademarks of the International Software Architecture Qualification Board e.&thinsp;V. This template is a community project and is neither provided nor endorsed by the iSAQB.</p>
             </div>
         </div>
         <!--div class="row row-cols-1">


### PR DESCRIPTION
## Problem

This mirrors the landing-page fixes already merged on `main-4.x` ([#1682](https://github.com/docToolchain/docToolchain/pull/1682)) onto the `ng` branch, where the same text still appears.

The iSAQB Template card on the landing page (`src/docs/landingpage.gsp`) described the template as:

> A ready-to-use documentation template following the iSAQB arc42 software architecture documentation standard.

This is **factually wrong**:

- The iSAQB **CPSA Advanced Level** certification has nothing to do with arc42.
- arc42-structured submissions are in fact **rejected as a form error** in the certification process.
- The thesis must address the questions posed in the assignment — it is explicitly **not** to be structured according to arc42.

## Changes

1. Replaced the description with an accurate one:
   > A ready-to-use template for writing your CPSA Advanced Level certification thesis, with a custom PDF theme for the required layout.
2. Added a discreet trademark disclaimer (iSAQB® / CPSA® are registered trademarks of the International Software Architecture Qualification Board e. V.; the template is an independent community project, not endorsed by the iSAQB).

The card itself (title, link to the template repo) is kept — only the misleading text is corrected and the disclaimer added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013eu96a9trAEnsTxHKMAtW5)_