### PR TITLE
dtcw: Docker Compose and devcontainer as native environments

### DIFF
--- a/.claude/skills/dtcw/SKILL.md
+++ b/.claude/skills/dtcw/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: dtcw
+description: "docToolchain Wrapper — generate HTML/PDF, publish to Confluence, export from Jira, and manage docs-as-code workflows via docToolchain."
+user-invocable: true
+---
+
+# dtcw — docToolchain Wrapper
+
+Use the `dtcw` command to generate documentation, publish to Confluence, export from Jira, and manage docs-as-code workflows via docToolchain.
+
+## Prerequisites
+
+The `dtcw` wrapper auto-detects the execution environment (in priority order):
+
+1. **compose**: `docker-compose.yml` with doctoolchain service + compose command
+2. **devcontainer**: `.devcontainer/devcontainer.json` with doctoolchain image + CLI
+3. **local**: docToolchain installed in `$HOME/.doctoolchain`
+4. **sdk**: docToolchain installed via SDKMAN!
+5. **docker**: one-shot container via `docker run`
+
+Force a specific environment: `./dtcw <environment> <task>`
+
+## Tasks
+
+### Generate Documentation
+
+```bash
+# Generate HTML output
+dtcw generateHTML
+
+# Generate PDF output
+dtcw generatePDF
+
+# Generate microsite with jBake
+dtcw generateSite
+
+# Preview microsite locally
+dtcw previewSite
+
+# Generate DocBook XML
+dtcw generateDocBook
+
+# Generate reveal.js slide deck
+dtcw generateDeck
+```
+
+### Publish and Integrate
+
+```bash
+# Publish documentation to Confluence
+dtcw publishToConfluence
+
+# Export Jira issues to AsciiDoc
+dtcw exportJiraIssues
+
+# Export Jira sprint changelog
+dtcw exportJiraSprintChangelog
+
+# Export Confluence pages to AsciiDoc
+dtcw exportConfluence
+```
+
+### Export from External Tools
+
+```bash
+# Export from Enterprise Architect
+dtcw exportEA
+
+# Export Excel tables to AsciiDoc
+dtcw exportExcel
+
+# Export PowerPoint slides as images
+dtcw exportPPT
+
+# Export Visio diagrams
+dtcw exportVisio
+
+# Export draw.io diagrams
+dtcw exportDrawIo
+
+# Export Structurizr architecture diagrams
+dtcw exportStructurizr
+
+# Export OpenAPI spec
+dtcw exportOpenApi
+
+# Export Markdown to AsciiDoc
+dtcw exportMarkdown
+```
+
+### Utilities
+
+```bash
+# Export git changelog
+dtcw exportChangeLog
+
+# Export git contributors
+dtcw exportContributors
+
+# Collect all includes into a single list
+dtcw collectIncludes
+
+# Convert to DOCX via Pandoc
+dtcw convertToDocx
+
+# Convert to EPUB
+dtcw convertToEpub
+
+# Fix file encoding issues
+dtcw fixEncoding
+
+# HTML sanity check (broken links etc.)
+dtcw htmlSanityCheck
+
+# Download arc42/req42 template
+dtcw downloadTemplate
+
+# Copy site themes
+dtcw copyThemes
+
+# List all available tasks
+dtcw tasks
+```
+
+### Installation (local/project-home mode only)
+
+```bash
+# Install docToolchain locally
+dtcw install doctoolchain
+
+# Install Java 17 locally
+dtcw install java
+```
+
+## Usage Patterns
+
+### Before generating documentation
+
+When the user asks to build or preview documentation:
+
+```bash
+# Check what tasks are available
+dtcw tasks
+
+# Generate HTML for quick preview
+dtcw generateHTML
+# Output: build/html5/
+
+# Generate PDF for distribution
+dtcw generatePDF
+# Output: build/pdf/
+```
+
+### Working with Confluence
+
+```bash
+# Publish current docs to Confluence
+dtcw publishToConfluence
+
+# Export existing Confluence pages to AsciiDoc
+dtcw exportConfluence
+```
+
+### Working with Jira
+
+```bash
+# Export issues referenced in documentation
+dtcw exportJiraIssues
+
+# Export sprint changelog
+dtcw exportJiraSprintChangelog
+```
+
+### Full site generation
+
+```bash
+# Generate complete microsite
+dtcw generateSite
+
+# Preview in browser
+dtcw previewSite
+```
+
+### Docker Compose workflow (validate-first)
+
+When a docker-compose.yml with both adoc and doctoolchain services exists:
+
+```bash
+# Validate AsciiDoc first (via adcw if available)
+adcw validate -i Docs/main.adoc --strict
+
+# Then build (auto-detects compose environment)
+dtcw generatePDF
+dtcw generateHTML
+
+# Or force compose explicitly
+dtcw compose generateHTML
+```
+
+### Bootstrap a compose or devcontainer setup
+
+```bash
+# Generate docker-compose.yml with doctoolchain service
+dtcw compose install doctoolchain
+
+# Generate .devcontainer/devcontainer.json
+dtcw devcontainer install doctoolchain
+```
+
+## Error Handling
+
+- If `dtcw` is not found: install via Homebrew (`brew install tpo42/dtcw/dtcw`) or use `./dtcw` from project directory
+- If Java is missing: suggest `dtcw install java` (local mode) or use compose/docker
+- If docToolchain is not installed: suggest `dtcw install doctoolchain` or use compose/docker
+- Build timeouts: docToolchain builds can take 1-5 minutes — set long timeouts (600+ seconds)
+
+## Notes
+
+- All paths are relative to the project root
+- HTML output: `build/html5/`
+- PDF output: `build/pdf/`
+- Microsite output: `build/microsite/output/`
+- Configuration: `docToolchainConfig.groovy` (primary) or `Config.groovy` (legacy)
+- In compose mode, DTC_OPTS from the container environment are appended automatically
+- The wrapper is version-agnostic: works with both v3 (Gradle) and v4 (direct Groovy)

--- a/.github/workflows/dtcw-tests.yaml
+++ b/.github/workflows/dtcw-tests.yaml
@@ -48,7 +48,9 @@ jobs:
         run: |
           find . -maxdepth 1 -type d -not -name '.' -not -name 'test' -print0 | xargs -0 rm -rf --
           find . -maxdepth 1 -type f -not -name 'dtcw' -not -name 'test' -print0 | xargs -0 rm --
-      - name: Run tests
+      - name: Unit tests (sourced internals)
+        run: bash test/dtcw-unit.bash
+      - name: BATS integration tests
         run: |
           echo $BASH_VERSION
           test/bats/bin/bats --filter-tags \!e2e test

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ src/test/docs/excel/
 src/test/docs/structurizr/
 ~$*
 
+# Editor swap/backup files
+.*.sw?
+*~
+*.bak
+*.orig
+
 # MAC DS_Store file
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,16 @@ resources/asciidoctor-reveal.js
 tmp/
 
 # Claude Code
