### PR TITLE
ci: run the wrapper and CodeQL gates for main-4.x pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "ng" ]
+    branches: [ "main-4.x", "ng" ]
   pull_request:
-    branches: [ "ng" ]
+    branches: [ "main-4.x", "ng" ]
   schedule:
     - cron: '19 7 * * 1'
 

--- a/.github/workflows/dtcw-tests.yaml
+++ b/.github/workflows/dtcw-tests.yaml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - gh-pages
   pull_request:
-    branches: [ ng ]
+    branches: [ main-4.x, ng ]
     paths:
       - 'dtcw'
       - 'test/**'

--- a/.github/workflows/dtcw.ps1-tests.yaml
+++ b/.github/workflows/dtcw.ps1-tests.yaml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - gh-pages
   pull_request:
-    branches: [ ng ]
+    branches: [ main-4.x, ng ]
     paths:
       - 'dtcw.ps1'
       - 'src/test/groovy/docToolchain/DtcwOnPowershellSpec.groovy'


### PR DESCRIPTION
Fixes #1692

Adds `main-4.x` to the `pull_request` branch list of the three workflows the branch split missed:

| Workflow | before | after |
|---|---|---|
| `dtcw-tests.yaml` | `[ ng ]` | `[ main-4.x, ng ]` |
| `dtcw.ps1-tests.yaml` | `[ ng ]` | `[ main-4.x, ng ]` |
| `codeql.yml` | `[ "ng" ]`, push and PR | `[ "main-4.x", "ng" ]`, push and PR |

The order matches the workflows that were already migrated (`codenarc.yml`, `dependency-check.yml`).

### Why this matters differently per workflow

The two `dtcw*` suites also carry `push: branches-ignore: [gh-pages]`, so they do run once a commit lands on `main-4.x` — verified, the latest such run was a `push` event on 2026-06-26 and it passed. Their gap is therefore *timing*: a wrapper defect is caught after the merge instead of in review, and never at all for a pull request from a fork, where the push event happens in the fork rather than upstream.

`codeql.yml` has no `push` fallback for this branch, so SAST is simply absent. Its last run against `main-4.x` was 2026-01-25, with roughly 200 commits since. Worth noting that `CLAUDE.md` lists CodeQL under Tier 2 mitigations as "✅ Present" — true for `ng`, not for the branch where v4 is actually being built. I have left `CLAUDE.md` alone; this PR restores the claim rather than rewording it.

### Verification

Trigger blocks re-parsed after the edit:

```
dtcw-tests.yaml       push: ["gh-pages"] (ignore)   pull_request: ["main-4.x", "ng"]
dtcw.ps1-tests.yaml   push: ["gh-pages"] (ignore)   pull_request: ["main-4.x", "ng"]
codeql.yml            push: ["main-4.x", "ng"]      pull_request: ["main-4.x", "ng"]
```

This pull request is its own proof: it targets `main-4.x`, so `Execute dtcw test suite` and `CodeQL` should appear in its checks — they were absent on #1690.

Note that `dtcw-tests.yaml` has a `paths` filter on `dtcw` and `test/**`, which this PR does not touch, so the suite still only runs when those change.

### Coordination

#1690 also edits `.github/workflows/dtcw-tests.yaml`, but at the bottom of the file (splitting the test step into a unit-test step and a BATS step), while this change is in the trigger block at the top. The two should merge cleanly in either order.

### All Submissions

* [ ] Did you update the `changelog.adoc`? — no. It has not been touched anywhere in the v4 range and its `Unreleased` section still lists v3-era entries; happy to add one if you want the file maintained again.
* [x] Does your PR affect the documentation? — no, CI configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