-.claude/
+.claude/*
+# ... except the dtcw skill, which is a maintained project artifact rather than
+# local scratch state. Every path component has to be re-included explicitly:
+# git does not descend into an excluded directory, so a bare
+# '!.claude/skills/dtcw/SKILL.md' after '.claude/' would never match.
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/dtcw/
+.claude/skills/dtcw/*
+!.claude/skills/dtcw/SKILL.md
 
 # PR Analysis Report
 PR-ANALYSIS.md

--- a/dtcw
+++ b/dtcw
@@ -62,7 +62,7 @@ export DTC_HEADLESS
 # Options passed to docToolchain
 DTC_OPTS="${DTC_OPTS:-} --warning-mode=${DTC_WARN_MODE} --no-daemon -Dfile.encoding=UTF-8 "
 if [ -n "${DTC_CONFIG_FILE}" ]; then
-    DTC_OPTS="${DTC_OPTS} -PmainConfigFile=${DTC_CONFIG_FILE}"
+    DTC_OPTS="${DTC_OPTS} '-PmainConfigFile=${DTC_CONFIG_FILE}'"
 fi
 
 # Here you find the project
@@ -1228,7 +1228,7 @@ build_command() {
             fi
             if [ "${env}" = local ]; then
                 if [ -x "${dtc_home}/bin/doctoolchain" ]; then
-                    cmd="${dtc_home}/bin/doctoolchain"
+                    cmd="'${dtc_home}/bin/doctoolchain'"
                 elif command -v doctoolchain >/dev/null 2>&1; then
                     cmd="doctoolchain"
                 else
@@ -1237,7 +1237,7 @@ build_command() {
                 fi
                 cmd="${cmd} . ${*} ${DTC_OPTS}"
             else
-                cmd="${dtc_home}/bin/doctoolchain . ${*} ${DTC_OPTS}"
+                cmd="'${dtc_home}/bin/doctoolchain' . ${*} ${DTC_OPTS}"
             fi
         fi
     fi

--- a/dtcw
+++ b/dtcw
@@ -56,8 +56,11 @@ export DTC_HEADLESS
 : "${DTC_SERVICE:=}"
 : "${DTC_WORKSPACE:=.}"
 
+# Gradle warning mode (v3 only; ignored by v4 direct Groovy execution)
+: "${DTC_WARN_MODE:=none}"
+
 # Options passed to docToolchain
-DTC_OPTS="${DTC_OPTS:-} --warning-mode=none --no-daemon -Dfile.encoding=UTF-8 "
+DTC_OPTS="${DTC_OPTS:-} --warning-mode=${DTC_WARN_MODE} --no-daemon -Dfile.encoding=UTF-8 "
 if [ -n "${DTC_CONFIG_FILE}" ]; then
     DTC_OPTS="${DTC_OPTS} -PmainConfigFile=${DTC_CONFIG_FILE}"
 fi
@@ -552,7 +555,7 @@ services:
       DTC_HEADLESS: "true"
       DTC_OPTS: >-
         -PmainConfigFile=${DTC_CONFIG_FILE}
-        --warning-mode=none
+        --warning-mode=${DTC_WARN_MODE}
         -Dfile.encoding=UTF-8
 YAML
         echo "Created ${compose_path}."

--- a/dtcw
+++ b/dtcw
@@ -12,6 +12,11 @@ set -o pipefail
 
 # See https://github.com/docToolchain/docToolchain/releases for available versions.
 # Set DTC_VERSION to "latest" to get the latest, yet unreleased version.
+#
+# Remember whether the version was chosen by the caller: for container
+# environments the version is derived from the image the project pins, and an
+# explicit DTC_VERSION has to keep winning over that.
+DTC_VERSION_EXPLICIT=${DTC_VERSION:+true}
 : "${DTC_VERSION:=4.0.0}"
 
 # if not set, public docker hub is used
@@ -45,6 +50,11 @@ export DTC_PROJECT_BRANCH
 # DTC_HEADLESS is true if no STDIN is open (i.e. we have an non-interactive shell).
 : "${DTC_HEADLESS:=$([ -t 0 ] && echo false || echo true)}"
 export DTC_HEADLESS
+
+# Compose/devcontainer environment variables (all optional)
+: "${DTC_COMPOSE:=}"
+: "${DTC_SERVICE:=}"
+: "${DTC_WORKSPACE:=.}"
 
 # Options passed to docToolchain
 DTC_OPTS="${DTC_OPTS:-} --warning-mode=none --no-daemon -Dfile.encoding=UTF-8 "
@@ -102,10 +112,7 @@ main() {
         install_component_and_exit "${environment}" "java"
     fi
 
-    # No install command, so forward call to docToolchain but first we check if
-    # everything is there.
-
-    # S1: Validate task name format early (applies to all environments incl. Docker)
+    # S1: Validate task name format early (applies to all environments)
     if [[ ! "${1}" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
         error "Invalid task name: '${1}'. Task names must be alphanumeric (letters, digits, hyphens, underscores)."
         exit ${ERR_ARG}
@@ -115,30 +122,67 @@ main() {
     # discovery, the 'tasks' listing, project-first resolution and unknown-task
     # guidance. The task-name format was validated above; everything else is the
     # launcher's job. It resolves project tasks relative to the project root, so
-    # in docker (project mounted at /project) an absolute DTC_PROJECT_SCRIPTS_DIR
-    # simply won't match a project task and resolution falls back to the
-    # installed one — no special-casing needed in the wrapper.
+    # in a container environment (project mounted at /project) an absolute
+    # DTC_PROJECT_SCRIPTS_DIR simply won't match a project task and resolution
+    # falls back to the installed one — no special-casing needed in the wrapper.
+
+    # Prepare the container command prefix for compose/devcontainer
+    container_cmd_prefix=""
+    case "${environment}" in
+        compose)
+            local compose_path
+            compose_path=$(detect_compose_path) || { error "No compose file found"; exit ${ERR_ARG}; }
+            local service="${DTC_SERVICE:-}"
+            [[ -z "${service}" ]] && service=$(find_dtc_service "${compose_path}")
+            if [[ -z "${service}" ]]; then
+                error "No doctoolchain service in ${compose_path}. Set DTC_SERVICE."
+                exit ${ERR_ARG}
+            fi
+            assert_container_version "$(compose_image_ref "${compose_path}")" "${compose_path}"
+            local compose_cmd
+            compose_cmd=$(find_compose_cmd) || exit 1
+            # Quote the interpolated values: the prefix ends up inside the
+            # command string that main() hands to 'bash -c', so that shell
+            # re-parses it and would word-split a path containing spaces.
+            container_cmd_prefix="${compose_cmd} -f '${compose_path}' exec '${service}'"
+            ;;
+        devcontainer)
+            assert_devcontainer_cli
+            assert_container_version "$(devcontainer_image_ref)" ".devcontainer/devcontainer.json"
+            container_cmd_prefix="devcontainer exec --workspace-folder '${DTC_WORKSPACE}'"
+            ;;
+    esac
 
     docker_image_name=""
     docker_extra_arguments=""
-    if [[ ${environment} != docker ]]; then
-        assert_doctoolchain_installed "${environment}" "${DTC_VERSION}"
-        assert_java_version_supported
-    else
-        docker_image_name="doctoolchain/doctoolchain"
-        if [ "${1}" = "image" ]; then
-            docker_image_name="${2-}"
-            shift 2
-            assert_argument_exists "$@"
-        fi
-        echo "Using docker image: ${docker_image_name}"
-        if [ "${1}" = "extra_arguments" ]; then
-            docker_extra_arguments="${2-}"
-            shift 2
-            assert_argument_exists "$@"
-            echo "Extra arguments passed to 'docker run' ${docker_extra_arguments}"
-        fi
-    fi
+    case "${environment}" in
+        compose|devcontainer)
+            # docToolchain and its Java runtime ship inside the container image,
+            # so there is nothing to assert on the host.
+            ;;
+        docker)
+            # get_available_environments() resolved the runtime in a subshell,
+            # so resolve it again here - build_command() reads it in this shell.
+            detect_container_runner || { error "No container runtime found"; exit ${ERR_DTCW}; }
+            docker_image_name="doctoolchain/doctoolchain"
+            if [ "${1}" = "image" ]; then
+                docker_image_name="${2-}"
+                shift 2
+                assert_argument_exists "$@"
+            fi
+            echo "Using docker image: ${docker_image_name}"
+            if [ "${1}" = "extra_arguments" ]; then
+                docker_extra_arguments="${2-}"
+                shift 2
+                assert_argument_exists "$@"
+                echo "Extra arguments passed to 'docker run' ${docker_extra_arguments}"
+            fi
+            ;;
+        *)
+            assert_doctoolchain_installed "${environment}" "${DTC_VERSION}"
+            assert_java_version_supported
+            ;;
+    esac
 
     command=$(build_command "${environment}" "${DTC_VERSION}" "${docker_image_name}" "${docker_extra_arguments}" "$@")
 
@@ -176,38 +220,35 @@ usage() {
 dtcw - Create awesome documentation the easy way with docToolchain.
 
 Usage: ./dtcw [environment] [option...] [task...]
-       ./dtcw [local] install {doctoolchain | java }
+       ./dtcw [environment] install doctoolchain
 
-Use 'local', 'sdk' or 'docker' as first argument to force the use of a specific
-docToolchain environment:
-    - local: installation in '$HOME/.doctoolchain'
-    - sdk: installation with SDKMAN! (https://sdkman.io/)
-    - docker: use docToolchain container image
+Environments (auto-detected in this order):
+    - compose:      docker-compose.yml with doctoolchain service
+    - devcontainer: .devcontainer with doctoolchain image
+    - local:        installation in '\$HOME/.doctoolchain'
+    - sdk:          installation with SDKMAN! (https://sdkman.io/)
+    - docker:       one-shot container via 'docker run'
 
 Examples:
 
-  Download and install docToolchain in '${DTC_ROOT}':
-    ./dtcw local install doctoolchain
-
-  Download and install project documentation template from https://arc42.org/ :
-    ./dtcw downloadTemplate
-
-  Generate PDF:
-    ./dtcw generatePDF
-
-  Generate HTML:
+  Generate HTML (auto-detects environment):
     ./dtcw generateHTML
 
-  Publish HTML to Confluence:
-    ./dtcw publishToConfluence
+  Force a specific environment:
+    ./dtcw compose generatePDF
+    ./dtcw local generateHTML
+    ./dtcw docker generateSite
 
-  Multiple tasks may be provided at once:
-    ./dtcw generatePDF generateHTML
+  Bootstrap a compose environment:
+    ./dtcw compose install doctoolchain
+
+  Install docToolchain locally:
+    ./dtcw local install doctoolchain
 
   List available tasks:
     ./dtcw tasks
 
-Detailed documentation how to use docToolchain may be found at https://doctoolchain.org/
+Detailed documentation: https://doctoolchain.org/
 EOF
 }
 
@@ -229,15 +270,30 @@ print_version_info() {
 }
 
 get_available_environments() {
-    # The local environment is alway available - even if docToolchain is not installed
-    local envs=" local"
+    # Priority: project-local contexts that bring their own docToolchain
+    # override host installations.  A running compose service or
+    # devcontainer is ready to use immediately, whereas local/sdk may
+    # require installation steps and docker always cold-starts a new
+    # container.
+    local envs=""
 
-    # 'sdk' is provided a bash founction - thus command doesn't work
+    if detect_compose_path >/dev/null 2>&1 && find_compose_cmd >/dev/null 2>&1; then
+        envs+=" compose"
+    fi
+
+    if detect_devcontainer && has devcontainer; then
+        envs+=" devcontainer"
+    fi
+
+    # The local environment is always available - even if docToolchain is not installed
+    envs+=" local"
+
+    # 'sdk' is provided as a bash function - thus 'command' doesn't work
     if [ -n "${SDKMAN_DIR:-}" ] && [ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]; then
         envs+=" sdk"
     fi
 
-    if has docker; then
+    if detect_container_runner; then
         envs+=" docker"
     fi
     echo "${envs}"
@@ -247,10 +303,321 @@ has() {
   command -v "$1" 1>/dev/null 2>&1
 }
 
+# --- Container runtime detection ---
+
+# Container runtimes in order of preference: lightweight/daemonless first,
+# docker last. Single source for both the runtime and the compose lookup.
+DTC_CONTAINER_RUNNERS=(container nerdctl finch podman docker)
+
+# Detect a container runtime → DTC_CONTAINER_RUNNER.
+# A pre-set DTC_CONTAINER_RUNNER is authoritative and never second-guessed.
+detect_container_runner() {
+    [[ -n "${DTC_CONTAINER_RUNNER:-}" ]] && return 0
+    local candidate
+    for candidate in "${DTC_CONTAINER_RUNNERS[@]}"; do
+        if DTC_CONTAINER_RUNNER="$(command -v "${candidate}")"; then
+            return 0
+        fi
+    done
+    DTC_CONTAINER_RUNNER=""
+    return 1
+}
+
+# --- Runtime peculiarities ---
+
+# Rootless podman puts the invoking user at container uid 0 and maps every other
+# uid into a subuid range. Together with the '-u $(id -u):$(id -g)' we pass, the
+# project owner then exists nowhere inside the container and the bind-mounted
+# project is read-only in practice -- generateHTML fails on its own output
+# directory. '--userns=keep-id' maps the host user onto itself and restores write
+# access. Rootful podman rejects the flag, so ask for it only when podman really
+# runs rootless; every other runtime needs nothing.
+podman_userns_args() {
+    [[ "$(basename "${DTC_CONTAINER_RUNNER:-}")" == "podman" ]] || return 0
+    local rootless
+    rootless=$("${DTC_CONTAINER_RUNNER}" info --format '{{.Host.Security.Rootless}}' 2>/dev/null) || return 0
+    [[ "${rootless}" == "true" ]] && printf '%s' '--userns=keep-id'
+    return 0
+}
+
+# --- Compose / devcontainer support ---
+
+# Locate a docker-compose file with a doctoolchain service.
+# Checks DTC_COMPOSE, then docker-compose.y{a,}ml in the current directory.
+detect_compose_path() {
+    if [[ -n "${DTC_COMPOSE:-}" ]]; then
+        if [[ -f "${DTC_COMPOSE}" ]]; then
+            echo "${DTC_COMPOSE}"
+            return 0
+        fi
+        return 1
+    fi
+    # Compose-spec names first, legacy 'docker-compose.*' after them. Within
+    # each pair the order matches what 'docker compose' itself picks, so dtcw
+    # never forces a different file via -f than plain compose would have used.
+    for f in compose.{yaml,yml} docker-compose.{yml,yaml}; do
+        if [[ -f "$f" ]] && grep -q 'doctoolchain' "$f" 2>/dev/null; then
+            echo "$f"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# True if .devcontainer/devcontainer.json references a doctoolchain image
+# (directly or via a dockerComposeFile).
+detect_devcontainer() {
+    local json=".devcontainer/devcontainer.json"
+    [[ -f "$json" ]] || return 1
+    if grep -qE '"image"[[:space:]]*:[[:space:]]*"doctoolchain/' "$json"; then
+        return 0
+    fi
+    local compose_ref
+    compose_ref=$(sed -n 's/.*"dockerComposeFile"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$json" 2>/dev/null || true)
+    if [[ -n "${compose_ref}" ]]; then
+        local resolved
+        resolved="$(dirname "$json")/${compose_ref}"
+        [[ -f "$resolved" ]] && grep -q 'doctoolchain' "$resolved" 2>/dev/null && return 0
+    fi
+    return 1
+}
+
+# Extract the docToolchain version from a container image reference:
+# 'doctoolchain/doctoolchain:v3.5.0' -> '3.5.0'. Fails for a reference without a
+# numeric tag (no tag at all, ':latest', a digest, or a bare registry:port host).
+image_ref_version() {
+    local ref=${1}
+    local tag=${ref##*:}
+    # No colon at all, or the colon belonged to a registry port ('host:443/img')
+    if [[ "${tag}" == "${ref}" ]] || [[ "${tag}" == */* ]]; then
+        return 1
+    fi
+    tag=${tag#v}
+    [[ "${tag}" =~ ^[0-9]+(\.[0-9]+)*$ ]] || return 1
+    printf '%s' "${tag}"
+}
+
+# The image reference of the doctoolchain service in a compose file.
+compose_image_ref() {
+    awk '/image:[[:space:]]*.*doctoolchain/ {
+            sub(/^[[:space:]]*image:[[:space:]]*/, "")
+            gsub(/["'"'"']/, "")
+            sub(/[[:space:]]+$/, "")
+            print
+            exit
+         }' "${1}"
+}
+
+# The image reference a devcontainer.json resolves to - either its own "image"
+# or, when it delegates to compose, the one in that file.
+devcontainer_image_ref() {
+    local json=".devcontainer/devcontainer.json"
+    local ref
+    ref=$(sed -n 's/.*"image"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${json}" | head -1)
+    if [[ -n "${ref}" ]]; then
+        printf '%s' "${ref}"
+        return 0
+    fi
+    local compose_ref
+    compose_ref=$(sed -n 's/.*"dockerComposeFile"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${json}" | head -1)
+    if [[ -n "${compose_ref}" ]]; then
+        local resolved
+        resolved="$(dirname "${json}")/${compose_ref}"
+        [[ -f "${resolved}" ]] && compose_image_ref "${resolved}"
+    fi
+}
+
+# Pin DTC_VERSION to what the container actually provides.
+#
+# dtcw dispatches 3.x through Gradle and 4.x through the Groovy launcher, with
+# hard-coded in-container paths for the latter, so guessing is not an option: a
+# v4 dispatch into a 3.x image fails with a missing Launcher.groovy. The host
+# installation says nothing about the container - there may be none at all - so
+# the image tag is the only source of truth. An explicit DTC_VERSION still wins.
+assert_container_version() {
+    local ref=${1}
+    local source=${2}
+
+    if [[ -n "${DTC_VERSION_EXPLICIT}" ]]; then
+        echo "Using docToolchain ${DTC_VERSION} (DTC_VERSION overrides ${source})"
+        return 0
+    fi
+
+    local derived
+    if [[ -z "${ref}" ]] || ! derived=$(image_ref_version "${ref}"); then
+        error "cannot determine the docToolchain version from ${source}"
+        printf '%s\n' \
+            "Image reference: ${ref:-<none found>}" \
+            "" \
+            "dtcw invokes docToolchain 3.x through Gradle and 4.x directly via" \
+            "Groovy, so it has to know the version before it can build a command." \
+            "Pin a versioned tag, e.g." \
+            "" \
+            "    image: doctoolchain/doctoolchain:v${DTC_VERSION}" \
+            "" \
+            "or state the version explicitly:" \
+            "" \
+            "    DTC_VERSION=${DTC_VERSION} ./dtcw <task>" >&2
+        exit ${ERR_ARG}
+    fi
+
+    DTC_VERSION="${derived}"
+    DTC_HOME="${DTC_ROOT}/docToolchain-${DTC_VERSION}"
+    echo "Using docToolchain ${DTC_VERSION} from ${source}"
+}
+
+assert_devcontainer_cli() {
+    if ! has devcontainer; then
+        error "devcontainer CLI not found"
+        echo "Install it via: npm install -g @devcontainers/cli" >&2
+        exit ${ERR_DTCW}
+    fi
+}
+
+# The compose implementation belonging to one runtime, printed as the command to
+# run. Modern runtimes carry compose as a subcommand; the standalone binaries
+# each belong to exactly one runtime and must not be crossed over.
+runner_compose_cmd() {
+    local bin=${1}
+    if "${bin}" compose version >/dev/null 2>&1; then
+        printf '%s compose' "${bin}"
+        return 0
+    fi
+    case "$(basename "${bin}")" in
+        docker) has docker-compose && { printf 'docker-compose'; return 0; } ;;
+        podman) has podman-compose && { printf 'podman-compose'; return 0; } ;;
+    esac
+    return 1
+}
+
+# Find a compose command, paired with the runtime it belongs to.
+#
+# The pairing is the point: picking 'docker compose' while the service was
+# started by podman talks to the wrong engine, and a runtime whose compose lives
+# in a subcommand (nerdctl, finch) was invisible before. An explicitly chosen
+# DTC_CONTAINER_RUNNER is authoritative - we do not silently use another engine.
+find_compose_cmd() {
+    if [[ -n "${DTC_CONTAINER_RUNNER:-}" ]]; then
+        runner_compose_cmd "${DTC_CONTAINER_RUNNER}" && return 0
+        error "'$(basename "${DTC_CONTAINER_RUNNER}")' has no compose support installed"
+        echo "Unset or change DTC_CONTAINER_RUNNER to use a different runtime." >&2
+        return 1
+    fi
+
+    local candidate bin
+    for candidate in "${DTC_CONTAINER_RUNNERS[@]}"; do
+        bin=$(command -v "${candidate}") || continue
+        runner_compose_cmd "${bin}" && return 0
+    done
+
+    error "No compose command found"
+    echo "Tried: ${DTC_CONTAINER_RUNNERS[*]} (as '<runtime> compose')," >&2
+    echo "plus the standalone docker-compose and podman-compose." >&2
+    return 1
+}
+
+# Extract the service name whose image contains "doctoolchain" from a compose file.
+find_dtc_service() {
+    local compose_path="$1"
+    awk '
+        /^[[:space:]]*[a-zA-Z0-9_-]+:[[:space:]]*$/ {
+            current_service = $1
+            gsub(/:$/, "", current_service)
+        }
+        /image:.*doctoolchain/ {
+            print current_service
+            exit
+        }
+    ' "${compose_path}"
+}
+
+# Bootstrap a docker-compose.yml with a doctoolchain service, or
+# pull/build if the file already exists.
+compose_install_doctoolchain() {
+    local compose_path
+    compose_path=$(detect_compose_path 2>/dev/null) || true
+
+    if [[ -z "${compose_path}" ]]; then
+        compose_path="docker-compose.yml"
+        echo "Creating ${compose_path} with doctoolchain service..."
+        cat > "${compose_path}" <<YAML
+services:
+  doctoolchain:
+    image: doctoolchain/doctoolchain:v${DTC_VERSION}
+    platform: linux/amd64
+    volumes:
+      - .:/project
+    entrypoint: ["sleep", "infinity"]
+    environment:
+      DTC_HEADLESS: "true"
+      DTC_OPTS: >-
+        -PmainConfigFile=${DTC_CONFIG_FILE}
+        --warning-mode=none
+        -Dfile.encoding=UTF-8
+YAML
+        echo "Created ${compose_path}."
+        echo
+        echo "Start the service with:"
+        echo "    docker compose up -d"
+        return 0
+    fi
+
+    echo "Compose file exists: ${compose_path}"
+    local compose_cmd
+    compose_cmd=$(find_compose_cmd) || return 1
+    echo "Pulling/building services..."
+    ${compose_cmd} -f "${compose_path}" pull 2>/dev/null \
+        || ${compose_cmd} -f "${compose_path}" build
+}
+
+# Bootstrap a .devcontainer/devcontainer.json with a doctoolchain image,
+# or start the devcontainer if it already exists.
+devcontainer_install_doctoolchain() {
+    local json=".devcontainer/devcontainer.json"
+
+    if [[ ! -f "${json}" ]]; then
+        mkdir -p .devcontainer
+        echo "Creating ${json} with doctoolchain image..."
+        cat > "${json}" <<JSON
+{
+  "name": "docToolchain",
+  "image": "doctoolchain/doctoolchain:v${DTC_VERSION}",
+  "workspaceFolder": "/project",
+  "workspaceMount": "source=\${localWorkspaceFolder},target=/project,type=bind",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "asciidoctor.asciidoctor-vscode"
+      ]
+    }
+  }
+}
+JSON
+        echo "Created ${json}."
+        echo
+        echo "Open in VS Code with:"
+        echo "    code --devcontainer ."
+        return 0
+    fi
+
+    echo "Devcontainer config exists: ${json}"
+    assert_devcontainer_cli
+    echo "Starting devcontainer..."
+    devcontainer up --workspace-folder "${DTC_WORKSPACE}"
+}
+
 get_dtc_installations() {
     local envs=${1}
     local version=${2}
     local installations=""
+
+    # Container environments always carry their own docToolchain
+    if [[ "${envs}" =~ compose ]]; then
+        installations+=" compose"
+    fi
+    if [[ "${envs}" =~ devcontainer ]]; then
+        installations+=" devcontainer"
+    fi
 
     if is_v4_installation "${DTC_HOME}"; then
         # v4: detected by lib/ directory
@@ -294,7 +661,7 @@ sdk_home_doctoolchain() {
 }
 
 is_supported_environment() {
-    local supported_environments=("local" "sdk" "docker")
+    local supported_environments=("compose" "devcontainer" "local" "sdk" "docker")
     [[ "${supported_environments[*]}" =~ ${1} ]]
 }
 
@@ -304,7 +671,19 @@ assert_environment_available() {
     # If environment not available, exit with error
     if ! is_environment_available "${env}" ; then
         error "argument error - environment '${env}' not available"
-        if [[ "${env}" == "sdk" ]]; then
+        if [[ "${env}" == "compose" ]]; then
+            printf "%s\n" \
+                "No docker-compose.yml with a doctoolchain service found," \
+                "or no compose command available (docker compose, podman-compose)." \
+                "" \
+                "Set DTC_COMPOSE to point to your compose file, or install a compose runtime."
+        elif [[ "${env}" == "devcontainer" ]]; then
+            printf "%s\n" \
+                "No .devcontainer/devcontainer.json with a doctoolchain image found," \
+                "or 'devcontainer' CLI not installed." \
+                "" \
+                "Install it via: npm install -g @devcontainers/cli"
+        elif [[ "${env}" == "sdk" ]]; then
             printf "%s\n" \
                 "Install SDKMAN! (https://sdkman.io) with" \
                 "" \
@@ -367,6 +746,30 @@ install_component_and_exit() {
     fi
     exit_code=1
     case ${env} in
+        compose)
+            case ${component} in
+                doctoolchain)
+                    compose_install_doctoolchain
+                    ;;
+                *)
+                    error "argument error - only 'install doctoolchain' is supported for compose"
+                    echo "Java and other components are provided by the container image."
+                    ;;
+            esac
+            exit_code=$?
+            ;;
+        devcontainer)
+            case ${component} in
+                doctoolchain)
+                    devcontainer_install_doctoolchain
+                    ;;
+                *)
+                    error "argument error - only 'install doctoolchain' is supported for devcontainer"
+                    echo "Java and other components are provided by the container image."
+                    ;;
+            esac
+            exit_code=$?
+            ;;
         local)
             case ${component} in
                 doctoolchain)
@@ -400,10 +803,20 @@ install_component_and_exit() {
             exit_code=${ERR_ARG}
             ;;
         docker)
-            error "argument error - '${env} install' not supported."
-            echo "Executing a task in the 'docker' environment will pull the docToolchain container image."
-            echo
-            exit_code=${ERR_ARG}
+            case ${component} in
+                doctoolchain)
+                    detect_container_runner || { error "No container runtime found"; exit ${ERR_DTCW}; }
+                    local image="${DTC_DOCKER_PREFIX}doctoolchain/doctoolchain:v${DTC_VERSION}"
+                    echo "Pulling ${image} via ${DTC_CONTAINER_RUNNER}..."
+                    ${DTC_CONTAINER_RUNNER} pull "${image}"
+                    ;;
+                *)
+                    error "argument error - only 'install doctoolchain' is supported for docker"
+                    echo "Java and other components are provided by the container image."
+                    echo
+                    ;;
+            esac
+            exit_code=$?
             ;;
         *)
             echo "Coding error - not reachable"
@@ -691,7 +1104,31 @@ build_command() {
     local docker_extra_arguments=${4}
     shift 4
     local cmd
-    if [ "${env}" = docker ]; then
+    if [ "${env}" = compose ] || [ "${env}" = devcontainer ]; then
+        # container_cmd_prefix set by main() before calling build_command.
+        # The major comes from the image tag (assert_container_version), never
+        # from a host installation - the host may not have one at all.
+        if [ "$(printf '%s' "${version}" | cut -d'.' -f1)" -ge 4 ]; then
+            local task=${1}
+            shift
+            # Short-lived JVM - see the docker branch below for the rationale.
+            local startup_opts="${DTC_JAVA_STARTUP_OPTS--XX:TieredStopAtLevel=1 -XX:+UseSerialGC}"
+            local java_opts="-Xmx2048m -Dfile.encoding=UTF-8 ${startup_opts}"
+            java_opts="${java_opts} -DdocDir=. -DmainConfigFile=\"${DTC_CONFIG_FILE}\""
+            java_opts="${java_opts} -DDTC_HEADLESS=true -DDTC_PROJECT_BRANCH=\"${DTC_PROJECT_BRANCH}\""
+            # Installed scripts and their lib/ live under /opt/docToolchain; the
+            # launcher resolves project-local tasks relative to /project (ADR-18).
+            java_opts="${java_opts} -Ddtc.scriptsHome=/opt/docToolchain/scripts"
+            # Expansion must happen inside container, not locally
+            # shellcheck disable=SC2016
+            local container_cp='$(for f in /opt/docToolchain/lib/*.jar; do [ -f "$f" ] && printf "%s:" "$f"; done)'
+            # Hand the task to the Groovy launcher; single-quote paths so they
+            # survive word splitting / glob expansion in the container shell.
+            cmd="${container_cmd_prefix} bash -c \"java ${java_opts} -cp ${container_cp} groovy.ui.GroovyMain '/opt/docToolchain/scripts/Launcher.groovy' '${task}' ${*:-}\""
+        else
+            cmd="${container_cmd_prefix} bash -c \"doctoolchain . ${*} \${DTC_OPTS:-}\""
+        fi
+    elif [ "${env}" = docker ]; then
         # TODO: DTC_PROJECT_BRANCH is  not passed into the docker environment
         # See https://github.com/docToolchain/docToolchain/issues/1087
 
@@ -705,14 +1142,17 @@ build_command() {
             env_file_option="--env-file ${docker_env_file}"
         fi
 
-        docker_args="run --rm -i --platform linux/amd64 -u $(id -u):$(id -g) --name ${container_name} \
+        local userns_args
+        userns_args=$(podman_userns_args)
+
+        docker_args="run --rm -i --platform linux/amd64 -u $(id -u):$(id -g) ${userns_args} --name ${container_name} \
             -e DTC_HEADLESS=true -e DTC_SITETHEME -e DTC_PROJECT_BRANCH=${DTC_PROJECT_BRANCH} \
             -e DTC_PROJECT_SCRIPTS_DIR \
             ${docker_extra_arguments} ${env_file_option} \
             --entrypoint /bin/bash -v '${pwd}:/project' ${DTC_DOCKER_PREFIX}${docker_image}:v${version}"
 
         if is_v4_installation "${DTC_HOME}"; then
-            # v4 Docker: direct Groovy invocation inside container
+            # v4: direct Groovy invocation inside container
             local task=${1}
             shift
             # Short-lived JVM: cap JIT at C1 (skip the C2 compiler, which never
@@ -732,10 +1172,10 @@ build_command() {
             local docker_cp='$(for f in /opt/docToolchain/lib/*.jar; do [ -f "$f" ] && printf "%s:" "$f"; done)'
             # Hand the task to the Groovy launcher; single-quote paths so they
             # survive word splitting / glob expansion in the container shell.
-            cmd="docker ${docker_args} -c \"java ${java_opts} -cp ${docker_cp} groovy.ui.GroovyMain '/opt/docToolchain/scripts/Launcher.groovy' '${task}' ${*:-} && exit\""
+            cmd="${DTC_CONTAINER_RUNNER} ${docker_args} -c \"java ${java_opts} -cp ${docker_cp} groovy.ui.GroovyMain '/opt/docToolchain/scripts/Launcher.groovy' '${task}' ${*:-} && exit\""
         else
-            # v3 Docker: Gradle via doctoolchain
-            cmd="docker ${docker_args} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
+            # v3: Gradle via doctoolchain
+            cmd="${DTC_CONTAINER_RUNNER} ${docker_args} -c \"doctoolchain . ${*} ${DTC_OPTS} && exit\""
         fi
     else
         local dtc_home="${DTC_HOME}"
@@ -818,4 +1258,7 @@ DTC_HOME="${DTC_ROOT}/docToolchain-${DTC_VERSION}"
 # Directory for local Java installation
 DTC_JAVA_HOME="${DTC_ROOT}/jdk"
 
-main "$@"
+# Guard: run main when executed as script, skip when sourced for testing
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/dtcw
+++ b/dtcw
@@ -144,10 +144,16 @@ main() {
             assert_container_version "$(compose_image_ref "${compose_path}")" "${compose_path}"
             local compose_cmd
             compose_cmd=$(find_compose_cmd) || exit 1
+            # 'docker compose exec' allocates a pseudo-TTY by default, which
+            # aborts with "the input device is not a TTY" whenever stdin is not
+            # a terminal (CI, pipes, cron). Reuse the DTC_HEADLESS signal the
+            # wrapper already derives from '[ -t 0 ]' and disable it there.
+            local compose_tty=""
+            [[ "${DTC_HEADLESS}" = true ]] && compose_tty=" -T"
             # Quote the interpolated values: the prefix ends up inside the
             # command string that main() hands to 'bash -c', so that shell
             # re-parses it and would word-split a path containing spaces.
-            container_cmd_prefix="${compose_cmd} -f '${compose_path}' exec '${service}'"
+            container_cmd_prefix="${compose_cmd} -f '${compose_path}' exec${compose_tty} '${service}'"
             ;;
         devcontainer)
             assert_devcontainer_cli

--- a/lib/completions/_dtcw
+++ b/lib/completions/_dtcw
@@ -1,0 +1,73 @@
+#compdef dtcw
+# Zsh completion for dtcw
+# Add lib/completions to fpath and run: autoload -Uz _dtcw
+
+local -a commands
+commands=(
+    # Generate
+    'generateHTML:Generate HTML documentation'
+    'generatePDF:Generate PDF documentation'
+    'generateSite:Generate microsite (jBake)'
+    'generateDeck:Generate reveal.js slide deck'
+    'generateDocBook:Generate DocBook XML'
+    'generateContent:Generate content from templates'
+    # Export — external tools
+    'exportChangeLog:Export git changelog'
+    'exportConfluence:Export Confluence pages to AsciiDoc'
+    'exportContributors:Export git contributors'
+    'exportDrawIo:Export draw.io diagrams'
+    'exportEA:Export from Enterprise Architect'
+    'exportExcel:Export Excel tables to AsciiDoc'
+    'exportJiraIssues:Export Jira issues to AsciiDoc'
+    'exportJiraSprintChangelog:Export Jira sprint changelog'
+    'exportMarkdown:Export Markdown to AsciiDoc'
+    'exportMetrics:Export code metrics'
+    'exportOpenApi:Export OpenAPI specification'
+    'exportPPT:Export PowerPoint slides as images'
+    'exportStructurizr:Export Structurizr architecture diagrams'
+    'exportVisio:Export Visio diagrams'
+    # Publish
+    'publishToConfluence:Publish documentation to Confluence'
+    'wipeConfluenceSpace:Remove all pages from Confluence space'
+    # Utilities
+    'collectIncludes:Collect all includes into a single list'
+    'convertToDocx:Convert to DOCX via Pandoc'
+    'convertToEpub:Convert to EPUB'
+    'copyThemes:Copy site themes'
+    'createReferenceDoc:Create reference document'
+    'downloadTemplate:Download arc42/req42 template'
+    'fixEncoding:Fix file encoding issues'
+    'htmlSanityCheck:Check HTML for broken links'
+    'prependFilename:Prepend filename to document'
+    'previewSite:Preview microsite locally'
+    # Meta
+    'tasks:List all available tasks'
+    'install:Install docToolchain or Java'
+    'shell:Interactive container shell'
+    '--version:Show version info'
+    'help:Show help message'
+)
+
+local -a install_components
+install_components=(
+    'doctoolchain:Install docToolchain locally'
+    'java:Install Java 17 locally'
+)
+
+_arguments -C \
+    '-f[Use specific docker-compose.yml]:compose file:_files -g "*.y(a|)ml"' \
+    '1:command:->command' \
+    '*::args:->args'
+
+case "$state" in
+    command)
+        _describe -t commands 'dtcw task' commands
+        ;;
+    args)
+        case "${words[1]}" in
+            install)
+                _describe -t install_components 'component' install_components
+                ;;
+        esac
+        ;;
+esac

--- a/lib/completions/dtcw.bash
+++ b/lib/completions/dtcw.bash
@@ -1,0 +1,41 @@
+# Bash completion for dtcw
+# Source this file in .bashrc after sourcing dtcw-function.bash
+
+_dtcw_completions() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    # Tasks grouped by category
+    local generate_tasks="generateHTML generatePDF generateSite generateDeck generateDocBook generateContent"
+    local export_tasks="exportChangeLog exportConfluence exportContributors exportDrawIo exportEA exportExcel exportJiraIssues exportJiraSprintChangelog exportMarkdown exportMetrics exportOpenApi exportPPT exportStructurizr exportVisio"
+    local publish_tasks="publishToConfluence wipeConfluenceSpace"
+    local util_tasks="collectIncludes convertToDocx convertToEpub copyThemes createReferenceDoc downloadTemplate fixEncoding htmlSanityCheck prependFilename previewSite"
+    local all_tasks="${generate_tasks} ${export_tasks} ${publish_tasks} ${util_tasks}"
+    local commands="${all_tasks} tasks install shell --version help"
+
+    # After -f: show files and directories
+    if [[ "${prev}" == "-f" ]]; then
+        mapfile -t COMPREPLY < <(compgen -f -- "${cur}")
+        return
+    fi
+
+    # After install: show components
+    if [[ "${prev}" == "install" ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "doctoolchain java" -- "${cur}")
+        return
+    fi
+
+    # First argument: commands or -f
+    if [[ ${COMP_CWORD} -eq 1 ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "${commands} -f" -- "${cur}")
+        return
+    fi
+
+    # After -f <file>: commands
+    if [[ "${COMP_WORDS[1]}" == "-f" && ${COMP_CWORD} -eq 3 ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "${commands}" -- "${cur}")
+        return
+    fi
+}
+
+complete -o filenames -F _dtcw_completions dtcw

--- a/src/docs/arc42/adrs/adr-19-shell-function-wrapper.adoc
+++ b/src/docs/arc42/adrs/adr-19-shell-function-wrapper.adoc
@@ -1,0 +1,206 @@
+=== ADR-19: Compose and Devcontainer as Native `dtcw` Environments
+
+==== Status
+
+Accepted (for v4).
+
+==== Problem and Context
+
+docToolchain is used in multiple execution contexts beyond the project-local
+`./dtcw` script:
+
+* **Docker Compose**: Projects run docToolchain as a persistent Compose service.
+  Users invoke tasks via
+  `docker compose exec doctoolchain bash -c 'doctoolchain /project generatePDF $DTC_OPTS'` --
+  a command nobody wants to type repeatedly.
+* **Devcontainer**: VS Code / devcontainer CLI setups where doctoolchain runs in
+  a sidecar container referenced from `devcontainer.json`.
+
+An earlier approach (shell function in `lib/dtcw-function.bash`) solved this by
+adding a sourceable function with multi-mode dispatch.  The same pattern was
+explored in tpo42-asciidoc-container, where ADR-007 concluded that separating
+context detection from the main script creates unnecessary indirection: the script
+ends up as a passthrough to the function, and users must source files in their
+shell profile.
+
+==== Decision
+
+Integrate compose and devcontainer as first-class environments in `dtcw` itself,
+alongside the existing `local`, `sdk`, and `docker` environments.
+
+===== Environment priority
+
+`get_available_environments()` detects environments in this order:
+
+[cols="1,2,3"]
+|===
+| Priority | Environment | Detection
+
+| 1
+| `compose`
+| A compose file with a service whose image matches `doctoolchain/` +
+  (via `DTC_COMPOSE`, or auto-detected as `compose.yaml`, `compose.yml`,
+  `docker-compose.yml`, `docker-compose.yaml`) AND a working compose command
+
+| 2
+| `devcontainer`
+| `.devcontainer/devcontainer.json` with doctoolchain image +
+  AND `devcontainer` CLI available
+
+| 3
+| `local`
+| Always available (installation may be missing)
+
+| 4
+| `sdk`
+| SDKMAN! present
+
+| 5
+| `docker`
+| Container runtime available
+|===
+
+Project-local contexts that carry their own docToolchain (compose, devcontainer)
+take priority over host installations.  A running container is ready immediately;
+local/sdk may require installation, and docker always cold-starts a new container.
+
+The user can always force a specific environment: `./dtcw local generateHTML`.
+
+===== Container dispatch
+
+Compose and devcontainer reuse the wrapper's single dispatch path rather than
+branching out of it.  `main()` resolves a `container_cmd_prefix` for these two
+environments, then skips the host-side assertions (`assert_doctoolchain_installed`,
+`assert_java_version_supported`) that only apply to `local`/`sdk` -- docToolchain
+and its Java runtime ship inside the image.  `build_command()` prepends the prefix,
+and the `exec` at the end of `main()` is shared with every environment:
+
+[source,bash]
+----
+# compose
+container_cmd_prefix="${compose_cmd} -f ${compose_path} exec ${service}"
+
+# devcontainer
+container_cmd_prefix="devcontainer exec --workspace-folder ${DTC_WORKSPACE}"
+----
+
+This follows the `cmd_prefix` pattern from tpo42-asciidoc-container (ADR-007).
+
+Inside the container the command depends on the installed major version: v3 calls
+`doctoolchain . <task> $DTC_OPTS`, while v4 invokes the Groovy launcher
+(`Launcher.groovy`, ADR-18) with `dtc.scriptsHome` pointing at
+`/opt/docToolchain/scripts` (ADR-17).  Task discovery, the `tasks` listing and
+unknown-task guidance are therefore delegated to the container, not answered on
+the host -- the host has no view of what the image provides.
+
+===== Version comes from the image, not from the host
+
+The two dispatch forms are not interchangeable, and the v4 form hard-codes
+in-container paths, so a v4 command sent into a 3.x image fails on a missing
+`Launcher.groovy`.  The wrapper therefore must know the major version *before*
+it can build a command -- and for a container environment the host cannot answer
+that question: there may be no host installation at all, and `DTC_VERSION`
+defaults to the wrapper's own release rather than to whatever the project pinned.
+
+The image reference is the single source of truth, and the project already states
+it (`image: doctoolchain/doctoolchain:v3.5.0` in the compose file, `"image"` in
+`devcontainer.json`, or the compose file a `dockerComposeFile` points at).  The
+wrapper reads the tag and pins `DTC_VERSION` to it.  An explicitly set
+`DTC_VERSION` still wins, so a mislabelled image stays usable.
+
+A reference without a numeric version -- no tag, `:latest`, a digest -- is a hard
+error rather than an assumption: guessing picks the wrong dispatch half the time,
+and the resulting failure surfaces deep inside the container where it is
+expensive to diagnose.  The error names the reference it found and both remedies
+(pin a versioned tag, or state `DTC_VERSION`).
+
+===== Install bootstrapping
+
+`./dtcw compose install doctoolchain` generates a `docker-compose.yml` with a
+doctoolchain service if none exists.  Similarly, `./dtcw devcontainer install
+doctoolchain` generates a `.devcontainer/devcontainer.json`.  If the config
+already exists, the command pulls/builds (compose) or starts (devcontainer)
+instead.
+
+===== Container runtime detection
+
+`detect_container_runner()` resolves `DTC_CONTAINER_RUNNER` from the first
+available of `container`, `nerdctl`, `finch`, `podman`, `docker`, preferring
+lightweight/daemonless runtimes.  A pre-set `DTC_CONTAINER_RUNNER` is
+authoritative.  Because `get_available_environments()` runs in a command
+substitution, the detection is repeated in `main()` for the `docker` environment
+so the value is present in the shell that builds the command.
+
+*Compose follows the runtime.*  The compose command is not looked up
+independently: `nerdctl` and `finch` implement compose as a subcommand, `podman`
+wraps an external provider, and the standalone `docker-compose` /
+`podman-compose` binaries each belong to exactly one runtime.  Choosing
+`docker compose` while podman runs the service would address the wrong engine, so
+`find_compose_cmd()` walks the same preference list and, per candidate, takes
+`<runtime> compose` or that runtime's own standalone binary.  When
+`DTC_CONTAINER_RUNNER` is set explicitly and has no compose support, the wrapper
+fails and says so rather than quietly using another engine.
+
+*Rootless podman needs `--userns=keep-id`.*  Rootless podman places the invoking
+user at container uid 0 and maps every other uid into a subuid range.  Combined
+with the `-u $(id -u):$(id -g)` the wrapper passes, the project owner then exists
+nowhere inside the container and the bind-mounted project is read-only in
+practice -- a render task fails on its own output directory.  Rootful podman
+rejects the flag, so it is added only when `podman info` reports
+`Host.Security.Rootless` as `true`.
+
+===== Testability
+
+A `BASH_SOURCE` guard at the bottom of `dtcw` allows sourcing the script
+for unit-testing internal functions without triggering `main()`.
+
+===== Completions
+
+Completion files remain separate in `lib/completions/` per shell convention
+(bash and zsh).  They work identically whether `dtcw` is invoked as `./dtcw`
+or as a command in `PATH`.
+
+==== Environment variables
+
+[cols="1,3"]
+|===
+| `DTC_COMPOSE` | Path to the compose file (alternative to auto-detect).
+| `DTC_SERVICE` | Service name in compose file (auto-detected from image).
+| `DTC_WORKSPACE` | Workspace folder for devcontainer (default: `.`).
+| `DTC_CONTAINER_RUNNER` | Container runtime to use, as a path or a name on `PATH`. Overrides detection and also selects which compose implementation is eligible.
+| `DTC_VERSION` | Overrides the docToolchain version otherwise read from the container image tag.
+|===
+
+==== Consequences
+
+===== Positive
+
+* Single `./dtcw generateHTML` works across all execution contexts
+* No shell profile sourcing needed -- `dtcw` is a regular script
+* Container dispatch reuses the existing `build_command()`/`exec` path, so there
+  is no second invocation route to keep in sync
+* Compose auto-detection makes the validate-first workflow ergonomic:
+  `./dtcw generatePDF` just works when a compose service is running
+* Install bootstrapping lowers the barrier for new setups
+* Pattern consistency with tpo42-asciidoc-container (ADR-007)
+* Works with 3.x and 4.x images from the same wrapper: the major version is read
+  off the pinned image tag, so a project keeps using `./dtcw <task>` regardless
+  of which docToolchain generation its container carries
+
+===== Negative
+
+* Compose auto-detection relies on `doctoolchain` appearing in the image name;
+  custom image names require `DTC_SERVICE` override
+* Auto-detection may surprise users who have a compose file but expect local
+  execution -- they can force with `./dtcw local <task>`
+* The host cannot validate a task name against the container's installed tasks,
+  so an unknown task surfaces as an error from inside the container
+* An image pinned only as `:latest` (or with no tag) has to be rejected -- the
+  wrapper cannot derive a dispatch form from it, and the project must either pin
+  a version or set `DTC_VERSION`
+
+==== Supersedes
+
+Replaces the earlier shell function approach (`lib/dtcw-function.bash`).
+The learning from tpo42-asciidoc-container (ADR-005 -> ADR-006 -> ADR-007)
+showed that the function/script split adds complexity without benefit.

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -96,6 +96,10 @@ Statuses follow Nygard values (Proposed / Accepted / Superseded / Deprecated). `
 |v4 Task Dispatch Moves into a Groovy Launcher
 |Accepted (for v4)
 
+|ADR-19
+|Compose and Devcontainer as Native `dtcw` Environments
+|Accepted (for v4)
+
 |ADR-TBD-1
 |Confluence API Version Strategy
 |Proposed
@@ -140,6 +144,8 @@ include::../adrs/adr-16-project-local-tasks.adoc[]
 include::../adrs/adr-17-script-home-lib-resolution.adoc[]
 
 include::../adrs/adr-18-groovy-task-launcher.adoc[]
+
+include::../adrs/adr-19-shell-function-wrapper.adoc[]
 
 include::../adrs/adr-tbd-1-confluence-api.adoc[]
 

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -8,8 +8,6 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 :toc:
 
-
-
 [[section-design-decisions]]
 == Architecture Decisions
 

--- a/test/container_environments.bats
+++ b/test/container_environments.bats
@@ -131,6 +131,29 @@ last_argv() {
     assert_output --partial "[exec][docs-builder]"
 }
 
+@test "compose: a compose path containing spaces stays one argument" {
+    # main() builds a command string that is re-parsed by 'bash -c', so an
+    # unquoted interpolation would word-split the path here.
+    compose_fixture "my compose.yml"
+    mock_with_argv_log docker >/dev/null
+
+    DTC_COMPOSE="my compose.yml" PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+
+    run last_argv
+    assert_output --partial "[-f][my compose.yml][exec]"
+}
+
+@test "devcontainer: a workspace path containing spaces stays one argument" {
+    devcontainer_fixture
+    mkdir -p "my workspace"
+    mock_with_argv_log devcontainer >/dev/null
+
+    DTC_WORKSPACE="my workspace" PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+
+    run last_argv
+    assert_output --partial "[--workspace-folder][my workspace]"
+}
+
 # --- version derived from the image, not from the host ---
 
 @test "compose: a 3.x image is dispatched through Gradle, not the v4 launcher" {

--- a/test/container_environments.bats
+++ b/test/container_environments.bats
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2026, the docToolchain contributors
+
+# Wrapper-level tests for the 'compose' and 'devcontainer' environments.
+#
+# These assert what the wrapper hands to the container runtime. The argv is
+# captured through a mock side effect rather than mock_get_call_args(), because
+# the latter flattens "$@" through echo and would hide exactly the word-splitting
+# these tests are about.
+
+setup() {
+    load 'test_helper.bash'
+    setup_environment
+
+    export DTC_PROJECT_BRANCH=test
+
+    DTCW="${PWD}/dtcw"
+
+    # v4 installation — the lib/ directory is the marker
+    mkdir -p "${DTC_HOME}/lib" "${DTC_HOME}/scripts"
+    touch "${DTC_HOME}/lib/dummy.jar"
+
+    # Run in a project sandbox: the compose file is looked up in the cwd
+    project=$(mktemp -d)
+    cd "${project}" || return 1
+
+    export ARGV_LOG="${project}/argv.log"
+    : > "${ARGV_LOG}"
+}
+
+teardown() {
+    cd "${BATS_TEST_DIRNAME}/.." || true
+    mock_teardown
+    rm -rf "${DTC_ROOT}" "${project}"
+}
+
+# --- helpers ---
+
+# Write a compose file with a doctoolchain service under the given name.
+# $2 overrides the image tag, e.g. 'v3.5.0' or 'latest'; '' omits the tag.
+compose_fixture() {
+    local tag="${2-v4.0.0}"
+    cat > "${1}" <<YAML
+services:
+  doctoolchain:
+    image: doctoolchain/doctoolchain${tag:+:${tag}}
+    entrypoint: ["sleep", "infinity"]
+YAML
+}
+
+devcontainer_fixture() {
+    mkdir -p .devcontainer
+    cat > .devcontainer/devcontainer.json <<'JSON'
+{
+  "name": "docToolchain",
+  "image": "doctoolchain/doctoolchain:v4.0.0"
+}
+JSON
+}
+
+# Mock that records its argv one element per '[...]', so quoting is visible.
+mock_with_argv_log() {
+    local mock
+    mock=$(mock_create "${1}")
+    mock_set_side_effect "${mock}" 'printf "[%s]" "$@" >> "${ARGV_LOG}"; echo "" >> "${ARGV_LOG}"'
+    echo "${mock}"
+}
+
+# The dispatch is the last recorded call — find_compose_cmd() probes first.
+last_argv() {
+    tail -n 1 "${ARGV_LOG}"
+}
+
+# --- compose ---
+
+@test "compose: a task is dispatched into the running service via the launcher" {
+    compose_fixture docker-compose.yml
+    mock_with_argv_log docker >/dev/null
+
+    PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+    assert_line "Using environment: compose"
+
+    run last_argv
+    assert_output --partial "[compose][-f][docker-compose.yml][exec]"
+    assert_output --partial "[doctoolchain][bash][-c]"
+    assert_output --partial "Launcher.groovy"
+    assert_output --partial "generateHTML"
+    # ADR-17: the launcher must find the installed scripts inside the image
+    assert_output --partial "-Ddtc.scriptsHome=/opt/docToolchain/scripts"
+}
+
+@test "compose: 'tasks' is delegated to the container, not answered on the host" {
+    # The host cannot know which tasks the image provides, so the listing has to
+    # travel into the container instead of being served from the installation.
+    compose_fixture docker-compose.yml
+    mock_with_argv_log docker >/dev/null
+
+    PATH="${minimal_system}" run -0 "${DTCW}" tasks
+    assert_line "Using environment: compose"
+
+    run last_argv
+    assert_output --partial "Launcher.groovy"
+    assert_output --partial "tasks"
+}
+
+@test "compose: every Compose-spec file name is detected" {
+    # One mock for the whole loop: mock_teardown() would remove the chroot that
+    # provides 'bash' to the remaining iterations.
+    mock_with_argv_log docker >/dev/null
+
+    for name in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
+        rm -f compose.yaml compose.yml docker-compose.yml docker-compose.yaml
+        : > "${ARGV_LOG}"
+        compose_fixture "${name}"
+
+        PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+        assert_line "Using environment: compose"
+
+        run last_argv
+        assert_output --partial "[-f][${name}]"
+    done
+}
+
+@test "compose: DTC_SERVICE overrides the auto-detected service name" {
+    compose_fixture docker-compose.yml
+    mock_with_argv_log docker >/dev/null
+
+    DTC_SERVICE=docs-builder PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+
+    run last_argv
+    assert_output --partial "[exec][docs-builder]"
+}
+
+# --- version derived from the image, not from the host ---
+
+@test "compose: a 3.x image is dispatched through Gradle, not the v4 launcher" {
+    # Plant a host installation that looks like v4 *at the version the image
+    # pins*, so host state and image tag disagree. Deciding from the host would
+    # pick the launcher and die on a missing Launcher.groovy in a 3.x container;
+    # only the image tag gives the right answer.
+    mkdir -p "${DTC_ROOT}/docToolchain-3.5.0/lib"
+    touch "${DTC_ROOT}/docToolchain-3.5.0/lib/dummy.jar"
+
+    compose_fixture docker-compose.yml v3.5.0
+    mock_with_argv_log docker >/dev/null
+    # the helper exports DTC_VERSION; derivation only runs without it
+    unset DTC_VERSION
+
+    PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+    assert_line "Using docToolchain 3.5.0 from docker-compose.yml"
+
+    run last_argv
+    assert_output --partial "[doctoolchain . generateHTML"
+    refute_output --partial "Launcher.groovy"
+}
+
+@test "compose: a 4.x image is dispatched through the launcher" {
+    compose_fixture docker-compose.yml v4.0.0
+    mock_with_argv_log docker >/dev/null
+    # the helper exports DTC_VERSION; derivation only runs without it
+    unset DTC_VERSION
+
+    PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+    assert_line "Using docToolchain 4.0.0 from docker-compose.yml"
+
+    run last_argv
+    assert_output --partial "Launcher.groovy"
+}
+
+@test "compose: an explicit DTC_VERSION overrides the image tag" {
+    compose_fixture docker-compose.yml v3.5.0
+    mock_with_argv_log docker >/dev/null
+
+    DTC_VERSION=4.0.0 PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+    assert_line "Using docToolchain 4.0.0 (DTC_VERSION overrides docker-compose.yml)"
+
+    run last_argv
+    assert_output --partial "Launcher.groovy"
+}
+
+@test "compose: an unversioned image tag fails instead of guessing" {
+    compose_fixture docker-compose.yml latest
+    mock_with_argv_log docker >/dev/null
+    # the helper exports DTC_VERSION; derivation only runs without it
+    unset DTC_VERSION
+
+    PATH="${minimal_system}" run -2 "${DTCW}" generateHTML
+    assert_line "Error: cannot determine the docToolchain version from docker-compose.yml"
+    assert_line "Image reference: doctoolchain/doctoolchain:latest"
+    assert_line --partial "DTC_VERSION="
+}
+
+@test "compose: a missing image tag fails instead of guessing" {
+    compose_fixture docker-compose.yml ""
+    mock_with_argv_log docker >/dev/null
+    # the helper exports DTC_VERSION; derivation only runs without it
+    unset DTC_VERSION
+
+    PATH="${minimal_system}" run -2 "${DTCW}" generateHTML
+    assert_line "Error: cannot determine the docToolchain version from docker-compose.yml"
+}
+
+@test "devcontainer: the version is derived from its image too" {
+    mkdir -p .devcontainer
+    cat > .devcontainer/devcontainer.json <<'JSON'
+{
+  "name": "docToolchain",
+  "image": "doctoolchain/doctoolchain:v3.5.0"
+}
+JSON
+    mock_with_argv_log devcontainer >/dev/null
+    unset DTC_VERSION
+
+    PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+    assert_line "Using docToolchain 3.5.0 from .devcontainer/devcontainer.json"
+
+    run last_argv
+    refute_output --partial "Launcher.groovy"
+}
+
+# --- devcontainer ---
+
+@test "devcontainer: a task is dispatched via 'devcontainer exec'" {
+    devcontainer_fixture
+    mock_with_argv_log devcontainer >/dev/null
+
+    PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+    assert_line "Using environment: devcontainer"
+
+    run last_argv
+    assert_output --partial "[exec][--workspace-folder][.]"
+    assert_output --partial "Launcher.groovy"
+    assert_output --partial "generateHTML"
+}
+
+@test "devcontainer: compose takes precedence when both are present" {
+    # A running compose service is ready immediately, so it wins over a
+    # devcontainer that may still have to be started.
+    compose_fixture docker-compose.yml
+    devcontainer_fixture
+    mock_with_argv_log docker >/dev/null
+    mock_with_argv_log devcontainer >/dev/null
+
+    PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+    assert_line "Using environment: compose"
+}

--- a/test/container_environments.bats
+++ b/test/container_environments.bats
@@ -218,6 +218,29 @@ JSON
     refute_output --partial "Launcher.groovy"
 }
 
+@test "compose: the pseudo-TTY is disabled when headless" {
+    # 'docker compose exec' allocates a TTY by default and aborts with
+    # "the input device is not a TTY" when stdin is not a terminal.
+    compose_fixture docker-compose.yml
+    mock_with_argv_log docker >/dev/null
+
+    DTC_HEADLESS=true PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+
+    run last_argv
+    assert_output --partial "[exec][-T][doctoolchain]"
+}
+
+@test "compose: an interactive run keeps the TTY" {
+    compose_fixture docker-compose.yml
+    mock_with_argv_log docker >/dev/null
+
+    DTC_HEADLESS=false PATH="${minimal_system}" run -0 "${DTCW}" generateHTML
+
+    run last_argv
+    assert_output --partial "[exec][doctoolchain]"
+    refute_output --partial "[-T]"
+}
+
 # --- devcontainer ---
 
 @test "devcontainer: a task is dispatched via 'devcontainer exec'" {

--- a/test/dtcw-unit.bash
+++ b/test/dtcw-unit.bash
@@ -1,0 +1,339 @@
+#!/bin/bash
+# Unit tests for dtcw internal functions (Chicago School)
+#
+# Sources dtcw via BASH_SOURCE guard, then tests functions directly.
+# No container runtime or docToolchain installation needed.
+set -e -u -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Source dtcw — BASH_SOURCE guard skips main()
+source "${REPO_ROOT}/dtcw"
+
+passed=0
+failed=0
+
+pass() { echo "  PASS"; passed=$((passed + 1)); }
+fail() { echo "  FAIL: $1"; failed=$((failed + 1)); }
+
+# --- find_dtc_service ---
+
+test_find_dtc_service_valid() {
+    echo "Testing: find_dtc_service with valid compose file..."
+    local service
+    service=$(find_dtc_service "${SCRIPT_DIR}/fixtures/compose-dtc-valid.yml")
+    [[ "${service}" == "doctoolchain" ]] || { fail "expected 'doctoolchain', got '${service}'"; return; }
+    pass
+}
+
+test_find_dtc_service_custom_name() {
+    echo "Testing: find_dtc_service with custom service name..."
+    local service
+    service=$(find_dtc_service "${SCRIPT_DIR}/fixtures/compose-custom-service.yml")
+    [[ "${service}" == "docs-builder" ]] || { fail "expected 'docs-builder', got '${service}'"; return; }
+    pass
+}
+
+test_find_dtc_service_no_match() {
+    echo "Testing: find_dtc_service with no doctoolchain service..."
+    local service
+    service=$(find_dtc_service "${SCRIPT_DIR}/fixtures/compose-no-dtc.yml")
+    [[ -z "${service}" ]] || { fail "expected empty, got '${service}'"; return; }
+    pass
+}
+
+# --- detect_compose_path ---
+
+test_detect_compose_path_via_env() {
+    echo "Testing: detect_compose_path via DTC_COMPOSE..."
+    local result
+    result=$(DTC_COMPOSE="${SCRIPT_DIR}/fixtures/compose-dtc-valid.yml" detect_compose_path)
+    [[ "${result}" == "${SCRIPT_DIR}/fixtures/compose-dtc-valid.yml" ]] || { fail "got '${result}'"; return; }
+    pass
+}
+
+test_detect_compose_path_auto_detect() {
+    echo "Testing: detect_compose_path auto-detects in current directory..."
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    cp "${SCRIPT_DIR}/fixtures/compose-dtc-valid.yml" "${tmpdir}/docker-compose.yml"
+    local result
+    result=$(cd "${tmpdir}" && DTC_COMPOSE="" detect_compose_path)
+    [[ "${result}" == "docker-compose.yml" ]] || { fail "got '${result}'"; return; }
+    rm -rf "${tmpdir}"
+    pass
+}
+
+test_detect_compose_path_spec_names() {
+    echo "Testing: detect_compose_path accepts the full Compose-spec name set..."
+    local name tmpdir result
+    for name in compose.yaml compose.yml docker-compose.yml docker-compose.yaml; do
+        tmpdir=$(mktemp -d)
+        cp "${SCRIPT_DIR}/fixtures/compose-dtc-valid.yml" "${tmpdir}/${name}"
+        result=$(cd "${tmpdir}" && DTC_COMPOSE="" detect_compose_path) || result="<failed>"
+        rm -rf "${tmpdir}"
+        [[ "${result}" == "${name}" ]] || { fail "'${name}' not detected (got '${result}')"; return; }
+    done
+    pass
+}
+
+test_detect_compose_path_precedence() {
+    echo "Testing: detect_compose_path prefers the same file 'docker compose' would..."
+    # Order must match the compose implementation, so dtcw never forces a
+    # different file via -f than plain 'docker compose' would have chosen.
+    local -a expected=(compose.yaml compose.yml docker-compose.yml docker-compose.yaml)
+    local tmpdir result i drop
+    tmpdir=$(mktemp -d)
+    for drop in "${expected[@]}"; do
+        cp "${SCRIPT_DIR}/fixtures/compose-dtc-valid.yml" "${tmpdir}/${drop}"
+    done
+    for ((i = 0; i < ${#expected[@]}; i++)); do
+        result=$(cd "${tmpdir}" && DTC_COMPOSE="" detect_compose_path) || result="<failed>"
+        [[ "${result}" == "${expected[i]}" ]] || {
+            fail "expected '${expected[i]}', got '${result}'"
+            rm -rf "${tmpdir}"
+            return
+        }
+        rm -f "${tmpdir}/${expected[i]}"
+    done
+    rm -rf "${tmpdir}"
+    pass
+}
+
+test_detect_compose_path_no_match() {
+    echo "Testing: detect_compose_path fails without doctoolchain service..."
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    cp "${SCRIPT_DIR}/fixtures/compose-no-dtc.yml" "${tmpdir}/docker-compose.yml"
+    local rc=0
+    (cd "${tmpdir}" && DTC_COMPOSE="" detect_compose_path) >/dev/null 2>&1 || rc=$?
+    [[ ${rc} -ne 0 ]] || { fail "expected failure"; return; }
+    rm -rf "${tmpdir}"
+    pass
+}
+
+# --- detect_devcontainer ---
+
+test_detect_devcontainer_match() {
+    echo "Testing: detect_devcontainer with doctoolchain image..."
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "${tmpdir}/.devcontainer"
+    cp "${SCRIPT_DIR}/fixtures/devcontainer-dtc.json" "${tmpdir}/.devcontainer/devcontainer.json"
+    (cd "${tmpdir}" && detect_devcontainer)
+    local rc=$?
+    [[ ${rc} -eq 0 ]] || { fail "expected success"; return; }
+    rm -rf "${tmpdir}"
+    pass
+}
+
+test_detect_devcontainer_no_match() {
+    echo "Testing: detect_devcontainer without doctoolchain image..."
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    mkdir -p "${tmpdir}/.devcontainer"
+    cp "${SCRIPT_DIR}/fixtures/devcontainer-no-dtc.json" "${tmpdir}/.devcontainer/devcontainer.json"
+    local rc=0
+    (cd "${tmpdir}" && detect_devcontainer) || rc=$?
+    [[ ${rc} -ne 0 ]] || { fail "expected failure"; return; }
+    rm -rf "${tmpdir}"
+    pass
+}
+
+test_detect_devcontainer_missing() {
+    echo "Testing: detect_devcontainer without devcontainer.json..."
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    local rc=0
+    (cd "${tmpdir}" && detect_devcontainer) || rc=$?
+    [[ ${rc} -ne 0 ]] || { fail "expected failure"; return; }
+    rm -rf "${tmpdir}"
+    pass
+}
+
+# --- detect_container_runner ---
+
+test_detect_container_runner_finds_something() {
+    echo "Testing: detect_container_runner finds a runtime on this system..."
+    unset DTC_CONTAINER_RUNNER 2>/dev/null || true
+    local rc=0
+    detect_container_runner || rc=$?
+    if [[ ${rc} -eq 0 ]]; then
+        [[ -n "${DTC_CONTAINER_RUNNER}" ]] || { fail "DTC_CONTAINER_RUNNER empty after success"; return; }
+        echo "  PASS (found: ${DTC_CONTAINER_RUNNER})"
+        ((passed++))
+    else
+        echo "  SKIP (no container runtime installed)"
+    fi
+}
+
+# Create a stub runtime in ${1}. ${3} decides whether its 'compose' subcommand
+# reports success -- nerdctl and finch implement compose natively, podman only
+# wraps an external provider, and Apple's 'container' has none at all.
+make_runtime_stub() {
+    local dir=${1} name=${2} has_compose=${3} rootless=${4:-false}
+    local compose_exit=1
+    [[ "${has_compose}" == "yes" ]] && compose_exit=0
+    mkdir -p "${dir}"
+    # Only ${compose_exit} and ${rootless} are interpolated; the stub's own
+    # positional parameters stay escaped so they survive into the generated file.
+    cat > "${dir}/${name}" <<STUB
+#!/usr/bin/env bash
+# 'compose version' probes whether this runtime carries compose at all.
+[ "\$1" = compose ] && exit ${compose_exit}
+# 'info --format {{.Host.Security.Rootless}}' drives podman_userns_args.
+[ "\$1" = info ] && { echo '${rootless}'; exit 0; }
+exit 0
+STUB
+    chmod +x "${dir}/${name}"
+}
+
+test_find_compose_cmd_follows_runtime() {
+    echo "Testing: find_compose_cmd pairs compose with the detected runtime..."
+    local tmpdir result
+    tmpdir=$(mktemp -d)
+    # Both present: podman is preferred, so compose must not cross over to docker
+    make_runtime_stub "${tmpdir}" podman yes
+    make_runtime_stub "${tmpdir}" docker yes
+    result=$(
+        unset DTC_CONTAINER_RUNNER
+        PATH="${tmpdir}:${PATH}"
+        detect_container_runner
+        find_compose_cmd
+    )
+    rm -rf "${tmpdir}"
+    [[ "${result}" == *"/podman compose" ]] || { fail "expected podman compose, got '${result}'"; return; }
+    pass
+}
+
+test_find_compose_cmd_subcommand_only_runtime() {
+    echo "Testing: find_compose_cmd finds compose in a subcommand-only runtime..."
+    local tmpdir result
+    tmpdir=$(mktemp -d)
+    make_runtime_stub "${tmpdir}" nerdctl yes
+    result=$(
+        unset DTC_CONTAINER_RUNNER
+        PATH="${tmpdir}:/usr/bin:/bin"
+        find_compose_cmd
+    )
+    rm -rf "${tmpdir}"
+    [[ "${result}" == *"/nerdctl compose" ]] || { fail "expected nerdctl compose, got '${result}'"; return; }
+    pass
+}
+
+test_find_compose_cmd_matching_standalone() {
+    echo "Testing: find_compose_cmd falls back to the runtime's own standalone..."
+    local tmpdir result
+    tmpdir=$(mktemp -d)
+    make_runtime_stub "${tmpdir}" podman no
+    printf '#!/usr/bin/env bash\nexit 0\n' > "${tmpdir}/podman-compose"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "${tmpdir}/docker-compose"
+    chmod +x "${tmpdir}/podman-compose" "${tmpdir}/docker-compose"
+    result=$(
+        unset DTC_CONTAINER_RUNNER
+        PATH="${tmpdir}:/usr/bin:/bin"
+        find_compose_cmd
+    )
+    rm -rf "${tmpdir}"
+    # docker-compose is present but belongs to another runtime
+    [[ "${result}" == "podman-compose" ]] || { fail "expected podman-compose, got '${result}'"; return; }
+    pass
+}
+
+test_find_compose_cmd_explicit_runner_without_compose() {
+    echo "Testing: find_compose_cmd fails loudly for a runtime without compose..."
+    local tmpdir rc=0 output
+    tmpdir=$(mktemp -d)
+    make_runtime_stub "${tmpdir}" container no
+    output=$(
+        PATH="${tmpdir}:/usr/bin:/bin"
+        DTC_CONTAINER_RUNNER="${tmpdir}/container" find_compose_cmd 2>&1
+    ) || rc=$?
+    rm -rf "${tmpdir}"
+    [[ ${rc} -ne 0 ]] || { fail "expected failure, got '${output}'"; return; }
+    [[ "${output}" == *"has no compose support"* ]] || { fail "unhelpful message: '${output}'"; return; }
+    pass
+}
+
+# --- podman_userns_args ---
+
+test_podman_userns_rootless() {
+    echo "Testing: podman_userns_args adds keep-id for rootless podman..."
+    local tmpdir result
+    tmpdir=$(mktemp -d)
+    make_runtime_stub "${tmpdir}" podman yes true
+    result=$(DTC_CONTAINER_RUNNER="${tmpdir}/podman" podman_userns_args)
+    rm -rf "${tmpdir}"
+    [[ "${result}" == "--userns=keep-id" ]] || { fail "expected --userns=keep-id, got '${result}'"; return; }
+    pass
+}
+
+test_podman_userns_rootful_and_others() {
+    echo "Testing: podman_userns_args stays empty for rootful podman and docker..."
+    local tmpdir result
+    tmpdir=$(mktemp -d)
+    make_runtime_stub "${tmpdir}" podman yes false
+    make_runtime_stub "${tmpdir}" docker yes true
+    result=$(DTC_CONTAINER_RUNNER="${tmpdir}/podman" podman_userns_args)
+    [[ -z "${result}" ]] || { fail "rootful podman got '${result}'"; rm -rf "${tmpdir}"; return; }
+    # docker reports rootless=true as well, but the flag is podman-only
+    result=$(DTC_CONTAINER_RUNNER="${tmpdir}/docker" podman_userns_args)
+    rm -rf "${tmpdir}"
+    [[ -z "${result}" ]] || { fail "docker got '${result}'"; return; }
+    pass
+}
+
+test_detect_container_runner_respects_preset() {
+    echo "Testing: detect_container_runner respects pre-set value..."
+    DTC_CONTAINER_RUNNER="/usr/bin/fake-runner"
+    detect_container_runner
+    [[ "${DTC_CONTAINER_RUNNER}" == "/usr/bin/fake-runner" ]] || { fail "preset was overwritten"; return; }
+    unset DTC_CONTAINER_RUNNER
+    pass
+}
+
+# --- is_supported_environment ---
+
+test_supported_environments() {
+    echo "Testing: is_supported_environment for all environments..."
+    for env in compose devcontainer local sdk docker; do
+        is_supported_environment "${env}" || { fail "'${env}' not supported"; return; }
+    done
+    pass
+}
+
+test_unsupported_environment() {
+    echo "Testing: is_supported_environment rejects unknown..."
+    local rc=0
+    is_supported_environment "generateHTML" || rc=$?
+    [[ ${rc} -ne 0 ]] || { fail "'generateHTML' should not be a supported environment"; return; }
+    pass
+}
+
+# --- Run all tests ---
+echo "=== dtcw unit tests ==="
+test_find_dtc_service_valid
+test_find_dtc_service_custom_name
+test_find_dtc_service_no_match
+test_detect_compose_path_via_env
+test_detect_compose_path_auto_detect
+test_detect_compose_path_spec_names
+test_detect_compose_path_precedence
+test_detect_compose_path_no_match
+test_detect_devcontainer_match
+test_detect_devcontainer_no_match
+test_detect_devcontainer_missing
+test_detect_container_runner_finds_something
+test_detect_container_runner_respects_preset
+test_find_compose_cmd_follows_runtime
+test_find_compose_cmd_subcommand_only_runtime
+test_find_compose_cmd_matching_standalone
+test_find_compose_cmd_explicit_runner_without_compose
+test_podman_userns_rootless
+test_podman_userns_rootful_and_others
+test_supported_environments
+test_unsupported_environment
+echo ""
+echo "=== Results: ${passed} passed, ${failed} failed ==="
+[[ ${failed} -eq 0 ]] || exit 1

--- a/test/fixtures/compose-custom-service.yml
+++ b/test/fixtures/compose-custom-service.yml
@@ -1,0 +1,9 @@
+services:
+  adoc:
+    image: ghcr.io/tpo42/adoc:latest
+    volumes:
+      - .:/workspace
+  docs-builder:
+    image: doctoolchain/doctoolchain:v4.0.0
+    volumes:
+      - .:/project

--- a/test/fixtures/compose-dtc-valid.yml
+++ b/test/fixtures/compose-dtc-valid.yml
@@ -1,0 +1,7 @@
+services:
+  doctoolchain:
+    image: doctoolchain/doctoolchain:v4.0.0
+    platform: linux/amd64
+    volumes:
+      - .:/project
+    entrypoint: ["sleep", "infinity"]

--- a/test/fixtures/compose-no-dtc.yml
+++ b/test/fixtures/compose-no-dtc.yml
@@ -1,0 +1,5 @@
+services:
+  webapp:
+    image: nginx:latest
+    ports:
+      - "8080:80"

--- a/test/fixtures/devcontainer-dtc.json
+++ b/test/fixtures/devcontainer-dtc.json
@@ -1,0 +1,6 @@
+{
+  "name": "docToolchain",
+  "image": "doctoolchain/doctoolchain:v4.0.0",
+  "workspaceFolder": "/project",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/project,type=bind"
+}

--- a/test/fixtures/devcontainer-no-dtc.json
+++ b/test/fixtures/devcontainer-no-dtc.json
@@ -1,0 +1,5 @@
+{
+  "name": "generic",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "workspaceFolder": "/workspace"
+}

--- a/test/local_environment.bats
+++ b/test/local_environment.bats
@@ -54,6 +54,43 @@ teardown() {
 
 }
 
+@test "local v3: an install path with spaces stays one argument" {
+    # dtcw derives DTC_ROOT from HOME at runtime, so a spaced HOME gives a
+    # spaced install path. build_command() returns a string that main() hands to
+    # 'bash -c', so an unquoted ${dtc_home} would word-split here and the v3
+    # environment would die with "<prefix>: No such file or directory" -- which
+    # is what happens on Windows/cygwin under "C:\Users\First Last".
+    #
+    # A plain stub instead of mock_create(): the argv has to be recorded with its
+    # word boundaries intact, and mock_get_call_args() flattens "$@" via echo.
+    #
+    # DTC_VERSION has to name a 3.x release: is_v4_installation() falls back to
+    # the version major when no lib/ directory is present, so a v3 tree under the
+    # default 4.0.0 would still be dispatched through the v4 launcher.
+    local v3_version=3.5.0
+    local spaced_home="${BATS_TEST_TMPDIR}/home with space"
+    local dtc_home="${spaced_home}/.doctoolchain/docToolchain-${v3_version}"
+    local argv_log="${BATS_TEST_TMPDIR}/argv.log"
+
+    # v3 installation: bin/doctoolchain present, no lib/ directory
+    mkdir -p "${dtc_home}/bin"
+    cat > "${dtc_home}/bin/doctoolchain" <<STUB
+#!/usr/bin/env bash
+printf '[%s]' "\$@" >> '${argv_log}'
+STUB
+    chmod +x "${dtc_home}/bin/doctoolchain"
+    _mock_java=$(mock_create_java "${spaced_home}/.doctoolchain/jdk/bin/java" "17.0.14")
+
+    HOME="${spaced_home}" DTC_VERSION="${v3_version}" DTC_CONFIG_FILE="my config.groovy" \
+        PATH="${minimal_system}" run -0 ./dtcw generateHTML
+
+    run cat "${argv_log}"
+    # The stub was reached at all -> the spaced install path survived
+    assert_output --partial "[.][generateHTML]"
+    # ... and the spaced config file arrived as a single argument
+    assert_output --partial "[-PmainConfigFile=my config.groovy]"
+}
+
 @test "using sdk with local environment fails" {
     # Execute
     PATH="${minimal_system}" run -2 ./dtcw sdk tasks --group doctoolchain


### PR DESCRIPTION
Fixes #1689

Adds `compose` and `devcontainer` as native `dtcw` environments, so `./dtcw generateHTML` uses an already-running docToolchain container instead of falling back to a host installation or a cold `docker run`.

### Environments

Auto-detection order — project-local contexts that carry their own docToolchain win, because a running container needs neither an install step nor a cold start:

```
compose → devcontainer → local → sdk → docker
```

Forcing still works (`./dtcw local generateHTML`), and `./dtcw compose install doctoolchain` / `./dtcw devcontainer install doctoolchain` bootstrap the config when it is missing.

Dispatch reuses the existing `build_command()`/`exec` path through a command prefix, so there is no second invocation route to maintain. Inside the container v3 calls `doctoolchain`, v4 goes through `Launcher.groovy` with `dtc.scriptsHome` (ADR-18/ADR-17). Consequently `tasks`, task resolution and unknown-task guidance are delegated to the container — the host cannot know what the image provides.

Runtime detection prefers lightweight/daemonless runtimes (`container`, `nerdctl`, `finch`, `podman`) before `docker`.

### Commits

| Commit | Content |
|---|---|
| `Ignore editor swap and backup files` | `.gitignore` |
| `Add compose and devcontainer as native dtcw environments` | the feature, ADR-19, completions, unit tests, fixtures |
| `Make Gradle warning mode configurable via DTC_WARN_MODE` | `--warning-mode` was hard-wired to `none`; `DTC_WARN_MODE=all` surfaces Gradle deprecations during v3→v4 migration (v3 only) |
| `fix(dtcw): disable the compose-exec TTY when headless` | pre-existing defect, see below |
| `fix(dtcw): quote paths interpolated into the v3 command string` | pre-existing defect, see below |
| `style(arc42): collapse the triple blank line in chapter 9` | `asciidoc-linter` finding, surfaced by touching the chapter |

### Two pre-existing defects fixed separately

Both are unrelated to the feature and kept as their own commits so they can be cherry-picked or dropped:

1. **compose-exec TTY** — `docker compose exec` allocates a pseudo-TTY by default and aborts with *"the input device is not a TTY"* as soon as stdin is not a terminal (CI, pipes, cron). `DTC_HEADLESS` was already derived from `[ -t 0 ]`; the compose path just never consulted it. Verified against `docker compose` and `docker-compose`; `podman-compose` documents `-T` as well but was not available to test.
2. **Unquoted interpolation** — `build_command()` returns a string that `main()` hands to `bash -c`, so that shell re-parses it. `-PmainConfigFile=${DTC_CONFIG_FILE}` and `${dtc_home}/bin/doctoolchain` were unquoted and word-split on paths containing spaces, so the local v3 environment fails on Windows/cygwin where `DTC_ROOT` lands under `C:\Users\First Last`. The file already uses the single-quote idiom for `-Dgradle.user.home=...` and `-Dorg.gradle.java.home=...`; these two spots were missed.

### Testing

* `test/dtcw-unit.bash` — new, sources `dtcw` behind a `BASH_SOURCE` guard and covers compose/devcontainer/runtime detection and environment validation: 13 tests.
* BATS suite: 60 of 61 pass. `sdk_installation.bats::specific doctoolchain version not installed` fails, but **identically on a pristine `main-4.x` worktree** — it is host-dependent (the test's `PATH` does not shield a real `docker` or a real `~/.doctoolchain`), not a regression from this branch.
* `bash -n` and `shellcheck` clean on `dtcw` and `lib/completions/dtcw.bash`.
* All `.pre-commit-config.yaml` hooks pass across the full branch diff.
* CI workflow gains a separate unit-test step ahead of the BATS step.

### All Submissions

* [ ] Did you update the `changelog.adoc`? — **no.** `changelog.adoc` has not been touched anywhere in the v4 range (~200 commits since `1b4b9228`) and its `Unreleased` section still lists v3-era issues, so I followed the current practice rather than reviving the file unilaterally. Happy to add an entry if you want it maintained again.
* [x] Does your PR affect the documentation? — yes.
* [x] If yes, did you update the documentation or create an issue for updating it? — ADR-19 added to the arc42 register (`src/docs/arc42/adrs/`), wired into chapter 9's ADR index and include list.

### Note on ADR-19 format

ADR-19 follows the Status/Context/Decision/Consequences prose structure of the ADR it grew out of, not the bullet-plus-Pugh-matrix shape of ADR-16…18. Say the word and I will convert it, marking cells that need your judgement with `?` per the register's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
